### PR TITLE
fix(react-email): Missing URL on global context for email VM

### DIFF
--- a/packages/react-email/src/utils/get-email-component.ts
+++ b/packages/react-email/src/utils/get-email-component.ts
@@ -56,6 +56,7 @@ export const getEmailComponent = async (
     ...global,
     console,
     Buffer,
+    URL,
     module: { exports: { default: undefined as unknown } },
     __filanem: emailPath,
     __dirname: path.dirname(emailPath),


### PR DESCRIPTION
## Background

As we need to pre-import the modules from Node into the app before loading them with `vm`
we also need to define the context in which the code will run for us to get the email's component,
this means that we need to pass in a few other global things like `Buffer` that the `global`
dynamically doesn't contain.

## What was the issue?

That being said, something that was missing from the global context was the `URL` class,
which this PR adds. Closes #1229 

## How can I test to make sure it's fixed?

1. Run `npx tsx ../../packages/react-email/src/cli/index.ts dev` inside of `./apps/demo`
2. Modify the email at `./apps/demo/emails/airbnb-review.tsx` by adding the following:
```javascript
console.log(new URL(""));
```
3. Open http://localhost:3000/preview/airbnb-review.tsx
4. Verify that this errors with "Invalid path" instead of with `URL is not defined`