### PR TITLE
Fix: `fix(client): TypeError when resolving email template import path

### DIFF
--- a/client/src/utils/get-emails.ts
+++ b/client/src/utils/get-emails.ts
@@ -6,8 +6,13 @@ export const CONTENT_DIR = 'emails';
 export const getEmails = async () => {
   const emailsDirectory = path.join(process.cwd(), CONTENT_DIR);
   const filenames = await fs.readdir(emailsDirectory);
+  const paths = filenames.map((filename) => {
+    return path.join(emailsDirectory, filename);
+  });
+
   const emails = filenames
     .map((file) => file.replace(/\.(jsx|tsx)$/g, ''))
     .filter((file) => file !== 'components');
-  return { emails, filenames };
+
+  return { emails, filenames, paths };
 };


### PR DESCRIPTION
## This PR fixes two issues:

1. A `TypeError` was being thrown when trying to resolve the import path of an email template on this line
```js
const importPath = exportTemplateFile.match(/import Mail from '(.+)';/)![1];
```

I have fixed the issue by exporting the original path from the `getEmails()` function and determining the import path based on the value of `params.slug`. 

This fixes the issue and removes an unnecessary file system operation that was being performed on line `34`:
```js
  const exportTemplateFile: string = await fs.readFile(path, {
    encoding: 'utf-8',
  });
```

2. A module not found error when trying to dynamically import email templates
I fixed this by adding the file extension `tsx` to the template string.
