### PR TITLE
fix(code-block): Highlighting not matching usual Prismjs's highlighting

### DIFF
--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -62,7 +62,7 @@ const CodeBlockLine = ({
     );
   }
 
-  return <>{token}</>;
+  return <span style={inheritedStyles}>{token}</span>;
 };
 
 /**

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -12,27 +12,51 @@ export type CodeBlockProps = Readonly<{
   code: string;
 }>;
 
+const stylesForToken = (token: Prism.Token, theme: Theme) => {
+  let styles = { ...theme[token.type] };
+
+  const aliases = Array.isArray(token.alias) ? token.alias : [token.alias];
+
+  for (const alias of aliases) {
+    styles = { ...styles, ...theme[alias] };
+  }
+
+  return styles;
+};
+
 const CodeBlockLine = ({
   token,
   theme,
+  inheritedStyles,
 }: {
   token: string | Prism.Token;
   theme: Theme;
+  inheritedStyles?: React.CSSProperties;
 }) => {
   if (token instanceof Prism.Token) {
+    const styleForToken = {
+      ...inheritedStyles,
+      ...stylesForToken(token, theme),
+    };
+
     if (token.content instanceof Prism.Token) {
       return (
-        <span style={theme[token.type]}>
+        <span style={styleForToken}>
           <CodeBlockLine theme={theme} token={token.content} />
         </span>
       );
     } else if (typeof token.content === "string") {
-      return <span style={theme[token.type]}>{token.content}</span>;
+      return <span style={styleForToken}>{token.content}</span>;
     }
     return (
       <>
         {token.content.map((subToken, i) => (
-          <CodeBlockLine key={i} theme={theme} token={subToken} />
+          <CodeBlockLine
+            inheritedStyles={styleForToken}
+            key={i}
+            theme={theme}
+            token={subToken}
+          />
         ))}
       </>
     );


### PR DESCRIPTION
Styles are not being added to tokens that should be added. This resulted
in the syntax highlighting not matching Prismjs's default. This was fixed by 
moving the styles related to the token type or its aliases down into the token tree.

<table>
  <tr>
    <th>before</th>
    <th>after</th>
  </tr>
  <tr>
    <td>
       <img src="https://github.com/resend/react-email/assets/88866334/4a55ef6c-938f-4d68-a73b-21fef316760d"/>
    </td>
    <td>
      <img src="https://github.com/resend/react-email/assets/88866334/a035bb36-f016-4b0d-9984-01ee3b818359"/>
    </td>
  </tr>
</table>
