### PR TITLE
fix(react-email): Hot reloading not working with custom emails directory

### DIFF
--- a/packages/react-email/src/contexts/emails.tsx
+++ b/packages/react-email/src/contexts/emails.tsx
@@ -6,7 +6,9 @@ import {
 } from '../actions/get-emails-directory-metadata';
 import { useHotreload } from '../hooks/use-hot-reload';
 import {
+  emailsDirRelativePath,
   emailsDirectoryAbsolutePath,
+  normalizePath,
   pathSeparator,
 } from '../utils/emails-directory-absolute-path';
 import {
@@ -16,15 +18,15 @@ import {
 
 const EmailsContext = createContext<
   | {
-      emailsDirectoryMetadata: EmailsDirectory;
-      /**
-       * Uses the hot reloaded bundled build and rendering email result
-       */
-      useEmailRenderingResult: (
-        slug: string,
-        serverEmailRenderedResult: EmailRenderingResult,
-      ) => EmailRenderingResult;
-    }
+    emailsDirectoryMetadata: EmailsDirectory;
+    /**
+     * Uses the hot reloaded bundled build and rendering email result
+     */
+    useEmailRenderingResult: (
+      slug: string,
+      serverEmailRenderedResult: EmailRenderingResult,
+    ) => EmailRenderingResult;
+  }
   | undefined
 >(undefined);
 
@@ -70,11 +72,16 @@ export const EmailsProvider = (props: {
         });
 
       for (const change of changes) {
+        const normalizedEmailsDirRelativePath = normalizePath(
+          emailsDirRelativePath,
+        );
         const slugForChangedEmail =
           // filename ex: emails/apple-receipt.tsx
           // so we need to remove the "emails/" because it isn't used
           // on the slug parameter for the preview page
-          change.filename.split(pathSeparator).slice(1).join('/');
+          change.filename
+            .replace(`${normalizedEmailsDirRelativePath}${pathSeparator}`, '')
+            .replace(normalizedEmailsDirRelativePath, '');
 
         const lastResult = renderingResultPerEmailSlug[slugForChangedEmail];
 

--- a/packages/react-email/src/contexts/emails.tsx
+++ b/packages/react-email/src/contexts/emails.tsx
@@ -18,15 +18,15 @@ import {
 
 const EmailsContext = createContext<
   | {
-    emailsDirectoryMetadata: EmailsDirectory;
-    /**
-     * Uses the hot reloaded bundled build and rendering email result
-     */
-    useEmailRenderingResult: (
-      slug: string,
-      serverEmailRenderedResult: EmailRenderingResult,
-    ) => EmailRenderingResult;
-  }
+      emailsDirectoryMetadata: EmailsDirectory;
+      /**
+       * Uses the hot reloaded bundled build and rendering email result
+       */
+      useEmailRenderingResult: (
+        slug: string,
+        serverEmailRenderedResult: EmailRenderingResult,
+      ) => EmailRenderingResult;
+    }
   | undefined
 >(undefined);
 

--- a/packages/react-email/src/utils/emails-directory-absolute-path.ts
+++ b/packages/react-email/src/utils/emails-directory-absolute-path.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-const emailsDirRelativePath =
+export const emailsDirRelativePath =
   process.env.NEXT_PUBLIC_EMAILS_DIR_RELATIVE_PATH ?? 'emails';
 
 export const userProjectLocation =
@@ -11,7 +11,7 @@ export const pathSeparator = process.env.NEXT_PUBLIC_OS_PATH_SEPARATOR! as
   | '/'
   | '\\';
 
-const normalizePath = (path: string) => {
+export const normalizePath = (path: string) => {
   let newPath = path;
 
   while (newPath.startsWith('./')) {


### PR DESCRIPTION
## What was the issue?

Hot reloading was not working if the custom directory was two folders deep.
This was because of a missing treatment I didn't add to where the changes are detected:

https://github.com/resend/react-email/blob/7028a581bac498bec90dce91277e0ec1de8f3221/packages/react-email/src/contexts/emails.tsx#L72-L83

This split, slice, and join technique would not work for deeper custom directories
then at the CWD where the user is running the `dev` command.

## How can I test to make sure it's fixed?

1. Open the terminal on `./apps/demo`
2. Temporarily move the `./apps/demo/emails` folder into `./app/demo/src/emails`
3. Run `npx tsx ../../packages/react-email/src/cli/index.ts dev -d ./src/emails` inside of `./apps/demo`
4. Open http://localhost:3000
5. Click on any email and make some changes to it
6. Verify that the email updates appropriately with the changes