### PR TITLE
fix(react-email): Build not working with custom emails directory

### DIFF
--- a/packages/react-email/src/cli/commands/build.ts
+++ b/packages/react-email/src/cli/commands/build.ts
@@ -49,7 +49,11 @@ const setNextEnvironmentVariablesForBuild = async (
   builtPreviewAppPath: string,
 ) => {
   const envVariables = {
-    ...getEnvVariablesForPreviewApp(emailsDirRelativePath, 'PLACEHOLDER', 'PLACEHOLDER'),
+    ...getEnvVariablesForPreviewApp(
+      emailsDirRelativePath,
+      'PLACEHOLDER',
+      'PLACEHOLDER',
+    ),
     NEXT_PUBLIC_IS_BUILDING: 'true',
   };
 
@@ -243,7 +247,10 @@ export const build = async ({
 
     spinner.text =
       'Setting Next environment variables for preview app to work properly';
-    await setNextEnvironmentVariablesForBuild(emailsDirRelativePath, builtPreviewAppPath);
+    await setNextEnvironmentVariablesForBuild(
+      emailsDirRelativePath,
+      builtPreviewAppPath,
+    );
 
     spinner.text = 'Setting server side generation for the email preview pages';
     await forceSSGForEmailPreviews(emailsDirPath, builtPreviewAppPath);

--- a/packages/react-email/src/cli/commands/build.ts
+++ b/packages/react-email/src/cli/commands/build.ts
@@ -45,10 +45,11 @@ const buildPreviewApp = (absoluteDirectory: string) => {
 };
 
 const setNextEnvironmentVariablesForBuild = async (
+  emailsDirRelativePath: string,
   builtPreviewAppPath: string,
 ) => {
   const envVariables = {
-    ...getEnvVariablesForPreviewApp('emails', 'PLACEHOLDER', 'PLACEHOLDER'),
+    ...getEnvVariablesForPreviewApp(emailsDirRelativePath, 'PLACEHOLDER', 'PLACEHOLDER'),
     NEXT_PUBLIC_IS_BUILDING: 'true',
   };
 
@@ -206,7 +207,7 @@ export const build = async ({
     }
 
     const emailsDirPath = path.join(process.cwd(), emailsDirRelativePath);
-    const staticPath = path.join(process.cwd(), 'emails', 'static');
+    const staticPath = path.join(emailsDirPath, 'static');
 
     const builtPreviewAppPath = path.join(process.cwd(), '.react-email');
 
@@ -230,7 +231,7 @@ export const build = async ({
 
     if (fs.existsSync(staticPath)) {
       spinner.text =
-        'Copying `emails/static` folder into `.react-email/public/static`';
+        'Copying `static` folder into `.react-email/public/static`';
       const builtStaticDirectory = path.resolve(
         builtPreviewAppPath,
         './public/static',
@@ -242,7 +243,7 @@ export const build = async ({
 
     spinner.text =
       'Setting Next environment variables for preview app to work properly';
-    await setNextEnvironmentVariablesForBuild(builtPreviewAppPath);
+    await setNextEnvironmentVariablesForBuild(emailsDirRelativePath, builtPreviewAppPath);
 
     spinner.text = 'Setting server side generation for the email preview pages';
     await forceSSGForEmailPreviews(emailsDirPath, builtPreviewAppPath);


### PR DESCRIPTION
## What does this fix?

This would fix the errors that would look like the following:

![image](https://github.com/resend/react-email/assets/88866334/22664823-5405-46bc-9228-e92f86f11c19)

This was being caused by a hard coded environment variable
being passed onto the preview app which came from the earlier
attempt at rendering the emails in a different way instead
of doing SSG. This was fixed by just copying the variable into it.

This also fixes the static folder not being properly copied which 
I noticed was the case here as well because of a hard coded value
too.

## How can I verify this works?

1. Move `./app/demo/emails` into `./app/demo/src/emails`
2. Run `npx tsx ../../packages/react-email/src/cli/index.ts build -d ./src/emails`
3. Verify that it doesn't error as the image shown before
4. Verify that the static files from `./app/demo/src/emails/static` were 
copied into `./app/demo/.react-email/public/static`

