### PR TITLE
fix(web): Demo folder location on GitHub

### DIFF
--- a/apps/web/src/pages/examples/index.tsx
+++ b/apps/web/src/pages/examples/index.tsx
@@ -128,7 +128,7 @@ const Examples = () => {
               or submit a{" "}
               <Anchor
                 appearance="white"
-                href="https://github.com/resend/react-email/tree/main/apps/demo/emails"
+                href="https://github.com/resend/react-email/tree/main/demo"
                 target="_blank"
               >
                 pull request


### PR DESCRIPTION
Or maybe we should move `demo` back to `apps/demo`