### PR TITLE
feat(react-email): Add sharp as a dependency on build

### DIFF
--- a/packages/react-email/src/cli/commands/build.ts
+++ b/packages/react-email/src/cli/commands/build.ts
@@ -146,13 +146,15 @@ export async function generateStaticParams() {
   );
 };
 
-const updatePackageJsonScripts = async (builtPreviewAppPath: string) => {
+const updatePackageJson = async (builtPreviewAppPath: string) => {
   const packageJsonPath = path.resolve(builtPreviewAppPath, './package.json');
   const packageJson = JSON.parse(
     await fs.promises.readFile(packageJsonPath, 'utf8'),
-  ) as { scripts: Record<string, string> };
+  ) as { scripts: Record<string, string>; dependencies: Record<string, string> };
   packageJson.scripts.build = 'next build';
   packageJson.scripts.start = 'next start';
+  
+  packageJson.dependencies.sharp = "0.33.2";
   await fs.promises.writeFile(
     packageJsonPath,
     JSON.stringify(packageJson),
@@ -242,7 +244,7 @@ export const build = async ({
     await forceSSGForEmailPreviews(emailsDirPath, builtPreviewAppPath);
 
     spinner.text = "Updating package.json's build and start scripts";
-    await updatePackageJsonScripts(builtPreviewAppPath);
+    await updatePackageJson(builtPreviewAppPath);
 
     spinner.text = 'Installing dependencies on `.react-email`';
     await npmInstall(builtPreviewAppPath, packageManager);

--- a/packages/react-email/src/cli/commands/build.ts
+++ b/packages/react-email/src/cli/commands/build.ts
@@ -150,11 +150,14 @@ const updatePackageJson = async (builtPreviewAppPath: string) => {
   const packageJsonPath = path.resolve(builtPreviewAppPath, './package.json');
   const packageJson = JSON.parse(
     await fs.promises.readFile(packageJsonPath, 'utf8'),
-  ) as { scripts: Record<string, string>; dependencies: Record<string, string> };
+  ) as {
+    scripts: Record<string, string>;
+    dependencies: Record<string, string>;
+  };
   packageJson.scripts.build = 'next build';
   packageJson.scripts.start = 'next start';
-  
-  packageJson.dependencies.sharp = "0.33.2";
+
+  packageJson.dependencies.sharp = '0.33.2';
   await fs.promises.writeFile(
     packageJsonPath,
     JSON.stringify(packageJson),


### PR DESCRIPTION
## What was the issue?

A warning would always be added to the terminal saying `sharp` was missing once the user ran `email build`
because of Next not being able to do image optimizations. I fixed this by modifying the file at `./.react-email/package.json` relative to the user's project
and adding `sharp` as a dependency there. This wasn't much of a hassle as we already modified
it to add the start and build scripts.

## How can I test to make sure it's fixed?

1. Run `npx tsx ../../packages/react-email/src/cli/index.ts build` inside of `./apps/demo`
2. Verify that there are no `sharp missing` warnings