### PR TITLE
fix(react-email): `email export` with sub directories and duplication of static files inside of `out/`

### DIFF
--- a/packages/code-block/src/prism.ts
+++ b/packages/code-block/src/prism.ts
@@ -7876,8 +7876,8 @@ export { Prism };
       return "string" == typeof e
         ? e
         : Array.isArray(e)
-        ? e.map(d).join("")
-        : d(e.content);
+          ? e.map(d).join("")
+          : d(e.content);
     }
     g.hooks.add("after-tokenize", function (e) {
       e.language in a &&
@@ -10194,8 +10194,8 @@ export { Prism };
       return "string" == typeof e
         ? e
         : Array.isArray(e)
-        ? e.map(a).join("")
-        : a(e.content);
+          ? e.map(a).join("")
+          : a(e.content);
     }
     (e.languages.naniscript = {
       comment: { pattern: /^([\t ]*);.*/m, lookbehind: !0 },
@@ -12582,13 +12582,13 @@ export { Prism };
               : "/>" !== a.content[a.content.length - 1].content &&
                 t.push({ tagName: s(a.content[0].content[1]), openedBraces: 0 })
             : 0 < t.length && "punctuation" === a.type && "{" === a.content
-            ? t[t.length - 1].openedBraces++
-            : 0 < t.length &&
-              0 < t[t.length - 1].openedBraces &&
-              "punctuation" === a.type &&
-              "}" === a.content
-            ? t[t.length - 1].openedBraces--
-            : (r = !0)),
+              ? t[t.length - 1].openedBraces++
+              : 0 < t.length &&
+                  0 < t[t.length - 1].openedBraces &&
+                  "punctuation" === a.type &&
+                  "}" === a.content
+                ? t[t.length - 1].openedBraces--
+                : (r = !0)),
           (r || "string" == typeof a) &&
             0 < t.length &&
             0 === t[t.length - 1].openedBraces &&
@@ -12608,8 +12608,8 @@ export { Prism };
         ? "string" == typeof e
           ? e
           : "string" == typeof e.content
-          ? e.content
-          : e.content.map(s).join("")
+            ? e.content
+            : e.content.map(s).join("")
         : "";
     };
     i.hooks.add("after-tokenize", function (e) {
@@ -15477,23 +15477,23 @@ export { Prism };
               : "/>" !== a.content[a.content.length - 1].content &&
                 t.push({ tagName: s(a.content[0].content[1]), openedBraces: 0 })
             : !(
-                0 < t.length &&
+                  0 < t.length &&
+                  "punctuation" === a.type &&
+                  "{" === a.content
+                ) ||
+                (e[n + 1] &&
+                  "punctuation" === e[n + 1].type &&
+                  "{" === e[n + 1].content) ||
+                (e[n - 1] &&
+                  "plain-text" === e[n - 1].type &&
+                  "{" === e[n - 1].content)
+              ? 0 < t.length &&
+                0 < t[t.length - 1].openedBraces &&
                 "punctuation" === a.type &&
-                "{" === a.content
-              ) ||
-              (e[n + 1] &&
-                "punctuation" === e[n + 1].type &&
-                "{" === e[n + 1].content) ||
-              (e[n - 1] &&
-                "plain-text" === e[n - 1].type &&
-                "{" === e[n - 1].content)
-            ? 0 < t.length &&
-              0 < t[t.length - 1].openedBraces &&
-              "punctuation" === a.type &&
-              "}" === a.content
-              ? t[t.length - 1].openedBraces--
-              : "comment" !== a.type && (r = !0)
-            : t[t.length - 1].openedBraces++),
+                "}" === a.content
+                ? t[t.length - 1].openedBraces--
+                : "comment" !== a.type && (r = !0)
+              : t[t.length - 1].openedBraces++),
           (r || "string" == typeof a) &&
             0 < t.length &&
             0 === t[t.length - 1].openedBraces &&
@@ -15514,8 +15514,8 @@ export { Prism };
       return "string" == typeof e
         ? e
         : "string" == typeof e.content
-        ? e.content
-        : e.content.map(s).join("");
+          ? e.content
+          : e.content.map(s).join("");
     };
     i.hooks.add("after-tokenize", function (e) {
       "xquery" === e.language && o(e.tokens);

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -10,20 +10,49 @@ import normalize from 'normalize-path';
 import { cp } from 'shelljs';
 import { closeOraOnSIGNIT } from '../utils/close-ora-on-sigint';
 import { tree } from '../utils';
+import {
+  EmailsDirectory,
+  getEmailsDirectoryMetadata,
+} from '../../actions/get-emails-directory-metadata';
+
+const getEmailTemplatesFromDirectory = (emailDirectory: EmailsDirectory) => {
+  const templatePaths = [] as string[];
+  emailDirectory.emailFilenames.forEach((filename) =>
+    templatePaths.push(path.join(emailDirectory.absolutePath, filename)),
+  );
+  emailDirectory.subDirectories.forEach((directory) => {
+    templatePaths.push(...getEmailTemplatesFromDirectory(directory));
+  });
+
+  return templatePaths;
+};
+
 /*
   This first builds all the templates using esbuild and then puts the output in the `.js`
   files. Then these `.js` files are imported dynamically and rendered to `.html` files
   using the `render` function.
  */
 export const exportTemplates = async (
-  outDir: string,
-  srcDir: string,
+  pathToWhereEmailMarkupShouldBeDumped: string,
+  emailsDirectoryPath: string,
   options: Options,
 ) => {
   const spinner = ora('Preparing files...\n').start();
   closeOraOnSIGNIT(spinner);
 
-  const allTemplates = glob.sync(normalize(path.join(srcDir, '*.{tsx,jsx}')));
+  const emailsDirectoryMetadata = await getEmailsDirectoryMetadata(
+    path.join(process.cwd(), emailsDirectoryPath),
+  );
+
+  if (typeof emailsDirectoryMetadata === 'undefined') {
+    spinner.stopAndPersist({
+      symbol: logSymbols.error,
+      text: `Could not find the directory at ${emailsDirectoryPath}`,
+    });
+    return;
+  }
+
+  const allTemplates = getEmailTemplatesFromDirectory(emailsDirectoryMetadata);
 
   const buildResult = buildSync({
     bundle: true,
@@ -32,7 +61,7 @@ export const exportTemplates = async (
     format: 'cjs',
     jsx: 'transform',
     write: true,
-    outdir: outDir,
+    outdir: pathToWhereEmailMarkupShouldBeDumped,
   });
   if (buildResult.warnings.length > 0) {
     console.warn(buildResult.warnings);
@@ -51,9 +80,12 @@ export const exportTemplates = async (
   }
   spinner.succeed();
 
-  const allBuiltTemplates = glob.sync(normalize(`${outDir}/*.js`), {
-    absolute: true,
-  });
+  const allBuiltTemplates = glob.sync(
+    normalize(`${pathToWhereEmailMarkupShouldBeDumped}/*.js`),
+    {
+      absolute: true,
+    },
+  );
 
   for (const template of allBuiltTemplates) {
     try {
@@ -82,24 +114,33 @@ export const exportTemplates = async (
   spinner.text = `Copying static files`;
   spinner.render();
 
-  const staticDir = path.join(srcDir, 'static');
-  const hasStaticDirectory = fs.existsSync(staticDir);
+  // ex: emails/static
+  const staticDirectoryPath = path.join(emailsDirectoryPath, 'static');
 
-  if (hasStaticDirectory) {
-    const result = cp('-r', staticDir, path.join(outDir, 'static'));
+  if (fs.existsSync(staticDirectoryPath)) {
+    const pathToDumpStaticFilesInto = path.join(pathToWhereEmailMarkupShouldBeDumped, 'static');
+    // cp('-r', ...) will copy *inside* of the static directory if it exists
+    // causing a duplication of static files, so we need to delete ir first
+    if (fs.existsSync(pathToDumpStaticFilesInto)) await fs.promises.rm(pathToDumpStaticFilesInto, { recursive: true });
+
+    const result = cp(
+      '-r',
+      staticDirectoryPath,
+      path.join(pathToWhereEmailMarkupShouldBeDumped, 'static'),
+    );
     if (result.code > 0) {
       spinner.stopAndPersist({
         symbol: logSymbols.error,
         text: 'Failed to copy static files',
       });
       throw new Error(
-        `Something went wrong while copying the file to ${outDir}/static, ${result.cat()}`,
+        `Something went wrong while copying the file to ${pathToWhereEmailMarkupShouldBeDumped}/static, ${result.stderr}`,
       );
     }
   }
   spinner.succeed();
 
-  const fileTree = await tree(outDir, 4);
+  const fileTree = await tree(pathToWhereEmailMarkupShouldBeDumped, 4);
 
   console.log(fileTree);
 

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -118,10 +118,14 @@ export const exportTemplates = async (
   const staticDirectoryPath = path.join(emailsDirectoryPath, 'static');
 
   if (fs.existsSync(staticDirectoryPath)) {
-    const pathToDumpStaticFilesInto = path.join(pathToWhereEmailMarkupShouldBeDumped, 'static');
+    const pathToDumpStaticFilesInto = path.join(
+      pathToWhereEmailMarkupShouldBeDumped,
+      'static',
+    );
     // cp('-r', ...) will copy *inside* of the static directory if it exists
     // causing a duplication of static files, so we need to delete ir first
-    if (fs.existsSync(pathToDumpStaticFilesInto)) await fs.promises.rm(pathToDumpStaticFilesInto, { recursive: true });
+    if (fs.existsSync(pathToDumpStaticFilesInto))
+      await fs.promises.rm(pathToDumpStaticFilesInto, { recursive: true });
 
     const result = cp(
       '-r',

--- a/packages/react-email/src/cli/utils/preview/start-dev-server.ts
+++ b/packages/react-email/src/cli/utils/preview/start-dev-server.ts
@@ -60,8 +60,8 @@ export const startDevServer = async (
       ) {
         void serveStaticFile(res, parsedUrl, staticBaseDirRelativePath);
       } else if (!isNextReady) {
-        void nextReadyPromise.then(
-          () => nextHandleRequest?.(req, res, parsedUrl),
+        void nextReadyPromise.then(() =>
+          nextHandleRequest?.(req, res, parsedUrl),
         );
       } else {
         void nextHandleRequest?.(req, res, parsedUrl);


### PR DESCRIPTION
## What does this fix?

It fixes two things. First it fixes that the sub directories were not taken into account
by the `email export` command which gave a discrepancy between it and `email dev`'s behavior.

Secondly, it fixes the duplication of `./out/static` directories like the following:

```javascript
out
└── static
   ├── notion-logo.png
   ├── plaid-logo.png
   ├── plaid.png
   ├── static
   |   ├── notion-logo.png
   |   ├── plaid-logo.png
   |   ├── plaid.png
   |   ├── stripe-logo.png
   |   ├── vercel-arrow.png
   |   ├── vercel-logo.png
   |   ├── vercel-team.png
   |   └── vercel-user.png
   ├── stripe-logo.png
   ├── vercel-arrow.png
   ├── vercel-logo.png
   ├── vercel-team.png
   └── vercel-user.png
```

## How can I make sure this is fixed?

1. Apply the same change as #1214 because without it `email export` will error
2. Create the directory `./apps/demo/emails/magic-links`
3. Move some emails into the new directory
4. Run `npx tsx ../../packages/react-email/src/cli/index.ts export` inside of `./apps/demo/emails/magic-link`
5. Verify that the `./apps/demo/out/magic-links` does exist with the expected emails inside of it
6. Run the same command again
7. Verify that there is no duplicated `static` directories

