### PR TITLE
feat(docs): More info on the `email dev` command

### DIFF
--- a/apps/docs/cli.mdx
+++ b/apps/docs/cli.mdx
@@ -22,7 +22,7 @@ This does adjust to your `--dir` option, so if your `emails` directory was insid
 of `./src/emails`, you would place your static files inside of `./src/emails/static`.
 
 These static files are directly served from our preview server by looking into the
-requests made into that end with `/static` and serving the files at that point,
+requests made into that end with `/static` (i.e. `http://localhost:3000/static/...`) and serving the files at that point,
 this also allows for you to have images inside of your emails like so:
 
 ```jsx
@@ -34,6 +34,31 @@ export default Email(props) {
   )
 }
 ```
+
+<Info>
+  This does not mean your images are hosted for you to send the emails,
+  if you do send your email here and you are using a image or similar inside of `emails/static`
+  they will not load properly on the email.
+</Info>
+
+Of curse, more often than not you will need to host your images on a CDN, so we recommend
+you change the `src` to the CDN's base url based on the environment like:
+
+```jsx
+const baseURL = process.env.NODE_ENV === 'production' 
+  ? 'https://cdn.com' 
+  : ''
+
+export default Email(props) {
+  return (
+    <div>
+      <img src={`${baseURL}/static/email-logo.png`} />
+    </div>
+  )
+}
+```
+
+You can refer to our [demo emails source code](https://demo.react.email/preview/vercel-invite-user.tsx?view=source) for an example of how we do this.
 
 ### How to make the preview server ignore directories
 

--- a/apps/docs/cli.mdx
+++ b/apps/docs/cli.mdx
@@ -10,7 +10,63 @@ icon: 'square-terminal'
 
 Starts a local development server that will watch your files and automatically rebuild your email when you make changes.
 
-**Options**
+### Where can I place my static files for previewing
+
+Almost always you will need to have static files in your emails, and seeing
+them on the preview server without having to first host on a CDN is very helpful.
+
+We do allow for this, and currently, you can place your files inside of a `static` 
+directory inside of your `emails` directory. 
+
+This does adjust to your `--dir` option, so if your `emails` directory was inside
+of `./src/emails`, you would place your static files inside of `./src/emails/static`.
+
+These static files are directly served from our preview server by looking into the
+requests made into that end with `/static` and serving the files at that point,
+this also allows for you to have images inside of your emails like so:
+
+```jsx
+export default Email(props) {
+  return (
+    <div>
+      <img src="/static/email-logo.png" />
+    </div>
+  )
+}
+```
+
+### How to make the preview server ignore directories
+
+Once the preview server has started and is now open on `localhost`, the preview server
+reads recursively down into all of your files and directories. This can be disabled
+from a directory down by prefixing it with `_`, e.g. `components -> _components`. So if you wanted
+to make components for your emails, you could make a structure as follows:
+
+```bash
+my-project
+├── emails
+│   ├── _components
+│   │   └── this-is-not-going-to-appear-in-the-sidebar.tsx
+│   ├── email.tsx
+│   └── static
+├── package.json
+└── tsconfig.json
+```
+
+### The heuristics for files to be considered emails
+
+To avoid uncanny files appearing in the sidebar of the preview server,
+we account for two heuristics to determine weather or not we should
+include it:
+
+1. If file has `.js, .jsx or .tsx` file extensions
+2. If the file contains a `export default` expression by matching with the regex <br/>
+`/\bexport\s*default\b/gm`
+
+These can certainly fail as they are only heuristics, so if you do find
+any issues with these, feel free to open an [issue](https://github.com/resend/react-email/issues).
+
+### Options
 
 <ResponseField name="--dir" type="string" default="emails">
   Change the directory of your email templates.


### PR DESCRIPTION
This adds currently three sections to the `email dev` portion of the `/cli` page we have on our docs:
- "Where can I place my static files for previewing"
- "How to make the preview server ignore directories"
- "The heuristics for files to be considered emails"

I believe these are very important as more often than not users will ask about these 
and want to know it, and having something on the docs that they can search for and find
is a much better experience than having to wait our response.
