### PR TITLE
feat(client): show proper error message on email component not exported as default

### DIFF
--- a/client/src/app/preview/[slug]/page.tsx
+++ b/client/src/app/preview/[slug]/page.tsx
@@ -24,6 +24,11 @@ export default async function Page({ params }) {
   });
 
   const Email = (await import(`../../../../emails/${params.slug}`)).default;
+  if (Email == null)
+    throw new Error(
+      `You need to export your Email component as a default export`,
+    );
+
   const previewProps = Email.PreviewProps || {};
   const markup = await renderAsync(<Email {...previewProps} />, {
     pretty: true,


### PR DESCRIPTION
This PR adds a proper error message when an email file doesn't have any default exports

![CleanShot 2024-01-19 at 08 05 53](https://github.com/resend/react-email/assets/2129163/4e8394e3-d8f3-4140-927e-d8f5144d9d55)
