### PR TITLE
fix(react-email): Export not rendering files from sub directories

### DIFF
--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -83,7 +83,7 @@ export const exportTemplates = async (
   spinner.succeed();
 
   const allBuiltTemplates = glob.sync(
-    normalize(`${pathToWhereEmailMarkupShouldBeDumped}/*.cjs`),
+    normalize(`${pathToWhereEmailMarkupShouldBeDumped}/**/*.cjs`),
     {
       absolute: true,
     },

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -59,6 +59,7 @@ export const exportTemplates = async (
     entryPoints: allTemplates,
     platform: 'node',
     format: 'cjs',
+    loader: { '.js': 'jsx' },
     outExtension: { '.js': '.cjs' },
     jsx: 'transform',
     write: true,


### PR DESCRIPTION
## What does this fix?

I made a previous PR #1279 that fixed the subdirectory support for `email export`
but forgot to change a small detail which was causing the emails on sub-directories to not be rendered making 
an `out/` structure that would render the ones at the root but leave the `.cjs` artifacts for the ones at sub
directories.

```bash
out
├── email.html
├── folder
│   └── email.cjs
├── notion-magic-link.html
├── static
└── testing-tw-merge.html
```

This was fixed by just modifying the glob that would look for the `.cjs` artifacts of email templates
built with `esbuild`.

---

The other thing was that the support for `.js` email files on `email export` is just not there. 
Meaning that if you had `.js` files with `jsx` syntax in them `esbuild` would throw errors
saying `jsx` support is not enabled. This is fixed by just setting the loader of `.js` 
to `jsx` itself.

This is important that we take note of, because the `email dev`'s preview server does have support
for these files by using the same technique of loaders as I mentioned above 👆🏻.

## How can I make sure it is fixed?

1. Create the directory `./apps/demo/emails/sub-dir`
2. Move some emails to the inside of `./apps/demo/emails/sub-dir`
3. Add a new email at `./apps/demo/emails/sub-dir/example-plain-javascript-email.js` with the contents
```jsx
export default function Email(props) {
    return <h1>Hello world!</h1>;
}
```
4. Run `npx tsx ../../packages/react-email/src/cli/index.ts export` inside of `./apps/demo`
5. Verify that all the files inside of `./apps/demo/out` are `.html` files
6. Verify that it doesn't error with something like
```bash
✘ [ERROR] The JSX syntax extension is not currently enabled

    emails/folder/folder2/folder3/email.js:4:9:
      4 │   return <Html>
        ╵          ^

  The esbuild loader for this file is currently set to "js" but it must be set to "jsx" to be able
  to parse JSX syntax. You can use "loader: { '.js': 'jsx' }" to do that.
```


