### PR TITLE
fix(react-email): Hard coded value for location of static files

### DIFF
--- a/packages/react-email/src/cli/commands/dev.ts
+++ b/packages/react-email/src/cli/commands/dev.ts
@@ -14,7 +14,7 @@ export const dev = async ({ dir: emailsDirRelativePath, port }: Args) => {
 
     const devServer = await startDevServer(
       emailsDirRelativePath,
-      emailsDirRelativePath, // defualts to ./emails/static for the static files that are served to the preview
+      emailsDirRelativePath, // defaults to ./emails/static for the static files that are served to the preview
       parseInt(port),
     );
 

--- a/packages/react-email/src/cli/commands/dev.ts
+++ b/packages/react-email/src/cli/commands/dev.ts
@@ -14,7 +14,7 @@ export const dev = async ({ dir: emailsDirRelativePath, port }: Args) => {
 
     const devServer = await startDevServer(
       emailsDirRelativePath,
-      './emails', // defualts to ./emails/static for the static files that are served to the preview
+      emailsDirRelativePath, // defualts to ./emails/static for the static files that are served to the preview
       parseInt(port),
     );
 


### PR DESCRIPTION
## What does this fix?

Static files not loading when using a custom directory due to their location
being hardcoded to `./emails`.

## How can I test to make sure it's fixed?

1. Move `./apps/demo/emails` into `./apps/demo/src/emails`
2. Run `npx tsx ../../packages/react-email/src/cli/index.ts dev -d ./src/emails` inside of `./apps/demo`
3. Open http://localhost:3000/preview/airbnb-review.tsx
4. Verify that the images are loading properly