### PR TITLE
fix(container): add alignment to td

### DIFF
--- a/packages/container/src/container.spec.tsx
+++ b/packages/container/src/container.spec.tsx
@@ -27,7 +27,7 @@ describe("<Container> component", () => {
     );
 
     expect(container).toMatchInlineSnapshot(
-      '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><table align=\\"center\\" width=\\"100%\\" border=\\"0\\" cellPadding=\\"0\\" cellSpacing=\\"0\\" role=\\"presentation\\" style=\\"max-width:300px\\"><tbody><tr style=\\"width:100%\\"><td><button type=\\"button\\">Hi</button></td></tr></tbody></table>"',
+      '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><table align=\\"center\\" width=\\"100%\\" border=\\"0\\" cellPadding=\\"0\\" cellSpacing=\\"0\\" role=\\"presentation\\" style=\\"max-width:300px\\"><tbody><tr style=\\"width:100%\\"><td align=\\"center\\"><button type=\\"button\\">Hi</button></td></tr></tbody></table>"',
     );
   });
 });

--- a/packages/container/src/container.tsx
+++ b/packages/container/src/container.tsx
@@ -22,7 +22,7 @@ export const Container: React.FC<Readonly<ContainerProps>> = ({
     >
       <tbody>
         <tr style={{ width: "100%" }}>
-          <td>{children}</td>
+          <td align="center">{children}</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
The website touts `Container` as 'A layout component that centers all the email content.'
This can be kind of misleading, especially if you're using the `email dev` preview, because this is not what you'll see if you just try to wrap your content in this component. This is an attempt to address that.