### PR TITLE
fix(react-email): `email export` failing due to non-cjs file extension

### DIFF
--- a/packages/code-block/src/prism.ts
+++ b/packages/code-block/src/prism.ts
@@ -7876,8 +7876,8 @@ export { Prism };
       return "string" == typeof e
         ? e
         : Array.isArray(e)
-          ? e.map(d).join("")
-          : d(e.content);
+        ? e.map(d).join("")
+        : d(e.content);
     }
     g.hooks.add("after-tokenize", function (e) {
       e.language in a &&
@@ -10194,8 +10194,8 @@ export { Prism };
       return "string" == typeof e
         ? e
         : Array.isArray(e)
-          ? e.map(a).join("")
-          : a(e.content);
+        ? e.map(a).join("")
+        : a(e.content);
     }
     (e.languages.naniscript = {
       comment: { pattern: /^([\t ]*);.*/m, lookbehind: !0 },
@@ -12582,13 +12582,13 @@ export { Prism };
               : "/>" !== a.content[a.content.length - 1].content &&
                 t.push({ tagName: s(a.content[0].content[1]), openedBraces: 0 })
             : 0 < t.length && "punctuation" === a.type && "{" === a.content
-              ? t[t.length - 1].openedBraces++
-              : 0 < t.length &&
-                  0 < t[t.length - 1].openedBraces &&
-                  "punctuation" === a.type &&
-                  "}" === a.content
-                ? t[t.length - 1].openedBraces--
-                : (r = !0)),
+            ? t[t.length - 1].openedBraces++
+            : 0 < t.length &&
+              0 < t[t.length - 1].openedBraces &&
+              "punctuation" === a.type &&
+              "}" === a.content
+            ? t[t.length - 1].openedBraces--
+            : (r = !0)),
           (r || "string" == typeof a) &&
             0 < t.length &&
             0 === t[t.length - 1].openedBraces &&
@@ -12608,8 +12608,8 @@ export { Prism };
         ? "string" == typeof e
           ? e
           : "string" == typeof e.content
-            ? e.content
-            : e.content.map(s).join("")
+          ? e.content
+          : e.content.map(s).join("")
         : "";
     };
     i.hooks.add("after-tokenize", function (e) {
@@ -15477,23 +15477,23 @@ export { Prism };
               : "/>" !== a.content[a.content.length - 1].content &&
                 t.push({ tagName: s(a.content[0].content[1]), openedBraces: 0 })
             : !(
-                  0 < t.length &&
-                  "punctuation" === a.type &&
-                  "{" === a.content
-                ) ||
-                (e[n + 1] &&
-                  "punctuation" === e[n + 1].type &&
-                  "{" === e[n + 1].content) ||
-                (e[n - 1] &&
-                  "plain-text" === e[n - 1].type &&
-                  "{" === e[n - 1].content)
-              ? 0 < t.length &&
-                0 < t[t.length - 1].openedBraces &&
+                0 < t.length &&
                 "punctuation" === a.type &&
-                "}" === a.content
-                ? t[t.length - 1].openedBraces--
-                : "comment" !== a.type && (r = !0)
-              : t[t.length - 1].openedBraces++),
+                "{" === a.content
+              ) ||
+              (e[n + 1] &&
+                "punctuation" === e[n + 1].type &&
+                "{" === e[n + 1].content) ||
+              (e[n - 1] &&
+                "plain-text" === e[n - 1].type &&
+                "{" === e[n - 1].content)
+            ? 0 < t.length &&
+              0 < t[t.length - 1].openedBraces &&
+              "punctuation" === a.type &&
+              "}" === a.content
+              ? t[t.length - 1].openedBraces--
+              : "comment" !== a.type && (r = !0)
+            : t[t.length - 1].openedBraces++),
           (r || "string" == typeof a) &&
             0 < t.length &&
             0 === t[t.length - 1].openedBraces &&
@@ -15514,8 +15514,8 @@ export { Prism };
       return "string" == typeof e
         ? e
         : "string" == typeof e.content
-          ? e.content
-          : e.content.map(s).join("");
+        ? e.content
+        : e.content.map(s).join("");
     };
     i.hooks.add("after-tokenize", function (e) {
       "xquery" === e.language && o(e.tokens);

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -59,6 +59,7 @@ export const exportTemplates = async (
     entryPoints: allTemplates,
     platform: 'node',
     format: 'cjs',
+    outExtension: { '.js': '.cjs' },
     jsx: 'transform',
     write: true,
     outdir: pathToWhereEmailMarkupShouldBeDumped,
@@ -81,7 +82,7 @@ export const exportTemplates = async (
   spinner.succeed();
 
   const allBuiltTemplates = glob.sync(
-    normalize(`${pathToWhereEmailMarkupShouldBeDumped}/*.js`),
+    normalize(`${pathToWhereEmailMarkupShouldBeDumped}/*.cjs`),
     {
       absolute: true,
     },
@@ -95,7 +96,7 @@ export const exportTemplates = async (
       const component = require(template);
       const rendered = render(component.default({}), options);
       const htmlPath = template.replace(
-        '.js',
+        '.cjs',
         options.plainText ? '.txt' : '.html',
       );
       writeFileSync(htmlPath, rendered);

--- a/packages/react-email/src/cli/utils/preview/start-dev-server.ts
+++ b/packages/react-email/src/cli/utils/preview/start-dev-server.ts
@@ -60,8 +60,8 @@ export const startDevServer = async (
       ) {
         void serveStaticFile(res, parsedUrl, staticBaseDirRelativePath);
       } else if (!isNextReady) {
-        void nextReadyPromise.then(() =>
-          nextHandleRequest?.(req, res, parsedUrl),
+        void nextReadyPromise.then(
+          () => nextHandleRequest?.(req, res, parsedUrl),
         );
       } else {
         void nextHandleRequest?.(req, res, parsedUrl);


### PR DESCRIPTION
## What does this fix?

This fixes an issue that would happen once the `package.json`'s `type` was set to "module"
and the user ran `email export`. The error looked something like the following:

```javascript
failed when rendering email.jsx
ReferenceError: module is not defined in ES module scope
This file is being treated as an ES module because it has a '.js' file extension and 'projectpath/package.json' 
contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
```

This fixes that by setting the outExtension for esbuild to be `.cjs` and adjusting
the following pieces of code that dependend on it being `.js`.

## How can I make sure its fixed?

1. Add `"type": "module"` inside of `./apps/demo/package.json`
2. Run `tsx ../../packages/react-email/src/cli/index.ts export` inside of `./apps/demo/package.json`
3. Verify that it doesn't error with the same thing
    - As a side note, it might error with something else related to #1245

