### PR TITLE
feat (react-email): Ignore test files when generating email previews

### DIFF
--- a/packages/react-email/source/utils/generate-email-preview.ts
+++ b/packages/react-email/source/utils/generate-email-preview.ts
@@ -54,6 +54,8 @@ const createEmailPreviews = (emailDir: string) => {
 
   const list = sync(osIndependentPath(path.join(emailDir, '/*.{jsx,tsx}')), {
     absolute: true,
+    // ignore any spec or test file within the email directory
+    ignore: [path.join(emailDir, '*.?(spec|test).{jsx,tsx}')],
   });
 
   /**


### PR DESCRIPTION
## Overview

This PR resolves an issue when generating emails previews, currently if you have any spec or test file within this directory these are picked up as they end in the `jsx` or `tsx` extension.