### PR TITLE
fix(build-preview): error when use email build and start

### DIFF
--- a/packages/react-email/source/utils/generate-email-preview.ts
+++ b/packages/react-email/source/utils/generate-email-preview.ts
@@ -88,7 +88,7 @@ const createEmailPreviews = (emailDir: string) => {
     const importFile = osIndependentPath(path.join(importPath, fileName));
 
     // if this import is changed, you also need to update `client/src/app/preview/[slug]/page.tsx`
-    const sourceCode = `import Mail from '${importFile}';\nexport default Mail;\n`;
+    const sourceCode = `// @ts-ignore\nimport Mail from '${importFile}';\nexport default Mail;\n`;
 
     fs.writeFileSync(targetFile, sourceCode);
   }


### PR DESCRIPTION
When using the `email build` and `email start` commands to deploy the preview page, an issue arises. After generating an email preview, the generateEmailsPreview function writes a file with source code in .tsx format. However, this process results in TypeScript errors, and the build cannot be completed successfully.

It serves as a temporary workaround.

- add `// @ts-ignore` leading sourceCode variable 