### PR TITLE
fix(react-email): Windows issue making the CLI's location not be found

### DIFF
--- a/packages/react-email/src/cli/utils/preview/start-dev-server.ts
+++ b/packages/react-email/src/cli/utils/preview/start-dev-server.ts
@@ -160,17 +160,17 @@ const makeExitHandler =
       | { shouldKillProcess: false }
       | { shouldKillProcess: true; killWithErrorCode: boolean },
   ) =>
-    (_codeOrSignal: number | NodeJS.Signals) => {
-      if (typeof devServer !== 'undefined') {
-        console.log('\nshutting down dev server');
-        devServer.close();
-        devServer = undefined;
-      }
+  (_codeOrSignal: number | NodeJS.Signals) => {
+    if (typeof devServer !== 'undefined') {
+      console.log('\nshutting down dev server');
+      devServer.close();
+      devServer = undefined;
+    }
 
-      if (options?.shouldKillProcess) {
-        process.exit(options.killWithErrorCode ? 1 : 0);
-      }
-    };
+    if (options?.shouldKillProcess) {
+      process.exit(options.killWithErrorCode ? 1 : 0);
+    }
+  };
 
 // do something when app is closing
 process.on('exit', makeExitHandler());

--- a/packages/react-email/src/cli/utils/preview/start-dev-server.ts
+++ b/packages/react-email/src/cli/utils/preview/start-dev-server.ts
@@ -26,7 +26,7 @@ const safeAsyncServerListen = (server: http.Server, port: number) => {
   });
 };
 
-export const isRunningBuilt = __filename.endsWith('cli/index.js');
+export const isRunningBuilt = __filename.endsWith(path.join('cli', 'index.js'));
 export const cliPacakgeLocation = isRunningBuilt
   ? path.resolve(__dirname, '..')
   : path.resolve(__dirname, '../../../..');
@@ -160,17 +160,17 @@ const makeExitHandler =
       | { shouldKillProcess: false }
       | { shouldKillProcess: true; killWithErrorCode: boolean },
   ) =>
-  (_codeOrSignal: number | NodeJS.Signals) => {
-    if (typeof devServer !== 'undefined') {
-      console.log('\nshutting down dev server');
-      devServer.close();
-      devServer = undefined;
-    }
+    (_codeOrSignal: number | NodeJS.Signals) => {
+      if (typeof devServer !== 'undefined') {
+        console.log('\nshutting down dev server');
+        devServer.close();
+        devServer = undefined;
+      }
 
-    if (options?.shouldKillProcess) {
-      process.exit(options.killWithErrorCode ? 1 : 0);
-    }
-  };
+      if (options?.shouldKillProcess) {
+        process.exit(options.killWithErrorCode ? 1 : 0);
+      }
+    };
 
 // do something when app is closing
 process.on('exit', makeExitHandler());

--- a/packages/react-email/src/utils/emails-directory-absolute-path.ts
+++ b/packages/react-email/src/utils/emails-directory-absolute-path.ts
@@ -14,15 +14,15 @@ export const pathSeparator = process.env.NEXT_PUBLIC_OS_PATH_SEPARATOR! as
 const normalizePath = (path: string) => {
   let newPath = path;
 
-  while (newPath.startsWith('./')) {
+  while (newPath.startsWith(`.${pathSeparator}`)) {
     newPath = newPath.slice(2);
   }
 
-  while (newPath.startsWith('/')) {
+  while (newPath.startsWith(pathSeparator)) {
     newPath = newPath.slice(1);
   }
 
-  while (newPath.endsWith('/')) {
+  while (newPath.endsWith(pathSeparator)) {
     newPath = newPath.slice(0, -1);
   }
 


### PR DESCRIPTION
Shoutout to @filipewine for reporting this to me

## What is the issue?

@filipewine reported to me an error he was having on Windows similar to the following:

```javascript
> email dev -p 3030

    React Email 2.0.0
    Running preview at:          http://localhost:3030

  ⠙ Getting react-email preview server ready...
Error: > Couldn't find any `pages` or `app` directory. Please create one under the project root
    at findPagesDir (G:\projects\next13-ticketing-app\node_modules\react-email\node_modules\next\dist\lib\find-pages-dir.js:42:15)
    at initialize (G:\projects\next13-ticketing-app\node_modules\react-email\node_modules\next\dist\server\lib\router-server.js:71:69)
    at async NextCustomServer.prepare (G:\projects\next13-ticketing-app\node_modules\react-email\node_modules\next\dist\server\next.js:240:28)

shutting down dev server
```

After some investigation, I found this was caused by a condition to define the directory for where Next would find the preview app, specifically:

https://github.com/resend/react-email/blob/7028a581bac498bec90dce91277e0ec1de8f3221/packages/react-email/src/cli/utils/preview/start-dev-server.ts#L121-L138

Which was defined here:

https://github.com/resend/react-email/blob/7028a581bac498bec90dce91277e0ec1de8f3221/packages/react-email/src/cli/utils/preview/start-dev-server.ts#L28-L33

After this, there was also another small issue similar to this that was causing the following error when opening emails:

![image](https://github.com/resend/react-email/assets/88866334/46c4dfcf-3a9e-4ddb-a5d0-a5b6d8e54c9a)

## How can I test to make sure it's fixed?

1. Run `npx tsx ../../packages/react-email/src/cli/index.ts dev` inside of `./apps/demo` on Windows
2. Open http://localhost:3000/airbnb-review.tsx
3. Verify that the email doesn't error nor that the dev command errors.