### PR TITLE
feat(react-email): Improved error stack traces for preview server

### DIFF
--- a/packages/react-email/src/utils/get-email-component.ts
+++ b/packages/react-email/src/utils/get-email-component.ts
@@ -85,6 +85,11 @@ export const getEmailComponent = async (
     process,
   };
   const sourceMapToEmail = JSON.parse(sourceMapFile.text) as RawSourceMap;
+  // because it will have a path like <tsconfigLocation>/stdout/email.js.map
+  sourceMapToEmail.sourceRoot = path.resolve(sourceMapFile.path, '../..');
+  sourceMapToEmail.sources = sourceMapToEmail.sources.map((source) =>
+    path.resolve(sourceMapFile.path, '..', source),
+  );
   try {
     vm.runInNewContext(builtEmailCode, fakeContext, { filename: emailPath });
   } catch (exception) {

--- a/packages/react-email/src/utils/get-email-component.ts
+++ b/packages/react-email/src/utils/get-email-component.ts
@@ -90,6 +90,8 @@ export const getEmailComponent = async (
   } catch (exception) {
     const error = exception as Error;
 
+    error.stack &&= error.stack.split('at Script.runInContext (node:vm')[0];
+
     return {
       error: improveErrorWithSourceMap(error, emailPath, sourceMapToEmail),
     };

--- a/packages/react-email/src/utils/improve-error-with-sourcemap.ts
+++ b/packages/react-email/src/utils/improve-error-with-sourcemap.ts
@@ -11,7 +11,8 @@ export const improveErrorWithSourceMap = (
 ): ErrorObject => {
   let stack: string | undefined;
 
-  const sourceRoot = sourceMapToOriginalFile.sourceRoot ?? path.dirname(originalFilePath);
+  const sourceRoot =
+    sourceMapToOriginalFile.sourceRoot ?? path.dirname(originalFilePath);
 
   const getStackLineFromMethodNameAndSource = (
     methodName: string,
@@ -26,15 +27,14 @@ export const improveErrorWithSourceMap = (
     const sourceToDisplay = path.relative(sourceRoot, source);
     return methodName === '<unknown>'
       ? ` at ${sourceToDisplay}${columnAndLine ? `:${columnAndLine}` : ''}`
-      : ` at ${methodName} (${sourceToDisplay}${columnAndLine ? `:${columnAndLine}` : ''
-      })`;
+      : ` at ${methodName} (${sourceToDisplay}${
+          columnAndLine ? `:${columnAndLine}` : ''
+        })`;
   };
 
   if (typeof error.stack !== 'undefined') {
     const parsedStack = stackTraceParser.parse(error.stack);
-    const sourceMapConsumer = new SourceMapConsumer(
-      sourceMapToOriginalFile,
-    );
+    const sourceMapConsumer = new SourceMapConsumer(sourceMapToOriginalFile);
     const newStackLines = [] as string[];
     for (const stackFrame of parsedStack) {
       if (stackFrame.file === originalFilePath) {

--- a/packages/react-email/src/utils/improve-error-with-sourcemap.ts
+++ b/packages/react-email/src/utils/improve-error-with-sourcemap.ts
@@ -23,9 +23,10 @@ export const improveErrorWithSourceMap = (
       column || line
         ? `${line ?? ''}${line && column ? ':' : ''}${column ?? ''}`
         : undefined;
+    const sourceToDisplay = path.relative(sourceRoot, source);
     return methodName === '<unknown>'
-      ? ` at ${path.relative(sourceRoot, source)}${columnAndLine ? `:${columnAndLine}` : ''}`
-      : ` at ${methodName} (${source}${columnAndLine ? `:${columnAndLine}` : ''
+      ? ` at ${sourceToDisplay}${columnAndLine ? `:${columnAndLine}` : ''}`
+      : ` at ${methodName} (${sourceToDisplay}${columnAndLine ? `:${columnAndLine}` : ''
       })`;
   };
 


### PR DESCRIPTION
## Why?

Before the source map resolving was very archaic, this PR does a few adjustments to this improving
on how it resolves them, now based on all the sources of the source map, and on how it shows
the locations inside of the trace.

This also removes the useless part of the trace that was pointing inside of the `vm` node module
when the error happenned by trying to get the email's component.

|     Before     |     After      |
|----------------|----------------|
| ![image](https://github.com/resend/react-email/assets/88866334/59387576-ff31-4ede-b9e2-8ef918cbf04a)| ![image](https://github.com/resend/react-email/assets/88866334/c82ff160-699d-4f06-bf56-bda8ee1cab04) |

## How can I make sure this is working?

1. Change any email inside of `./apps/demo` to have errors
2. Run `tsx ../../packages/react-email/src/cli/index.ts dev` inside of `./apps/demo`
3. Verify that the stack trace is much more useful and more detailed than before

