### PR TITLE
fix (tailwind): `NOVE_ENV=production` causing missing head errors with Head component

### DIFF
--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -181,7 +181,12 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
   else if (
     typeof element.type === "function" &&
     element.type.name === "Head" 
-  ) 
+  ) {
+    // Ignore <Head> components
+  }
+  else {
+    // Other elements are ok
+  }
 });
    
 

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -175,16 +175,15 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
       element,
       nonMediaQueryTailwindStylesPerClass,
     );
-
-    if (
-      element.type === "head" ||
-      (typeof element.type === "function" &&
-        "name" in element.type &&
-        element.type.name === "Head")
-    ) {
-      headElementIndex = i;
-    }
-  });
+  if (element.type === "head") {
+      headElementIndex = i; 
+  }
+  else if (
+    typeof element.type === "function" &&
+    element.type.name === "Head" 
+  ) 
+});
+   
 
   headStyles = headStyles.filter((style) => style.trim().length > 0);
 


### PR DESCRIPTION
issue-:#1112


Fix:Head Component bug.

Check for plain <head> tag and save the index
When encountering <Head> component, ignore it instead of saving index
This will skip over any <Head> components during the build process, avoiding the bug. But it will detect a plain <head> tag and use that for purging styles correctly.

So this allows using <head> under Tailwind for production builds, while skipping any <Head> components that may break things.


