### PR TITLE
fix(react-email): ESM Issue with `await import` of the compiled email templates

### DIFF
--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -94,7 +94,7 @@ export const exportTemplates = async (
       // eslint-disable-next-line
       const component = await import(template);
       // eslint-disable-next-line
-      const rendered = render(component.default({}), options);
+      const rendered = render(component.default.default({}), options);
       const htmlPath = template.replace(
         '.js',
         options.plainText ? '.txt' : '.html',

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -91,10 +91,9 @@ export const exportTemplates = async (
     try {
       spinner.text = `rendering ${template.split('/').pop()}`;
       spinner.render();
-      // eslint-disable-next-line
-      const component = await import(template);
-      // eslint-disable-next-line
-      const rendered = render(component.default.default({}), options);
+      delete require.cache[template];
+      const component = require(template);
+      const rendered = render(component.default({}), options);
       const htmlPath = template.replace(
         '.js',
         options.plainText ? '.txt' : '.html',


### PR DESCRIPTION
## What was the issue?

Errors like the following when running `email export`:

```bash
TypeError: component.default is not a function
    at /Users/app/mailbox/node_modules/.pnpm/react-email@2.0.0_eslint@8.56.0/node_modules/react-email/cli/index.js:778:75
    at step (/Users/app/mailbox/node_modules/.pnpm/react-email@2.0.0_eslint@8.56.0/node_modules/react-email/cli/index.js:186:23)
    at Object.next (/Users/app/mailbox/node_modules/.pnpm/react-email@2.0.0_eslint@8.56.0/node_modules/react-email/cli/index.js:127:20)
    at asyncGeneratorStep (/Users/app/mailbox/node_modules/.pnpm/react-email@2.0.0_eslint@8.56.0/node_modules/react-email/cli/index.js:12:28)
    at _next (/Users/app/mailbox/node_modules/.pnpm/react-email@2.0.0_eslint@8.56.0/node_modules/react-email/cli/index.js:30:17)
```

This was happening because of a `await import` of the esbuild CJS bundled version of the email templates which
had flaky exports because of CJS and ESM incompatibility. The best solution was to use a `require` in the place of a `await import` or a `.default.default` which would be flaky as well.

## How can I test to make sure it's fixed?

1. Run `npx tsx ../../packages/react-email/src/cli/index.ts export` inside of `./apps/demo`
2. Verify that it doesn't error with `TypeError: component.default is not a function`