### PR TITLE
fix(react-email): Missing suspense boundaries

### DIFF
--- a/packages/code-block/src/prism.ts
+++ b/packages/code-block/src/prism.ts
@@ -7876,8 +7876,8 @@ export { Prism };
       return "string" == typeof e
         ? e
         : Array.isArray(e)
-          ? e.map(d).join("")
-          : d(e.content);
+        ? e.map(d).join("")
+        : d(e.content);
     }
     g.hooks.add("after-tokenize", function (e) {
       e.language in a &&
@@ -10194,8 +10194,8 @@ export { Prism };
       return "string" == typeof e
         ? e
         : Array.isArray(e)
-          ? e.map(a).join("")
-          : a(e.content);
+        ? e.map(a).join("")
+        : a(e.content);
     }
     (e.languages.naniscript = {
       comment: { pattern: /^([\t ]*);.*/m, lookbehind: !0 },
@@ -12582,13 +12582,13 @@ export { Prism };
               : "/>" !== a.content[a.content.length - 1].content &&
                 t.push({ tagName: s(a.content[0].content[1]), openedBraces: 0 })
             : 0 < t.length && "punctuation" === a.type && "{" === a.content
-              ? t[t.length - 1].openedBraces++
-              : 0 < t.length &&
-                  0 < t[t.length - 1].openedBraces &&
-                  "punctuation" === a.type &&
-                  "}" === a.content
-                ? t[t.length - 1].openedBraces--
-                : (r = !0)),
+            ? t[t.length - 1].openedBraces++
+            : 0 < t.length &&
+              0 < t[t.length - 1].openedBraces &&
+              "punctuation" === a.type &&
+              "}" === a.content
+            ? t[t.length - 1].openedBraces--
+            : (r = !0)),
           (r || "string" == typeof a) &&
             0 < t.length &&
             0 === t[t.length - 1].openedBraces &&
@@ -12608,8 +12608,8 @@ export { Prism };
         ? "string" == typeof e
           ? e
           : "string" == typeof e.content
-            ? e.content
-            : e.content.map(s).join("")
+          ? e.content
+          : e.content.map(s).join("")
         : "";
     };
     i.hooks.add("after-tokenize", function (e) {
@@ -15477,23 +15477,23 @@ export { Prism };
               : "/>" !== a.content[a.content.length - 1].content &&
                 t.push({ tagName: s(a.content[0].content[1]), openedBraces: 0 })
             : !(
-                  0 < t.length &&
-                  "punctuation" === a.type &&
-                  "{" === a.content
-                ) ||
-                (e[n + 1] &&
-                  "punctuation" === e[n + 1].type &&
-                  "{" === e[n + 1].content) ||
-                (e[n - 1] &&
-                  "plain-text" === e[n - 1].type &&
-                  "{" === e[n - 1].content)
-              ? 0 < t.length &&
-                0 < t[t.length - 1].openedBraces &&
+                0 < t.length &&
                 "punctuation" === a.type &&
-                "}" === a.content
-                ? t[t.length - 1].openedBraces--
-                : "comment" !== a.type && (r = !0)
-              : t[t.length - 1].openedBraces++),
+                "{" === a.content
+              ) ||
+              (e[n + 1] &&
+                "punctuation" === e[n + 1].type &&
+                "{" === e[n + 1].content) ||
+              (e[n - 1] &&
+                "plain-text" === e[n - 1].type &&
+                "{" === e[n - 1].content)
+            ? 0 < t.length &&
+              0 < t[t.length - 1].openedBraces &&
+              "punctuation" === a.type &&
+              "}" === a.content
+              ? t[t.length - 1].openedBraces--
+              : "comment" !== a.type && (r = !0)
+            : t[t.length - 1].openedBraces++),
           (r || "string" == typeof a) &&
             0 < t.length &&
             0 === t[t.length - 1].openedBraces &&
@@ -15514,8 +15514,8 @@ export { Prism };
       return "string" == typeof e
         ? e
         : "string" == typeof e.content
-          ? e.content
-          : e.content.map(s).join("");
+        ? e.content
+        : e.content.map(s).join("");
     };
     i.hooks.add("after-tokenize", function (e) {
       "xquery" === e.language && o(e.tokens);

--- a/packages/react-email/src/app/preview/[slug]/page.tsx
+++ b/packages/react-email/src/app/preview/[slug]/page.tsx
@@ -1,6 +1,8 @@
+import { Suspense } from 'react';
 import { getEmailsDirectoryMetadata } from '../../../actions/get-emails-directory-metadata';
 import { renderEmailBySlug } from '../../../actions/render-email-by-slug';
 import { emailsDirectoryAbsolutePath } from '../../../utils/emails-directory-absolute-path';
+import Home from '../../page';
 import Preview from './preview';
 
 export const dynamicParams = true;
@@ -34,7 +36,14 @@ export default async function Page({ params }: { params: PreviewParams }) {
     });
   }
 
-  return <Preview renderingResult={emailRenderingResult} slug={slug} />;
+  return (
+    // This suspense is so that this page doesn't throw warnings 
+    // on the build of the preview server de-opting into 
+    // client-side rendering on build
+    <Suspense fallback={<Home />}>
+      <Preview renderingResult={emailRenderingResult} slug={slug} />
+    </Suspense>
+  );
 }
 
 export function generateMetadata({ params }: { params: PreviewParams }) {

--- a/packages/react-email/src/app/preview/[slug]/page.tsx
+++ b/packages/react-email/src/app/preview/[slug]/page.tsx
@@ -37,8 +37,8 @@ export default async function Page({ params }: { params: PreviewParams }) {
   }
 
   return (
-    // This suspense is so that this page doesn't throw warnings 
-    // on the build of the preview server de-opting into 
+    // This suspense is so that this page doesn't throw warnings
+    // on the build of the preview server de-opting into
     // client-side rendering on build
     <Suspense fallback={<Home />}>
       <Preview renderingResult={emailRenderingResult} slug={slug} />

--- a/packages/react-email/src/cli/utils/preview/start-dev-server.ts
+++ b/packages/react-email/src/cli/utils/preview/start-dev-server.ts
@@ -60,8 +60,8 @@ export const startDevServer = async (
       ) {
         void serveStaticFile(res, parsedUrl, staticBaseDirRelativePath);
       } else if (!isNextReady) {
-        void nextReadyPromise.then(() =>
-          nextHandleRequest?.(req, res, parsedUrl),
+        void nextReadyPromise.then(
+          () => nextHandleRequest?.(req, res, parsedUrl),
         );
       } else {
         void nextHandleRequest?.(req, res, parsedUrl);

--- a/packages/react-email/src/components/sidebar/sidebar.tsx
+++ b/packages/react-email/src/components/sidebar/sidebar.tsx
@@ -30,12 +30,14 @@ export const Sidebar = ({
       </div>
       <nav className="p-4 flex-grow lg:pt-0 pl-0 w-screen h-[calc(100vh_-_70px)] lg:w-full lg:min-w-[275px] lg:max-w-[275px] flex flex-col overflow-y-auto">
         <Collapsible.Root>
-          <SidebarDirectoryChildren
-            currentEmailOpenSlug={currentEmailOpenSlug}
-            emailsDirectoryMetadata={emailsDirectoryMetadata}
-            isRoot
-            open
-          />
+          <React.Suspense>
+            <SidebarDirectoryChildren
+              currentEmailOpenSlug={currentEmailOpenSlug}
+              emailsDirectoryMetadata={emailsDirectoryMetadata}
+              isRoot
+              open
+            />
+          </React.Suspense>
         </Collapsible.Root>
       </nav>
     </aside>


### PR DESCRIPTION
## What was the issue?

This solves this things in the same way:

1. All of the preview pages de-opting into client-side rendering with warnings (see https://nextjs.org/docs/messages/deopted-into-client-rendering)
2. Build failing because of `useSearchParams` inside of `packages/react-email/src/components/sidebar/sidebar-directory-children.tsx`. (see https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout)

Both of these were fixed by adding a Suspense boundary first here:

https://github.com/resend/react-email/blob/6a5cdf392b3742174caa3f26749d9e4fadcab31d/packages/react-email/src/app/preview/%5Bslug%5D/page.tsx#L39-L47

Then here:

https://github.com/resend/react-email/blob/6a5cdf392b3742174caa3f26749d9e4fadcab31d/packages/react-email/src/components/sidebar/sidebar.tsx#L32-L41

## How can I test to make sure it's fixed?

1. Run `npx tsx ../../packages/react-email/src/cli/index.ts build` inside of `./apps/demo`
2. Verify that Next, both doesn't warn about de-opting into client-side rendering and that it doesn't error when rendering `/`.
