### PR TITLE
fix(react-email): email export is not working -- component.default is not a function

### DIFF
--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -62,7 +62,7 @@ export const exportTemplates = async (
       // eslint-disable-next-line
       const component = await import(template);
       // eslint-disable-next-line
-      const rendered = render(component.default({}), options);
+      const rendered = render(component.default.default({}), options);
       const htmlPath = template.replace(
         '.js',
         options.plainText ? '.txt' : '.html',


### PR DESCRIPTION
Email export is not working.

Related Issue: https://github.com/resend/react-email/issues/1245