### PR TITLE
fix(code-block): Certain tokens not being rendered

### DIFF
--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-array-index-key */
 import * as React from "react";
 import type { PrismLangauge } from "./languages-available";
 import type { Theme } from "./themes";
@@ -28,9 +29,16 @@ const CodeBlockLine = ({
     } else if (typeof token.content === "string") {
       return <span style={theme[token.type]}>{token.content}</span>;
     }
-  } else if (typeof token === "string") {
-    return token;
+    return (
+      <>
+        {token.content.map((subToken, i) => (
+          <CodeBlockLine key={i} theme={theme} token={subToken} />
+        ))}
+      </>
+    );
   }
+
+  return <>{token}</>;
 };
 
 /**


### PR DESCRIPTION
## What does this fix?

Sometimes with the current version, some tokens would not be rendered
because we were missing treating an edge case where the token
is a stream of other tokens. They would be missing and look something like:

![image](https://github.com/resend/react-email/assets/88866334/3f669007-d395-4722-b1ff-8ec283b3b298)

## How can I verify this works?

1. Run `pnpm build` inside of `./packages/code-block`
2. Add `@react-email/code-block` as a dep of `./apps/demo` as follows:
```json
{
    "dependencies": {
        "@react-email/code-block": "../../packages/code-block"    
    }
}
```
3. Add an `email.tsx` inside of `./apps/demo/emails` with the following content:
```tsx
import { CodeBlock, nightOwl } from '@react-email/code-block';

export default function Email() {
  const code = `export default async (req, res) => {
  try {
    const html = await renderAsync(
      EmailTemplate({ firstName: 'John' })
    );
    return NextResponse.json({ html });
  } catch (error) {
    return NextResponse.json({ error });
  }
}`;

  return (<CodeBlock
    code={code}
    theme={nightOwl}
    language="javascript"
  />);
};
```
4. Run `pnpm dev` inside of `./apps/demo`
5. Open localhost:3000/preview/email.tsx
6. Verify that there is no missing words or characters in the rendered code block.
Some of the parts that had missing characters were:
    - The `renderAsync` identifier before the parenthesis
    - The `EmailTemplate` identifier before the parenthesis
    - The `.json` for `NextResponse`
