### PR TITLE
chore(react-email, create-email): Bump for .1 canary release

### DIFF
--- a/packages/create-email/package.json
+++ b/packages/create-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-email",
-  "version": "0.0.23-canary.0",
+  "version": "0.0.23-canary.1",
   "description": "The easiest way to get started with React Email",
   "main": "src/index.js",
   "type": "module",

--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emails",
-  "version": "0.0.19-canary.0",
+  "version": "0.0.19-canary.1",
   "private": true,
   "scripts": {
     "build": "email build",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@react-email/components": "0.0.15-canary.1",
-    "react-email": "2.1.0-canary.0",
+    "react-email": "2.1.0-canary.1",
     "react": "18.2.0"
   },
   "devDependencies": {

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-email",
-  "version": "2.1.0-canary.0",
+  "version": "2.1.0-canary.1",
   "description": "A live preview of your emails right in your browser.",
   "bin": {
     "email": "./cli/index.js"


### PR DESCRIPTION
`react-email` -> `2.1.0-canary.1`
`create-email` -> `0.0.23-canary.1`