### PR TITLE
fix(tailwind): Media query escaped class names

### DIFF
--- a/packages/tailwind/readme.md
+++ b/packages/tailwind/readme.md
@@ -59,6 +59,59 @@ const Email = () => {
 };
 ```
 
+## Contributing notes
+
+These are some things you will need to keep in mind if you are improving the Tailwind component
+with things that might influence certain decisions we have made for better
+email client support that have been made also in the past by other contributors but not documented
+which ended up causing us to have these problems and need to rediscover the best decisions again.
+
+### The inlining of all styles
+
+This is one of the most important because this is not one of the use cases this is
+the main focus point of using the Tailwind component. The support for defining styles with tags
+and using [classes is not the best](https://www.caniemail.com/features/html-style/).
+
+This though can't be used the same for media queries so we do append the media queries
+and the class names associated with them on a `<style>` tag on the `<head>` element.
+
+### The treatment for Tailwind's CSS variables
+
+This is also something we need to keep in mind here, emails don't really have great support
+for CSS variables, so we needed to use a [postcss plugin](https://github.com/MadLittleMods/postcss-css-variables) 
+alongisde Tailwind to resolve all of these variables.
+
+### The treatment for media query class names
+
+For media queries we have made more than one decision that are for the better. The first one
+and most important is sanitizing the media query class names on the `<style>` tag to avoid
+needing to escape the class names which does cause problems. 
+
+### RGB syntax color changes
+
+For the best support two things were taken into account here. First thing is that
+the syntax using spaces, which Tailwind generally uses, is not really supported, 
+neither for `rgb` nor for `rgba`, so we do a pass through Tailwind's generated 
+styles to change the syntax into using commas instead of spaces.
+
+Second thing is that both `rgba` and using `/` for defining the color's opacity
+are not very well supported, but passing in the opacity as a fourth parameter of `rgb()`
+is what is mostly supported so we also account for that.
+
+This has an effect like the following:
+
+```CSS
+rgb(255 255 255 / 1) -> rgb(255,255,255)
+rgb(212 213 102 / 0.2) -> rgb(212,213,102,0.2)
+```
+
+### Defining the styles on the React `style` prop
+
+This is something that comes a bit at the risk of performance but it is a safer way of doing this.
+The reason this is safer is because certain components of ours or even custom ones may modify the 
+way styles are applied and defining it directly on the rendered HTML would cause unexpected behavior
+on that.
+
 ## Support
 
 This component was tested using the most popular email clients.

--- a/packages/tailwind/readme.md
+++ b/packages/tailwind/readme.md
@@ -78,20 +78,20 @@ and the class names associated with them on a `<style>` tag on the `<head>` elem
 ### The treatment for Tailwind's CSS variables
 
 This is also something we need to keep in mind here, emails don't really have great support
-for CSS variables, so we needed to use a [postcss plugin](https://github.com/MadLittleMods/postcss-css-variables) 
+for CSS variables, so we needed to use a [postcss plugin](https://github.com/MadLittleMods/postcss-css-variables)
 alongisde Tailwind to resolve all of these variables.
 
 ### The treatment for media query class names
 
 For media queries we have made more than one decision that are for the better. The first one
 and most important is sanitizing the media query class names on the `<style>` tag to avoid
-needing to escape the class names which does cause problems. 
+needing to escape the class names which does cause problems.
 
 ### RGB syntax color changes
 
 For the best support two things were taken into account here. First thing is that
-the syntax using spaces, which Tailwind generally uses, is not really supported, 
-neither for `rgb` nor for `rgba`, so we do a pass through Tailwind's generated 
+the syntax using spaces, which Tailwind generally uses, is not really supported,
+neither for `rgb` nor for `rgba`, so we do a pass through Tailwind's generated
 styles to change the syntax into using commas instead of spaces.
 
 Second thing is that both `rgba` and using `/` for defining the color's opacity
@@ -108,7 +108,7 @@ rgb(212 213 102 / 0.2) -> rgb(212,213,102,0.2)
 ### Defining the styles on the React `style` prop
 
 This is something that comes a bit at the risk of performance but it is a safer way of doing this.
-The reason this is safer is because certain components of ours or even custom ones may modify the 
+The reason this is safer is because certain components of ours or even custom ones may modify the
 way styles are applied and defining it directly on the rendered HTML would cause unexpected behavior
 on that.
 

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { renderToStaticMarkup as render } from "react-dom/server";
+import React from "react";
 import { Hr } from "@react-email/hr";
 import { Html } from "@react-email/html";
 import { Head } from "@react-email/head";
@@ -150,7 +151,7 @@ describe("Responsive styles", () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<html lang=\\"en\\"><head><style>@media(min-width:640px){.sm\\\\:bg-red-300{background-color:rgb(252,165,165)!important}}@media(min-width:768px){.md\\\\:bg-red-400{background-color:rgb(248,113,113)!important}}@media(min-width:1024px){.lg\\\\:bg-red-500{background-color:rgb(239,68,68)!important}}</style></head><body><div class=\\"sm:bg-red-300 md:bg-red-400 lg:bg-red-500\\" style=\\"background-color:rgb(254,202,202)\\"></div></body></html>"',
+      '"<html lang=\\"en\\"><head><style>@media(min-width:640px){.sm_bg-red-300{background-color:rgb(252,165,165)!important}}@media(min-width:768px){.md_bg-red-400{background-color:rgb(248,113,113)!important}}@media(min-width:1024px){.lg_bg-red-500{background-color:rgb(239,68,68)!important}}</style></head><body><div class=\\"sm_bg-red-300 md_bg-red-400 lg_bg-red-500\\" style=\\"background-color:rgb(254,202,202)\\"></div></body></html>"',
     );
   });
 
@@ -186,7 +187,7 @@ describe("Responsive styles", () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<html lang=\\"en\\"><head><style></style><link/><style>@media(min-width:640px){.sm\\\\:bg-red-500{background-color:rgb(239,68,68)!important}}</style></head><body><div class=\\"sm:bg-red-500\\" style=\\"background-color:rgb(254,202,202)\\"></div></body></html>"',
+      '"<html lang=\\"en\\"><head><style></style><link/><style>@media(min-width:640px){.sm_bg-red-500{background-color:rgb(239,68,68)!important}}</style></head><body><div class=\\"sm_bg-red-500\\" style=\\"background-color:rgb(254,202,202)\\"></div></body></html>"',
     );
   });
 });
@@ -355,7 +356,7 @@ describe("Custom plugins config", () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<html lang=\\"en\\"><head><style>@media(min-width:640px){.sm\\\\:border-custom{border:2px solid!important}}</style></head><body><div class=\\"sm:border-custom\\" style=\\"border:2px solid\\"></div></body></html>"',
+      '"<html lang=\\"en\\"><head><style>@media(min-width:640px){.sm_border-custom{border:2px solid!important}}</style></head><body><div class=\\"sm_border-custom\\" style=\\"border:2px solid\\"></div></body></html>"',
     );
   });
 });
@@ -377,11 +378,11 @@ describe("<Tailwind> component", () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<html dir=\\"ltr\\" lang=\\"en\\"><head><meta content=\\"text/html; charset=UTF-8\\" http-equiv=\\"Content-Type\\"/><style>@media(min-width:640px){.sm\\\\:bg-red-50{background-color:rgb(254,242,242)!important}.sm\\\\:text-sm{font-size:0.875rem!important;line-height:1.25rem!important}}@media(min-width:768px){.md\\\\:text-lg{font-size:1.125rem!important;line-height:1.75rem!important}}</style></head><span><!--[if mso]><i style=\\"letter-spacing: 10px;mso-font-width:-100%;\\" hidden>&nbsp;</i><![endif]--></span><div class=\\"sm:bg-red-50 sm:text-sm md:text-lg custom-class\\" style=\\"background-color:rgb(255,255,255)\\"></div></html>"',
+      '"<html dir=\\"ltr\\" lang=\\"en\\"><head><meta content=\\"text/html; charset=UTF-8\\" http-equiv=\\"Content-Type\\"/><style>@media(min-width:640px){.sm_bg-red-50{background-color:rgb(254,242,242)!important}.sm_text-sm{font-size:0.875rem!important;line-height:1.25rem!important}}@media(min-width:768px){.md_text-lg{font-size:1.125rem!important;line-height:1.75rem!important}}</style></head><span><!--[if mso]><i style=\\"letter-spacing: 10px;mso-font-width:-100%;\\" hidden>&nbsp;</i><![endif]--></span><div class=\\"sm_bg-red-50 sm_text-sm md_text-lg custom-class\\" style=\\"background-color:rgb(255,255,255)\\"></div></html>"',
     );
   });
 
-  it("should recognize custom resopnsive screen", () => {
+  it("should recognize custom responsive screen", () => {
     const config: TailwindConfig = {
       theme: {
         screens: {
@@ -404,21 +405,22 @@ describe("<Tailwind> component", () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<html dir=\\"ltr\\" lang=\\"en\\"><head><meta content=\\"text/html; charset=UTF-8\\" http-equiv=\\"Content-Type\\"/><style>@media(min-width:1280px){.xl\\\\:bg-green-500{background-color:rgb(34,197,94)!important}}@media(min-width:1536px){.\\\\32xl\\\\:bg-blue-500{background-color:rgb(59,130,246)!important}}</style></head><div class=\\"xl:bg-green-500\\" style=\\"background-color:rgb(254,226,226)\\">Test</div><div class=\\"2xl:bg-blue-500\\">Test</div></html>"',
+      '"<html dir=\\"ltr\\" lang=\\"en\\"><head><meta content=\\"text/html; charset=UTF-8\\" http-equiv=\\"Content-Type\\"/><style>@media(min-width:1280px){.xl_bg-green-500{background-color:rgb(34,197,94)!important}}@media(min-width:1536px){.2xl_bg-blue-500{background-color:rgb(59,130,246)!important}}</style></head><div class=\\"xl_bg-green-500\\" style=\\"background-color:rgb(254,226,226)\\">Test</div><div class=\\"2xl_bg-blue-500\\">Test</div></html>"',
     );
   });
 
-  it("should work with calc() with + sign", () => {
+  it.only("should work with calc() with + sign", () => {
     const actualOutput = render(
       <Tailwind>
-        <div className="max-h-[calc(50px+3rem)] bg-red-100">
+        <head />
+        <div className="max-h-[calc(50px+3rem)] lg:max-h-[calc(50px+5rem)] bg-red-100">
           <div className="h-[200px]">something tall</div>
         </div>
       </Tailwind>,
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<div style=\\"max-height:calc(50px + 3rem);background-color:rgb(254,226,226)\\"><div style=\\"height:200px\\">something tall</div></div>"',
+      '"<head><style>@media(min-width:1024px){.lg_max-h-calc50pxplus5rem{max-height:calc(50px + 5rem)!important}}</style></head><div class=\\"lg_max-h-calc50pxplus5rem\\" style=\\"max-height:calc(50px + 3rem);background-color:rgb(254,226,226)\\"><div style=\\"height:200px\\">something tall</div></div>"',
     );
   });
 });

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -409,7 +409,7 @@ describe("<Tailwind> component", () => {
     );
   });
 
-  it.only("should work with calc() with + sign", () => {
+  it("should work with calc() with + sign", () => {
     const actualOutput = render(
       <Tailwind>
         <head />

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -155,9 +155,11 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
 
     let finalMediaQuery = mediaQuery;
 
-    for (const [fullRule, escapedRuleClassName, ruleContent] of content.matchAll(
-      /\s*\.([\S]+)\s*{([^}]*)}/gm,
-    )) {
+    for (const [
+      fullRule,
+      escapedRuleClassName,
+      ruleContent,
+    ] of content.matchAll(/\s*\.([\S]+)\s*{([^}]*)}/gm)) {
       const ruleClassName = escapedRuleClassName.replaceAll(/\\[0-9]|\\/g, "");
       nonEscapedMediaQueryClasses.push(ruleClassName);
 

--- a/packages/tailwind/src/utils/escape-class-name.ts
+++ b/packages/tailwind/src/utils/escape-class-name.ts
@@ -15,5 +15,3 @@ export const escapeClassName = (className: string) => {
     },
   );
 };
-
-

--- a/packages/tailwind/src/utils/escape-class-name.ts
+++ b/packages/tailwind/src/utils/escape-class-name.ts
@@ -15,3 +15,5 @@ export const escapeClassName = (className: string) => {
     },
   );
 };
+
+

--- a/packages/tailwind/src/utils/sanitize-class-name.spec.ts
+++ b/packages/tailwind/src/utils/sanitize-class-name.spec.ts
@@ -1,0 +1,7 @@
+import { sanitizeClassName } from "./sanitize-class-name";
+
+test('sanitizeClassName', () => {
+  expect(sanitizeClassName("min-height-[calc(25px+100%-20%*2/4)]")).toBe(
+    "min-height-calc25pxplus100pc-20pc_2_4",
+  );
+})

--- a/packages/tailwind/src/utils/sanitize-class-name.spec.ts
+++ b/packages/tailwind/src/utils/sanitize-class-name.spec.ts
@@ -1,7 +1,7 @@
 import { sanitizeClassName } from "./sanitize-class-name";
 
-test('sanitizeClassName', () => {
+test("sanitizeClassName", () => {
   expect(sanitizeClassName("min-height-[calc(25px+100%-20%*2/4)]")).toBe(
     "min-height-calc25pxplus100pc-20pc_2_4",
   );
-})
+});

--- a/packages/tailwind/src/utils/sanitize-class-name.ts
+++ b/packages/tailwind/src/utils/sanitize-class-name.ts
@@ -1,0 +1,23 @@
+/**
+ * Replaces special characters to avoid problems on email clients.
+ *
+ * @param className - This should not come with any escaped charcters, it should come the same
+ * as is on the `className` attribute on React elements.
+ */
+export const sanitizeClassName = (className: string) => {
+  return className
+    .replaceAll("+", "plus")
+    .replaceAll("[", "")
+    .replaceAll("%", "pc")
+    .replaceAll("]", "")
+    .replaceAll("(", "")
+    .replaceAll(")", "")
+    .replaceAll("!", "imprtnt")
+    .replaceAll(">", "gt")
+    .replaceAll("<", "lt")
+    .replaceAll("=", "eq")
+    .replace(
+      /[^a-zA-Z0-9\-_]/g,
+      "_",
+    );
+};

--- a/packages/tailwind/src/utils/sanitize-class-name.ts
+++ b/packages/tailwind/src/utils/sanitize-class-name.ts
@@ -16,8 +16,5 @@ export const sanitizeClassName = (className: string) => {
     .replaceAll(">", "gt")
     .replaceAll("<", "lt")
     .replaceAll("=", "eq")
-    .replace(
-      /[^a-zA-Z0-9\-_]/g,
-      "_",
-    );
+    .replace(/[^a-zA-Z0-9\-_]/g, "_");
 };


### PR DESCRIPTION
This PR changes how the media query class names are kept by removing
escaping characters from them and replacing the ones they were meant
to escape with other characters that have better CSS support. Closes #1095.

Besides this, I also added in something I think is really important.
I added [Contributing notes](https://github.com/resend/react-email/pull/1114/files#diff-d5f010753aedd069206ab7ace5ccab1e79d89c40f3dbe2228539e7b450cc1c17) that mention the decisions
taken to modify the CSS generated by Tailwind and how it is applied to the email
for better email client support and for us to not lose these.

Would also be a great idea to write unit tests for these email support decisions, so we 
don't lose them by checking on a CI basis as well.

## How can I make sure this is fixed?

You can take a look into how I implemented the unit tests and how their snapshots look, no need to test by manually rendering.

Though you can try making sure things are completely working by sending to a Gmail account of yours an email with React Email's Tailwind integration as Gmail strips the styles completely. Just remember to use media queries, as they are the only ones that end up on a `<style>` tag.