### PR TITLE
fix(create-email): Issues when running `dev` command on `react-email-starter`

### DIFF
--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -12,6 +12,11 @@
   },
   "dependencies": {
     "@react-email/components": "0.0.14",
-    "react-email": "2.0.0"
+    "react-email": "2.0.0",
+    "react": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.33",
+    "@types/react-dom": "18.2.14"
   }
 }

--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -2,9 +2,6 @@
   "name": "emails",
   "version": "0.0.18",
   "private": true,
-  "workspaces": [
-    ".react-email"
-  ],
   "scripts": {
     "build": "email build",
     "dev": "email dev",


### PR DESCRIPTION
## What does this fix?

When running `npx create-email@latest` and then running `npm run dev`
on it there would be issues when rendering any email preview because
of React missing as a dependency.

This is something that has changed from the old preview server as
we now do bundling of the email templates instead of loading them in through
imports which makes it so that the emails `package.json` can go by without `react` 
as a dependency.

## How can I verify this works?

1. Go into `./packages/create-email`
2. Run `node ./src/index.js`
3. Go into `react-email-starter`
4. Run `npm install` or anything else except for `pnpm install`
5. Run `npm run dev`
6. Open http://localhost:3000
7. Open any email and verify it does not error with `ERROR: Could not resolve "react/jsx-runtime"`
