### PR TITLE
fix(react-email): Emails parent folder with `_` prefix

### DIFF
--- a/packages/react-email/src/actions/get-emails-directory-metadata.ts
+++ b/packages/react-email/src/actions/get-emails-directory-metadata.ts
@@ -4,11 +4,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const isFileAnEmail = (fullPath: string): boolean => {
-  const unixFullPath = fullPath.replaceAll(path.sep, '/');
-
-  // eslint-disable-next-line prefer-named-capture-group
-  if (/(\/|^)_[^/]*/.test(unixFullPath)) return false;
-
   const stat = fs.statSync(fullPath);
 
   if (stat.isDirectory()) return false;


### PR DESCRIPTION
## What was the issue?

Someone from Discord came to me reporting that they weren't being able to see their emails
on the Sidebar of the preview app. This was caused due to an unnecessary regex that was testing
whether or not the path to the email had a `_` at the start of any of its segments meaning
that it would fail if the user had a project either being the one or being inside a directory prefixed with `_`.

Here's the code with the issue:

https://github.com/resend/react-email/blob/7028a581bac498bec90dce91277e0ec1de8f3221/packages/react-email/src/actions/get-emails-directory-metadata.ts#L6-L13

## How can I test to make sure it's fixed?

1. Rename the folder at `./apps/demo` into `./_apps/demo`
2. Run `npx tsx ../../packages/react-email/src/cli/index.ts dev` inside of `./_apps/demo`
3. Open http://localhost:3000
4. Verify that all the emails are appearing appropriately on the Sidebar and that they render correctly