### PR TITLE
fix(react-email): Preview app failing without node >= 20 for some users

### DIFF
--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@types/fs-extra": "11.0.1",
     "@types/mime-types": "2.1.4",
-    "@types/node": "20.10.4",
+    "@types/node": "18.0.0",
     "@types/normalize-path": "3.0.2",
     "@types/shelljs": "0.8.15",
     "@vercel/style-guide": "5.1.0",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
+    "test": "vitest run",
     "clean": "rm -rf dist",
     "lint": "eslint . && tsc"
   },

--- a/packages/react-email/src/actions/get-emails-directory-metadata.spec.ts
+++ b/packages/react-email/src/actions/get-emails-directory-metadata.spec.ts
@@ -1,0 +1,38 @@
+import path from 'node:path';
+import { getEmailsDirectoryMetadata } from './get-emails-directory-metadata';
+
+test('getEmailsDirectoryMetadata on demo emails', async () => {
+  expect(
+    await getEmailsDirectoryMetadata(
+      path.resolve(__dirname, '../../../../apps/demo/emails/'),
+    ),
+  ).toEqual({
+    absolutePath:
+      '/home/gabriel/Projects/Work/resend/react-email/apps/demo/emails',
+    directoryName: 'emails',
+    emailFilenames: [
+      'airbnb-review.tsx',
+      'amazon-review.tsx',
+      'apple-receipt.tsx',
+      'aws-verify-email.tsx',
+      'codepen-challengers.tsx',
+      'dropbox-reset-password.tsx',
+      'github-access-token.tsx',
+      'google-play-policy-update.tsx',
+      'koala-welcome.tsx',
+      'linear-login-code.tsx',
+      'netlify-welcome.tsx',
+      'nike-receipt.tsx',
+      'notion-magic-link.tsx',
+      'plaid-verify-identity.tsx',
+      'raycast-magic-link.tsx',
+      'slack-confirm.tsx',
+      'stack-overflow-tips.tsx',
+      'stripe-welcome.tsx',
+      'twitch-reset-password.tsx',
+      'vercel-invite-user.tsx',
+      'yelp-recent-login.tsx',
+    ],
+    subDirectories: [],
+  });
+});

--- a/packages/react-email/src/actions/get-emails-directory-metadata.ts
+++ b/packages/react-email/src/actions/get-emails-directory-metadata.ts
@@ -52,7 +52,7 @@ const mergeDirectoriesWithSubDirectories = (
 };
 
 export const getEmailsDirectoryMetadata = async (
-  absolutePathToEmailsDirectory: string,
+  absolutePathToEmailsDirectory: string
 ): Promise<EmailsDirectory | undefined> => {
   if (!fs.existsSync(absolutePathToEmailsDirectory)) return;
 
@@ -61,7 +61,7 @@ export const getEmailsDirectoryMetadata = async (
   });
 
   const emailFilenames = dirents
-    .filter((dirent) => isFileAnEmail(path.join(dirent.path, dirent.name)))
+    .filter((dirent) => isFileAnEmail(path.join(absolutePathToEmailsDirectory, dirent.name)))
     .map((dirent) => dirent.name);
 
   const subDirectories = await Promise.all(
@@ -75,7 +75,7 @@ export const getEmailsDirectoryMetadata = async (
       .map(
         (dirent) =>
           getEmailsDirectoryMetadata(
-            path.join(dirent.path, dirent.name),
+            path.join(absolutePathToEmailsDirectory, dirent.name),
           ) as Promise<EmailsDirectory>,
       ),
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,8 +745,8 @@ importers:
         specifier: 2.1.4
         version: 2.1.4
       '@types/node':
-        specifier: 20.10.4
-        version: 20.10.4
+        specifier: 18.0.0
+        version: 18.0.0
       '@types/normalize-path':
         specifier: 3.0.2
         version: 3.0.2
@@ -767,7 +767,7 @@ importers:
         version: 4.7.0
       vitest:
         specifier: 1.1.3
-        version: 1.1.3(@types/node@20.10.4)(happy-dom@12.2.2)
+        version: 1.1.3(@types/node@18.0.0)(happy-dom@12.2.2)
       watch:
         specifier: 1.0.2
         version: 1.0.2
@@ -3570,6 +3570,10 @@ packages:
   /@types/minimist@1.2.5:
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
     dev: false
+
+  /@types/node@18.0.0:
+    resolution: {integrity: sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==}
+    dev: true
 
   /@types/node@18.18.0:
     resolution: {integrity: sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw==}
@@ -9892,7 +9896,7 @@ packages:
       - terser
     dev: true
 
-  /vite-node@1.1.3(@types/node@20.10.4):
+  /vite-node@1.1.3(@types/node@18.0.0):
     resolution: {integrity: sha512-BLSO72YAkIUuNrOx+8uznYICJfTEbvBAmWClY3hpath5+h1mbPS5OMn42lrTxXuyCazVyZoDkSRnju78GiVCqA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -9901,7 +9905,7 @@ packages:
       debug: 4.3.4
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 5.0.11(@types/node@20.10.4)
+      vite: 5.0.11(@types/node@18.0.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -10057,6 +10061,42 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /vite@5.0.11(@types/node@18.0.0):
+    resolution: {integrity: sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.0.0
+      esbuild: 0.19.11
+      postcss: 8.4.32
+      rollup: 4.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
   /vite@5.0.11(@types/node@18.18.0):
     resolution: {integrity: sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -10086,42 +10126,6 @@ packages:
         optional: true
     dependencies:
       '@types/node': 18.18.0
-      esbuild: 0.19.11
-      postcss: 8.4.32
-      rollup: 4.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
-  /vite@5.0.11(@types/node@20.10.4):
-    resolution: {integrity: sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 20.10.4
       esbuild: 0.19.11
       postcss: 8.4.32
       rollup: 4.6.0
@@ -10255,7 +10259,7 @@ packages:
       - terser
     dev: true
 
-  /vitest@1.1.3(@types/node@20.10.4)(happy-dom@12.2.2):
+  /vitest@1.1.3(@types/node@18.0.0)(happy-dom@12.2.2):
     resolution: {integrity: sha512-2l8om1NOkiA90/Y207PsEvJLYygddsOyr81wLQ20Ra8IlLKbyQncWsGZjnbkyG2KwwuTXLQjEPOJuxGMG8qJBQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -10280,7 +10284,7 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/node': 20.10.4
+      '@types/node': 18.0.0
       '@vitest/expect': 1.1.3
       '@vitest/runner': 1.1.3
       '@vitest/snapshot': 1.1.3
@@ -10300,8 +10304,8 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.1
       tinypool: 0.8.1
-      vite: 5.0.11(@types/node@20.10.4)
-      vite-node: 1.1.3(@types/node@20.10.4)
+      vite: 5.0.11(@types/node@18.0.0)
+      vite-node: 1.1.3(@types/node@18.0.0)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
## What does this fix?

Closes #1235.

For a few users, there was throwing an error like the following once they ran `email dev`:

```javascript
Error: The "path" argument must be of type string. Received undefined
```

Which would come pointing to the following code:

https://github.com/resend/react-email/blob/7028a581bac498bec90dce91277e0ec1de8f3221/packages/react-email/src/actions/get-emails-directory-metadata.ts#L67-L71

This was due to us using `dirent.path` which was only introduced on **Node 20** as pointed out 
by @connorwinston on https://github.com/resend/react-email/issues/1235#issuecomment-1911263774.

## How can I make sure this is fixed?

Use something like `Node 19.8.1` and then:

1. Run `npx tsx ../../packages/react-email/src/cli/index.ts dev` inside of `./apps/demo`
2. Open http://localhost:3000/preview/airbnb-review.tsx
3. Verify that there is no thrown error about `dirent.path` being `undefined`.

I've also made a unit test that runs the function with the issue
on our `demo` directory to ensure it returns the proper value always.
