### PR TITLE
fix(react-email): Sidebar toggle tooltip & email preview's iframe default background

### DIFF
--- a/packages/react-email/src/app/preview/[slug]/preview.tsx
+++ b/packages/react-email/src/app/preview/[slug]/preview.tsx
@@ -87,7 +87,7 @@ const Preview = ({
           <>
             {activeView === 'desktop' && (
               <iframe
-                className="w-full h-[calc(100vh_-_140px)] lg:h-[calc(100vh_-_70px)]"
+                className="w-full bg-white h-[calc(100vh_-_140px)] lg:h-[calc(100vh_-_70px)]"
                 srcDoc={renderedEmailMetadata.markup}
                 title={slug}
               />
@@ -95,7 +95,7 @@ const Preview = ({
 
             {activeView === 'mobile' && (
               <iframe
-                className="w-[360px] h-[calc(100vh_-_140px)] lg:h-[calc(100vh_-_70px)] mx-auto"
+                className="w-[360px] bg-white h-[calc(100vh_-_140px)] lg:h-[calc(100vh_-_70px)] mx-auto"
                 srcDoc={renderedEmailMetadata.markup}
                 title={slug}
               />

--- a/packages/react-email/src/components/shell.tsx
+++ b/packages/react-email/src/components/shell.tsx
@@ -59,7 +59,7 @@ export const Shell = ({
       <div className="flex bg-slate-2">
         <Sidebar
           className={cn(
-            'w-screen max-w-full bg-black h-screen lg:h-auto z-50 lg:max-w-[275px] fixed top-[70px] lg:top-0 left-0',
+            'w-screen max-w-full bg-black h-screen lg:h-auto z-50 lg:z-auto lg:max-w-[275px] fixed top-[70px] lg:top-0 left-0',
             {
               'translate-x-0 lg:-translate-x-full': sidebarToggled,
               '-translate-x-full lg:translate-x-0': !sidebarToggled,


### PR DESCRIPTION
## What was the issue?

Because of a fix I made for the mobile preview app's Sidebar being transparent
it caused the tooltip for toggling the Sidebar to be bellow it due to its z-index.
The way I fixed this was by just adding the larger z-index when the user was on mobile.

## How can I test to make sure it's fixed?

1. Run `npx tsx ../../packages/react-email/src/cli/index.ts dev` inside of `./apps/demo`
2. Open http://localhost:3000
3. Hover the button to toggle the sidebar
4. Verify that the tooltip is above the sidebar