### PR TITLE
fix(client): added success feedback on successful email sent

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-collapsible": "1.0.1",
     "@radix-ui/react-popover": "1.0.2",
     "@radix-ui/react-slot": "1.0.1",
+    "@radix-ui/react-toast": "1.1.4",
     "@radix-ui/react-toggle-group": "1.0.1",
     "@radix-ui/react-tooltip": "1.0.2",
     "@react-email/render": "0.0.7",

--- a/client/src/components/send.tsx
+++ b/client/src/components/send.tsx
@@ -1,4 +1,5 @@
 import * as Popover from '@radix-ui/react-popover';
+import * as Toast from '@radix-ui/react-toast';
 import * as React from 'react';
 import { inter } from '../app/layout';
 import { Button } from './button';
@@ -46,101 +47,106 @@ export const Send = ({ markup }: { markup: string }) => {
 
   return (
     <Popover.Root>
-      <Popover.Trigger asChild>
-        <button className="box-border outline-none self-center w-20 h-5 flex items-center justify-center rounded-lg text-center transition duration-300 ease-in-out border border-slate-6 text-slate-11 text-sm px-4 py-4 hover:border-slate-12 hover:text-slate-12 font-sans">
-          Send
-        </button>
-      </Popover.Trigger>
-      <Popover.Anchor />
-      <Popover.Portal>
-        <Popover.Content
-          align="end"
-          className={`w-80 -mt-10 p-3 bg-black border border-slate-6 text-slate-11 rounded-lg font-sans ${inter.variable}`}
-        >
-          <Popover.Close
-            aria-label="Close"
-            className="absolute right-2 flex items-center justify-center w-6 h-6 text-xs text-slate-11 hover:text-slate-12 transition duration-300 ease-in-out rounded-full"
+      <Toast.Provider>
+        <Popover.Trigger asChild>
+          <button className="box-border outline-none self-center w-20 h-5 flex items-center justify-center rounded-lg text-center transition duration-300 ease-in-out border border-slate-6 text-slate-11 text-sm px-4 py-4 hover:border-slate-12 hover:text-slate-12 font-sans">
+            Send
+          </button>
+        </Popover.Trigger>
+        <Popover.Anchor />
+        <Popover.Portal>
+          <Popover.Content
+            align="end"
+            className={`w-80 -mt-10 p-3 bg-black border border-slate-6 text-slate-11 rounded-lg font-sans ${inter.variable}`}
           >
-            ✕
-          </Popover.Close>
-          <form onSubmit={onFormSubmit} className="mt-1">
-            <label
-              htmlFor="to"
-              className="text-slate-10 text-xs uppercase mb-2 block"
+            <Popover.Close
+              aria-label="Close"
+              className="absolute right-2 flex items-center justify-center w-6 h-6 text-xs text-slate-11 hover:text-slate-12 transition duration-300 ease-in-out rounded-full"
             >
-              Recipient
-            </label>
-            <input
-              autoFocus={true}
-              className="appearance-none rounded-lg px-2 py-1 mb-3 outline-none w-full bg-slate-3 border placeholder-slate-8 border-slate-6 text-slate-12 text-sm focus:ring-1 focus:ring-slate-12 transition duration-300 ease-in-out"
-              onChange={(e) => setTo(e.target.value)}
-              defaultValue={to}
-              placeholder="you@example.com"
-              type="email"
-              id="to"
-              required
-            />
-            <label
-              htmlFor="subject"
-              className="text-slate-10 text-xs uppercase mb-2 block"
-            >
-              Subject
-            </label>
-            <input
-              className="appearance-none rounded-lg px-2 py-1 mb-3 outline-none w-full bg-slate-3 border placeholder-slate-8 border-slate-6 text-slate-12 text-sm focus:ring-1 focus:ring-slate-12 transition duration-300 ease-in-out"
-              onChange={(e) => setSubject(e.target.value)}
-              defaultValue={subject}
-              placeholder="My Email"
-              type="text"
-              id="subject"
-              required
-            />
-            <div className="flex items-center justify-between">
-              <Text className="inline-block" size="1">
-                Powered by{' '}
-                <a
-                  className="hover:text-slate-12 transition ease-in-out duration-300"
-                  href="https://resend.com"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Resend
-                </a>
-              </Text>
-              <Button
-                type="submit"
-                disabled={
-                  subject.length === 0 ||
-                  to.length === 0 ||
-                  isSending ||
-                  sendSuccess
-                }
-                className="disabled:bg-slate-11 disabled:border-transparent"
+              ✕
+            </Popover.Close>
+            <form onSubmit={onFormSubmit} className="mt-1">
+              <label
+                htmlFor="to"
+                className="text-slate-10 text-xs uppercase mb-2 block"
               >
-                Send
-              </Button>
-              <div
-                className={`fixed border border-white/30 bottom-[-40px] right-0 bg-green-600 text-white shadow rounded flex flex-col transition-[transform_opacity] motion-reduce:transition-none duration-500 ${
-                  sendSuccess
-                    ? 'translate-x-0 opacity-100'
-                    : 'translate-x-full opacity-0'
-                }`}
+                Recipient
+              </label>
+              <input
+                autoFocus={true}
+                className="appearance-none rounded-lg px-2 py-1 mb-3 outline-none w-full bg-slate-3 border placeholder-slate-8 border-slate-6 text-slate-12 text-sm focus:ring-1 focus:ring-slate-12 transition duration-300 ease-in-out"
+                onChange={(e) => setTo(e.target.value)}
+                defaultValue={to}
+                placeholder="you@example.com"
+                type="email"
+                id="to"
+                required
+              />
+              <label
+                htmlFor="subject"
+                className="text-slate-10 text-xs uppercase mb-2 block"
               >
-                <div className="flex items-center justify-between w-full p-2">
-                  <p className="mr-2 text-sm">Email sent!</p>
-                  <button
-                    onClick={() => setSendSuccess(false)}
-                    disabled={!sendSuccess}
-                    className="text-xs text-white/70 hover:text-white"
+                Subject
+              </label>
+              <input
+                className="appearance-none rounded-lg px-2 py-1 mb-3 outline-none w-full bg-slate-3 border placeholder-slate-8 border-slate-6 text-slate-12 text-sm focus:ring-1 focus:ring-slate-12 transition duration-300 ease-in-out"
+                onChange={(e) => setSubject(e.target.value)}
+                defaultValue={subject}
+                placeholder="My Email"
+                type="text"
+                id="subject"
+                required
+              />
+              <div className="flex items-center justify-between">
+                <Text className="inline-block" size="1">
+                  Powered by{' '}
+                  <a
+                    className="hover:text-slate-12 transition ease-in-out duration-300"
+                    href="https://resend.com"
+                    target="_blank"
+                    rel="noreferrer"
                   >
+                    Resend
+                  </a>
+                </Text>
+                <Button
+                  type="submit"
+                  disabled={
+                    subject.length === 0 ||
+                    to.length === 0 ||
+                    isSending ||
+                    sendSuccess
+                  }
+                  className="disabled:bg-slate-11 disabled:border-transparent"
+                >
+                  Send
+                </Button>
+              </div>
+              <Toast.Root
+                className="bg-[#18794e] rounded-md shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] p-3 grid [grid-template-areas:_'title_action'_'description_action'] grid-cols-[auto_max-content] gap-x-[15px] items-center data-[state=open]:animate-slideIn data-[state=closed]:animate-hide data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=cancel]:translate-x-0 data-[swipe=cancel]:transition-[transform_200ms_ease-out] data-[swipe=end]:animate-swipeOut"
+                open={sendSuccess}
+                onOpenChange={setSendSuccess}
+              >
+                <Toast.Description asChild>
+                  <p className="text-white">Email sent</p>
+                </Toast.Description>
+                <Toast.Action
+                  className="[grid-area:_action]"
+                  asChild
+                  altText="Close email sent notification"
+                >
+                  <button className="inline-flex items-center justify-center rounded font-medium text-xs px-[8px] leading-[25px] h-[25px] text-white shadow-[inset_0_0_0_1px] hover:shadow-[inset_0_0_0_1px] focus:shadow-[0_0_0_2px] ">
                     ✕
                   </button>
-                </div>
-              </div>
-            </div>
-          </form>
-        </Popover.Content>
-      </Popover.Portal>
+                </Toast.Action>
+              </Toast.Root>
+              <Toast.Viewport
+                className={`[--viewport-padding:_0px] fixed bottom-[-72px] right-0 flex flex-col p-[var(--viewport-padding)] gap-[10px] w-[160px] max-w-[220px] m-0 list-none z-[2147483647] outline-none`}
+              />
+            </form>
+          </Popover.Content>
+        </Popover.Portal>
+      </Toast.Provider>
     </Popover.Root>
   );
 };

--- a/client/src/components/send.tsx
+++ b/client/src/components/send.tsx
@@ -8,6 +8,7 @@ export const Send = ({ markup }: { markup: string }) => {
   const [to, setTo] = React.useState('');
   const [subject, setSubject] = React.useState('Testing React Email');
   const [isSending, setIsSending] = React.useState(false);
+  const [sendSuccess, setSendSuccess] = React.useState(false);
 
   const onFormSubmit = async (e: React.FormEvent) => {
     try {
@@ -27,6 +28,14 @@ export const Send = ({ markup }: { markup: string }) => {
       if (response.status === 429) {
         const { error } = await response.json();
         alert(error);
+      }
+
+      if (response.status === 200) {
+        const successTimeoutDuration = 3 * 1000;
+        setSendSuccess(true);
+        setTimeout(() => {
+          setSendSuccess(false);
+        }, successTimeoutDuration);
       }
     } catch (e) {
       alert('Something went wrong. Please try again.');
@@ -86,10 +95,6 @@ export const Send = ({ markup }: { markup: string }) => {
               id="subject"
               required
             />
-            <input
-              type="checkbox"
-              className="appearance-none checked:bg-blue-500"
-            />
             <div className="flex items-center justify-between">
               <Text className="inline-block" size="1">
                 Powered by{' '}
@@ -104,11 +109,34 @@ export const Send = ({ markup }: { markup: string }) => {
               </Text>
               <Button
                 type="submit"
-                disabled={subject.length === 0 || to.length === 0 || isSending}
+                disabled={
+                  subject.length === 0 ||
+                  to.length === 0 ||
+                  isSending ||
+                  sendSuccess
+                }
                 className="disabled:bg-slate-11 disabled:border-transparent"
               >
                 Send
               </Button>
+              <div
+                className={`fixed border border-white/30 bottom-[-40px] right-0 bg-green-600 text-white shadow rounded flex flex-col transition-[transform_opacity] motion-reduce:transition-none duration-500 ${
+                  sendSuccess
+                    ? 'translate-x-0 opacity-100'
+                    : 'translate-x-full opacity-0'
+                }`}
+              >
+                <div className="flex items-center justify-between w-full p-2">
+                  <p className="mr-2 text-sm">Email sent!</p>
+                  <button
+                    onClick={() => setSendSuccess(false)}
+                    disabled={!sendSuccess}
+                    className="text-xs text-white/70 hover:text-white"
+                  >
+                    ✕
+                  </button>
+                </div>
+              </div>
             </div>
           </form>
         </Popover.Content>

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -83,6 +83,25 @@ module.exports = {
           '0%': { strokeDashoffset: 1000 },
           '100%': { strokeDashoffset: 0 },
         },
+        hide: {
+          from: { opacity: 1 },
+          to: { opacity: 0 },
+        },
+        slideIn: {
+          from: {
+            transform: 'translateX(calc(100% + var(--viewport-padding)))',
+          },
+          to: { transform: 'translateX(0)' },
+        },
+        swipeOut: {
+          from: { transform: 'translateX(var(--radix-toast-swipe-end-x))' },
+          to: { transform: 'translateX(calc(100% + var(--viewport-padding)))' },
+        },
+      },
+      animation: {
+        hide: 'hide 100ms ease-in',
+        slideIn: 'slideIn 150ms cubic-bezier(0.16, 1, 0.3, 1)',
+        swipeOut: 'swipeOut 100ms ease-out',
       },
     },
   },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -274,6 +274,13 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/primitive@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.0.1.tgz#e46f9958b35d10e9f6dc71c497305c22e3e55dbd"
+  integrity sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
 "@radix-ui/react-arrow@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.0.1.tgz#5246adf79e97f89e819af68da51ddcf349ecf1c4"
@@ -308,6 +315,17 @@
     "@radix-ui/react-primitive" "1.0.1"
     "@radix-ui/react-slot" "1.0.1"
 
+"@radix-ui/react-collection@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.0.3.tgz#9595a66e09026187524a36c6e7e9c7d286469159"
+  integrity sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+
 "@radix-ui/react-compose-refs@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz#37595b1f16ec7f228d698590e78eeed18ff218ae"
@@ -315,10 +333,24 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-compose-refs@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz#7ed868b66946aa6030e580b1ffca386dd4d21989"
+  integrity sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
 "@radix-ui/react-context@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.0.0.tgz#f38e30c5859a9fb5e9aa9a9da452ee3ed9e0aee0"
   integrity sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-context@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.0.1.tgz#fe46e67c96b240de59187dcb7a1a50ce3e2ec00c"
+  integrity sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
@@ -340,6 +372,18 @@
     "@radix-ui/react-primitive" "1.0.1"
     "@radix-ui/react-use-callback-ref" "1.0.0"
     "@radix-ui/react-use-escape-keydown" "1.0.2"
+
+"@radix-ui/react-dismissable-layer@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.4.tgz#883a48f5f938fa679427aa17fcba70c5494c6978"
+  integrity sha512-7UpBa/RKMoHJYjie1gkF1DlK8l1fdU/VKDpoS3rCCo8YBJR294GwcEHyxHw72yvphJ7ld0AXEcSLAzY2F/WyCg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-escape-keydown" "1.0.3"
 
 "@radix-ui/react-focus-guards@1.0.0":
   version "1.0.0"
@@ -412,6 +456,14 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-primitive" "1.0.1"
 
+"@radix-ui/react-portal@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.0.3.tgz#ffb961244c8ed1b46f039e6c215a6c4d9989bda1"
+  integrity sha512-xLYZeHrWoPmA5mEKEfZZevoVRK/Q43GfzRXkWV6qawIWWK8t6ifIiLQdd7rmQ4Vk1bmI21XhqF9BN3jWf+phpA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
 "@radix-ui/react-presence@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.0.0.tgz#814fe46df11f9a468808a6010e3f3ca7e0b2e84a"
@@ -421,6 +473,15 @@
     "@radix-ui/react-compose-refs" "1.0.0"
     "@radix-ui/react-use-layout-effect" "1.0.0"
 
+"@radix-ui/react-presence@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.0.1.tgz#491990ba913b8e2a5db1b06b203cb24b5cdef9ba"
+  integrity sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
 "@radix-ui/react-primitive@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.1.tgz#c1ebcce283dd2f02e4fbefdaa49d1cb13dbc990a"
@@ -428,6 +489,14 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-slot" "1.0.1"
+
+"@radix-ui/react-primitive@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz#d49ea0f3f0b2fe3ab1cb5667eb03e8b843b914d0"
+  integrity sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-slot" "1.0.2"
 
 "@radix-ui/react-roving-focus@1.0.1":
   version "1.0.1"
@@ -452,6 +521,33 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-compose-refs" "1.0.0"
+
+"@radix-ui/react-slot@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.2.tgz#a9ff4423eade67f501ffb32ec22064bc9d3099ab"
+  integrity sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+
+"@radix-ui/react-toast@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-toast/-/react-toast-1.1.4.tgz#9a7fc2d71700886f3292f7699c905f1e01be59e1"
+  integrity sha512-wf+fc8DOywrpRK3jlPlWVe+ELYGHdKDaaARJZNuUTWyWYq7+ANCFLp4rTjZ/mcGkJJQ/vZ949Zis9xxEpfq9OA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.4"
+    "@radix-ui/react-portal" "1.0.3"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+    "@radix-ui/react-visually-hidden" "1.0.3"
 
 "@radix-ui/react-toggle-group@1.0.1":
   version "1.0.1"
@@ -503,6 +599,13 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-use-callback-ref@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz#f4bb1f27f2023c984e6534317ebc411fc181107a"
+  integrity sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
 "@radix-ui/react-use-controllable-state@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz#a64deaafbbc52d5d407afaa22d493d687c538b7f"
@@ -510,6 +613,14 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-callback-ref" "1.0.0"
+
+"@radix-ui/react-use-controllable-state@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz#ecd2ced34e6330caf89a82854aa2f77e07440286"
+  integrity sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
 
 "@radix-ui/react-use-escape-keydown@1.0.2":
   version "1.0.2"
@@ -519,10 +630,25 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-callback-ref" "1.0.0"
 
+"@radix-ui/react-use-escape-keydown@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz#217b840c250541609c66f67ed7bab2b733620755"
+  integrity sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
 "@radix-ui/react-use-layout-effect@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz#2fc19e97223a81de64cd3ba1dc42ceffd82374dc"
   integrity sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-layout-effect@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz#be8c7bc809b0c8934acf6657b577daf948a75399"
+  integrity sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
@@ -549,6 +675,14 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-primitive" "1.0.1"
+
+"@radix-ui/react-visually-hidden@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz#51aed9dd0fe5abcad7dee2a234ad36106a6984ac"
+  integrity sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
 
 "@radix-ui/rect@1.0.0":
   version "1.0.0"


### PR DESCRIPTION
## Pull Request Description:
This is my proposed fixed for issue [#714]. It contains the following: 
- A success notification that will pop up for a specified duration on successful email send
- Removed an unused checkbox in the `send` component

You can see a demo below:
![react-email-success-toast-demo](https://github.com/resendlabs/react-email/assets/67395687/3ff82087-94e8-484c-b1ac-becf83fe6189)
