### PR TITLE
feat(render): Remove brackets surrounding anchor tags with plain text option

### DIFF
--- a/packages/render/src/render-async.ts
+++ b/packages/render/src/render-async.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import { convert } from "html-to-text";
 import type { ReactDOMServerReadableStream } from "react-dom/server";
-
 import { pretty } from "./utils/pretty";
 
 const readStream = async (readableStream: ReactDOMServerReadableStream) => {

--- a/packages/render/src/render.spec.tsx
+++ b/packages/render/src/render.spec.tsx
@@ -1,8 +1,7 @@
+import React from "react";
 import { Template } from "./utils/template";
 import { Preview } from "./utils/preview";
 import { render } from "./index";
-
-import React from "react";
 
 describe("render", () => {
   it("converts a React component into HTML", () => {
@@ -10,6 +9,21 @@ describe("render", () => {
     expect(actualOutput).toMatchInlineSnapshot(
       '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><h1>Welcome, Jim!</h1><img alt=\\"test\\" src=\\"img/test.png\\"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p>"',
     );
+  });
+
+  it("should not have brackets around the link with the plain text active", () => {
+    const Email = (
+      <div>
+        <a href="https://github.com/resend/react-email/pull/1087">
+          This is the PR that fixes the issues with this!
+        </a>
+      </div>
+    );
+    const textRendered = render(Email, { plainText: true });
+    expect(textRendered).toMatchInlineSnapshot(`
+      "This is the PR that fixes the issues with this!
+      https://github.com/resend/react-email/pull/1087"
+    `);
   });
 
   it("converts a React component into PlainText", () => {

--- a/packages/render/src/render.ts
+++ b/packages/render/src/render.ts
@@ -32,6 +32,10 @@ const renderAsPlainText = (
     selectors: [
       { selector: "img", format: "skip" },
       { selector: "#__react-email-preview", format: "skip" },
+      {
+        selector: "a",
+        options: { linkBrackets: false }
+      }
     ],
   });
 };

--- a/packages/render/src/render.ts
+++ b/packages/render/src/render.ts
@@ -1,6 +1,5 @@
 import * as ReactDomServer from "react-dom/server";
 import { convert } from "html-to-text";
-
 import { pretty } from "./utils/pretty";
 
 export interface Options {
@@ -34,8 +33,8 @@ const renderAsPlainText = (
       { selector: "#__react-email-preview", format: "skip" },
       {
         selector: "a",
-        options: { linkBrackets: false }
-      }
+        options: { linkBrackets: false },
+      },
     ],
   });
 };


### PR DESCRIPTION
We're having customer support inquiries that links in our plain text emails lead to nonexistent or broken pages. Customer support have identified that the issue is that users are either copying links but not removing the bracket, or their email clients are not stripping the trailing bracket `]`.

I've investigated how `react-email` generates the plain text emails, and it comes down to a package called `html-to-text`.

https://www.npmjs.com/package/html-to-text

This library has the option to either disable or configure the brackets via the option `linkBrackets`.

I've simply disabled brackets since `html-to-text` isn't optimized for compatibility with email clients and this seems like the simplest solution.

> Side note: it's impossible for us to patch the `@react-email/render` package with `pnpm patch`. So right now we're stripping the bad links of their trailing `]` which is quite a fragile and hacky solution. I think that https://github.com/resendlabs/react-email/issues/881 might fix the patching problem.