### PR TITLE
chore: Add forward ref to all relevant components

### DIFF
--- a/packages/body/src/body.tsx
+++ b/packages/body/src/body.tsx
@@ -5,7 +5,7 @@ type RootProps = React.ComponentPropsWithoutRef<"body">;
 
 export type BodyProps = RootProps;
 
-export const Body: React.FC<Readonly<BodyProps>> = React.forwardRef<
+export const Body = React.forwardRef<
   BodyElement,
   Readonly<BodyProps>
 >(({ children, style, ...props }, ref) => {

--- a/packages/body/src/body.tsx
+++ b/packages/body/src/body.tsx
@@ -5,15 +5,14 @@ type RootProps = React.ComponentPropsWithoutRef<"body">;
 
 export type BodyProps = RootProps;
 
-export const Body = React.forwardRef<
-  BodyElement,
-  Readonly<BodyProps>
->(({ children, style, ...props }, ref) => {
-  return (
-    <body {...props} ref={ref} style={style}>
-      {children}
-    </body>
-  );
-});
+export const Body = React.forwardRef<BodyElement, Readonly<BodyProps>>(
+  ({ children, style, ...props }, ref) => {
+    return (
+      <body {...props} ref={ref} style={style}>
+        {children}
+      </body>
+    );
+  },
+);
 
 Body.displayName = "Body";

--- a/packages/body/src/body.tsx
+++ b/packages/body/src/body.tsx
@@ -1,19 +1,19 @@
 import * as React from "react";
 
+type BodyElement = React.ElementRef<"body">;
 type RootProps = React.ComponentPropsWithoutRef<"body">;
 
 export type BodyProps = RootProps;
 
-export const Body: React.FC<Readonly<BodyProps>> = ({
-  children,
-  style,
-  ...props
-}) => {
+export const Body: React.FC<Readonly<BodyProps>> = React.forwardRef<
+  BodyElement,
+  Readonly<BodyProps>
+>(({ children, style, ...props }, ref) => {
   return (
-    <body {...props} style={style}>
+    <body {...props} ref={ref} style={style}>
       {children}
     </body>
   );
-};
+});
 
 Body.displayName = "Body";

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -4,42 +4,41 @@ import { parsePadding, pxToPt } from "./utils";
 type ButtonElement = React.ElementRef<"a">;
 export type ButtonProps = React.ComponentPropsWithoutRef<"a">;
 
-export const Button = React.forwardRef<
-  ButtonElement,
-  Readonly<ButtonProps>
->(({ children, style, target = "_blank", ...props }, ref) => {
-  const { pt, pr, pb, pl } = parsePadding({
-    padding: style?.padding,
-    paddingLeft: style?.paddingLeft,
-    paddingRight: style?.paddingRight,
-    paddingTop: style?.paddingTop,
-    paddingBottom: style?.paddingBottom,
-  });
+export const Button = React.forwardRef<ButtonElement, Readonly<ButtonProps>>(
+  ({ children, style, target = "_blank", ...props }, ref) => {
+    const { pt, pr, pb, pl } = parsePadding({
+      padding: style?.padding,
+      paddingLeft: style?.paddingLeft,
+      paddingRight: style?.paddingRight,
+      paddingTop: style?.paddingTop,
+      paddingBottom: style?.paddingBottom,
+    });
 
-  const y = pt + pb;
-  const textRaise = pxToPt(y);
+    const y = pt + pb;
+    const textRaise = pxToPt(y);
 
-  return (
-    <a
-      {...props}
-      ref={ref}
-      style={buttonStyle({ ...style, pt, pr, pb, pl })}
-      target={target}
-    >
-      <span
-        dangerouslySetInnerHTML={{
-          __html: `<!--[if mso]><i style="letter-spacing: ${pl}px;mso-font-width:-100%;mso-text-raise:${textRaise}" hidden>&nbsp;</i><![endif]-->`,
-        }}
-      />
-      <span style={buttonTextStyle(pb)}>{children}</span>
-      <span
-        dangerouslySetInnerHTML={{
-          __html: `<!--[if mso]><i style="letter-spacing: ${pr}px;mso-font-width:-100%" hidden>&nbsp;</i><![endif]-->`,
-        }}
-      />
-    </a>
-  );
-});
+    return (
+      <a
+        {...props}
+        ref={ref}
+        style={buttonStyle({ ...style, pt, pr, pb, pl })}
+        target={target}
+      >
+        <span
+          dangerouslySetInnerHTML={{
+            __html: `<!--[if mso]><i style="letter-spacing: ${pl}px;mso-font-width:-100%;mso-text-raise:${textRaise}" hidden>&nbsp;</i><![endif]-->`,
+          }}
+        />
+        <span style={buttonTextStyle(pb)}>{children}</span>
+        <span
+          dangerouslySetInnerHTML={{
+            __html: `<!--[if mso]><i style="letter-spacing: ${pr}px;mso-font-width:-100%" hidden>&nbsp;</i><![endif]-->`,
+          }}
+        />
+      </a>
+    );
+  },
+);
 
 Button.displayName = "Button";
 

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -4,7 +4,7 @@ import { parsePadding, pxToPt } from "./utils";
 type ButtonElement = React.ElementRef<"a">;
 export type ButtonProps = React.ComponentPropsWithoutRef<"a">;
 
-export const Button: React.FC<Readonly<ButtonProps>> = React.forwardRef<
+export const Button = React.forwardRef<
   ButtonElement,
   Readonly<ButtonProps>
 >(({ children, style, target = "_blank", ...props }, ref) => {

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -1,14 +1,13 @@
 import * as React from "react";
 import { parsePadding, pxToPt } from "./utils";
 
+type ButtonElement = React.ElementRef<"a">;
 export type ButtonProps = React.ComponentPropsWithoutRef<"a">;
 
-export const Button: React.FC<Readonly<ButtonProps>> = ({
-  children,
-  style,
-  target = "_blank",
-  ...props
-}) => {
+export const Button: React.FC<Readonly<ButtonProps>> = React.forwardRef<
+  ButtonElement,
+  Readonly<ButtonProps>
+>(({ children, style, target = "_blank", ...props }, ref) => {
   const { pt, pr, pb, pl } = parsePadding({
     padding: style?.padding,
     paddingLeft: style?.paddingLeft,
@@ -23,6 +22,7 @@ export const Button: React.FC<Readonly<ButtonProps>> = ({
   return (
     <a
       {...props}
+      ref={ref}
       style={buttonStyle({ ...style, pt, pr, pb, pl })}
       target={target}
     >
@@ -39,7 +39,9 @@ export const Button: React.FC<Readonly<ButtonProps>> = ({
       />
     </a>
   );
-};
+});
+
+Button.displayName = "Button";
 
 const buttonStyle = (
   style?: React.CSSProperties & {

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -68,7 +68,7 @@ const CodeBlockLine = ({
 /**
  * A component to show code using prismjs.
  */
-export const CodeBlock: React.FC<CodeBlockProps> = React.forwardRef<
+export const CodeBlock = React.forwardRef<
   React.ElementRef<"pre">,
   CodeBlockProps
 >((props, ref) => {

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -68,7 +68,10 @@ const CodeBlockLine = ({
 /**
  * A component to show code using prismjs.
  */
-export const CodeBlock: React.FC<CodeBlockProps> = (props) => {
+export const CodeBlock: React.FC<CodeBlockProps> = React.forwardRef<
+  React.ElementRef<"pre">,
+  CodeBlockProps
+>((props, ref) => {
   const languageGrammar = Prism.languages[props.language];
   if (typeof languageGrammar === "undefined")
     throw new Error(
@@ -81,7 +84,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = (props) => {
   );
 
   return (
-    <pre style={{ ...props.theme.base, ...props.style }}>
+    <pre ref={ref} style={{ ...props.theme.base, ...props.style }}>
       <code>
         {tokensPerLine.map((tokensForLine, lineIndex) => (
           <p key={lineIndex}>
@@ -102,4 +105,6 @@ export const CodeBlock: React.FC<CodeBlockProps> = (props) => {
       </code>
     </pre>
   );
-};
+});
+
+CodeBlock.displayName = "CodeBlock";

--- a/packages/code-inline/src/code-inline.tsx
+++ b/packages/code-inline/src/code-inline.tsx
@@ -1,16 +1,19 @@
+import React from "react";
+
 type RootProps = React.ComponentPropsWithoutRef<"code"> &
   React.ComponentPropsWithoutRef<"span">;
 
+type SpanElement = React.ElementRef<"span">;
 export type CodeInlineProps = RootProps;
 
 /**
  * If you are sending emails for users that have the Orange.fr email client,
  * beware that this component will only work when you have a head containing meta tags.
  */
-export const CodeInline: React.FC<Readonly<CodeInlineProps>> = ({
-  children,
-  ...props
-}) => {
+export const CodeInline: React.FC<Readonly<CodeInlineProps>> = React.forwardRef<
+  SpanElement,
+  Readonly<CodeInlineProps>
+>(({ children, ...props }, ref) => {
   return (
     <>
       {/* 
@@ -45,10 +48,13 @@ export const CodeInline: React.FC<Readonly<CodeInlineProps>> = ({
       <span
         {...props}
         className={`${props.className ? props.className : ""} cio`}
+        ref={ref}
         style={{ display: "none", ...props.style }}
       >
         {children}
       </span>
     </>
   );
-};
+});
+
+CodeInline.displayName = "CodeInline";

--- a/packages/code-inline/src/code-inline.tsx
+++ b/packages/code-inline/src/code-inline.tsx
@@ -10,7 +10,7 @@ export type CodeInlineProps = RootProps;
  * If you are sending emails for users that have the Orange.fr email client,
  * beware that this component will only work when you have a head containing meta tags.
  */
-export const CodeInline: React.FC<Readonly<CodeInlineProps>> = React.forwardRef<
+export const CodeInline = React.forwardRef<
   SpanElement,
   Readonly<CodeInlineProps>
 >(({ children, ...props }, ref) => {

--- a/packages/column/src/column.tsx
+++ b/packages/column/src/column.tsx
@@ -5,7 +5,7 @@ type TdElement = React.ElementRef<"td">;
 
 export type ColumnProps = RootProps;
 
-export const Column: React.FC<Readonly<ColumnProps>> = React.forwardRef<
+export const Column = React.forwardRef<
   TdElement,
   Readonly<ColumnProps>
 >(({ children, style, ...props }, ref) => {

--- a/packages/column/src/column.tsx
+++ b/packages/column/src/column.tsx
@@ -5,15 +5,14 @@ type TdElement = React.ElementRef<"td">;
 
 export type ColumnProps = RootProps;
 
-export const Column = React.forwardRef<
-  TdElement,
-  Readonly<ColumnProps>
->(({ children, style, ...props }, ref) => {
-  return (
-    <td {...props} data-id="__react-email-column" ref={ref} style={style}>
-      {children}
-    </td>
-  );
-});
+export const Column = React.forwardRef<TdElement, Readonly<ColumnProps>>(
+  ({ children, style, ...props }, ref) => {
+    return (
+      <td {...props} data-id="__react-email-column" ref={ref} style={style}>
+        {children}
+      </td>
+    );
+  },
+);
 
 Column.displayName = "Column";

--- a/packages/column/src/column.tsx
+++ b/packages/column/src/column.tsx
@@ -1,17 +1,19 @@
 import * as React from "react";
 
 type RootProps = React.ComponentPropsWithoutRef<"td">;
+type TdElement = React.ElementRef<"td">;
 
 export type ColumnProps = RootProps;
 
-export const Column: React.FC<Readonly<ColumnProps>> = ({
-  children,
-  style,
-  ...props
-}) => {
+export const Column: React.FC<Readonly<ColumnProps>> = React.forwardRef<
+  TdElement,
+  Readonly<ColumnProps>
+>(({ children, style, ...props }, ref) => {
   return (
-    <td {...props} data-id="__react-email-column" style={style}>
+    <td {...props} data-id="__react-email-column" ref={ref} style={style}>
       {children}
     </td>
   );
-};
+});
+
+Column.displayName = "Column";

--- a/packages/container/src/container.tsx
+++ b/packages/container/src/container.tsx
@@ -5,7 +5,7 @@ type TableElement = React.ElementRef<"table">;
 
 export type ContainerProps = RootProps;
 
-export const Container: React.FC<Readonly<ContainerProps>> = React.forwardRef<
+export const Container = React.forwardRef<
   TableElement,
   Readonly<ContainerProps>
 >(({ children, style, ...props }, ref) => {

--- a/packages/container/src/container.tsx
+++ b/packages/container/src/container.tsx
@@ -1,14 +1,14 @@
 import * as React from "react";
 
 type RootProps = React.ComponentPropsWithoutRef<"table">;
+type TableElement = React.ElementRef<"table">;
 
 export type ContainerProps = RootProps;
 
-export const Container: React.FC<Readonly<ContainerProps>> = ({
-  children,
-  style,
-  ...props
-}) => {
+export const Container: React.FC<Readonly<ContainerProps>> = React.forwardRef<
+  TableElement,
+  Readonly<ContainerProps>
+>(({ children, style, ...props }, ref) => {
   return (
     <table
       align="center"
@@ -17,6 +17,7 @@ export const Container: React.FC<Readonly<ContainerProps>> = ({
       border={0}
       cellPadding="0"
       cellSpacing="0"
+      ref={ref}
       role="presentation"
       style={{ maxWidth: "37.5em", ...style }}
     >
@@ -27,4 +28,6 @@ export const Container: React.FC<Readonly<ContainerProps>> = ({
       </tbody>
     </table>
   );
-};
+});
+
+Container.displayName = "Container";

--- a/packages/head/src/head.tsx
+++ b/packages/head/src/head.tsx
@@ -1,13 +1,20 @@
 import * as React from "react";
 
 type RootProps = React.ComponentPropsWithoutRef<"head">;
+type HeadElement = React.ElementRef<"head">;
 
 export type HeadProps = RootProps;
 
-export const Head: React.FC<Readonly<HeadProps>> = ({ children, ...props }) => (
-  <head {...props}>
+export const Head = React.forwardRef<
+  HeadElement,
+  Readonly<HeadProps>
+>(({ children, ...props }, ref) => (
+  <head {...props} ref={ref}>
     <meta content="text/html; charset=UTF-8" httpEquiv="Content-Type" />
     <meta name="x-apple-disable-message-reformatting" />
     {children}
   </head>
-);
+));
+
+Head.displayName = "Head";
+

--- a/packages/head/src/head.tsx
+++ b/packages/head/src/head.tsx
@@ -5,16 +5,14 @@ type HeadElement = React.ElementRef<"head">;
 
 export type HeadProps = RootProps;
 
-export const Head = React.forwardRef<
-  HeadElement,
-  Readonly<HeadProps>
->(({ children, ...props }, ref) => (
-  <head {...props} ref={ref}>
-    <meta content="text/html; charset=UTF-8" httpEquiv="Content-Type" />
-    <meta name="x-apple-disable-message-reformatting" />
-    {children}
-  </head>
-));
+export const Head = React.forwardRef<HeadElement, Readonly<HeadProps>>(
+  ({ children, ...props }, ref) => (
+    <head {...props} ref={ref}>
+      <meta content="text/html; charset=UTF-8" httpEquiv="Content-Type" />
+      <meta name="x-apple-disable-message-reformatting" />
+      {children}
+    </head>
+  ),
+);
 
 Head.displayName = "Head";
-

--- a/packages/hr/src/hr.tsx
+++ b/packages/hr/src/hr.tsx
@@ -4,14 +4,19 @@ type RootProps = React.ComponentPropsWithoutRef<"hr">;
 
 export type HrProps = RootProps;
 
-export const Hr: React.FC<Readonly<HrProps>> = ({ style, ...props }) => (
-  <hr
-    {...props}
-    style={{
-      width: "100%",
-      border: "none",
-      borderTop: "1px solid #eaeaea",
-      ...style,
-    }}
-  />
+export const Hr = React.forwardRef<React.ElementRef<"hr">, Readonly<HrProps>>(
+  ({ style, ...props }, ref) => (
+    <hr
+      {...props}
+      ref={ref}
+      style={{
+        width: "100%",
+        border: "none",
+        borderTop: "1px solid #eaeaea",
+        ...style,
+      }}
+    />
+  ),
 );
+
+Hr.displayName = "Hr";

--- a/packages/html/src/html.tsx
+++ b/packages/html/src/html.tsx
@@ -4,13 +4,13 @@ type RootProps = React.ComponentPropsWithoutRef<"html">;
 
 export type HtmlProps = RootProps;
 
-export const Html: React.FC<Readonly<HtmlProps>> = ({
-  children,
-  lang = "en",
-  dir = "ltr",
-  ...props
-}) => (
-  <html {...props} dir={dir} lang={lang}>
+export const Html = React.forwardRef<
+  React.ElementRef<"html">,
+  Readonly<HtmlProps>
+>(({ children, lang = "en", dir = "ltr", ...props }, ref) => (
+  <html {...props} dir={dir} lang={lang} ref={ref}>
     {children}
   </html>
-);
+));
+
+Html.displayName = "Html";

--- a/packages/img/src/img.tsx
+++ b/packages/img/src/img.tsx
@@ -4,18 +4,15 @@ type RootProps = React.ComponentPropsWithoutRef<"img">;
 
 export type ImgProps = RootProps;
 
-export const Img: React.FC<Readonly<ImgProps>> = ({
-  alt,
-  src,
-  width,
-  height,
-  style,
-  ...props
-}) => (
+export const Img = React.forwardRef<
+  React.ElementRef<"img">,
+  Readonly<ImgProps>
+>(({ alt, src, width, height, style, ...props }, ref) => (
   <img
     {...props}
     alt={alt}
     height={height}
+    ref={ref}
     src={src}
     style={{
       display: "block",
@@ -26,4 +23,6 @@ export const Img: React.FC<Readonly<ImgProps>> = ({
     }}
     width={width}
   />
-);
+));
+
+Img.displayName = "Img";

--- a/packages/link/src/link.tsx
+++ b/packages/link/src/link.tsx
@@ -4,13 +4,13 @@ type RootProps = React.ComponentPropsWithoutRef<"a">;
 
 export type LinkProps = RootProps;
 
-export const Link: React.FC<Readonly<LinkProps>> = ({
-  target = "_blank",
-  style,
-  ...props
-}) => (
+export const Link = React.forwardRef<
+  React.ElementRef<"a">,
+  Readonly<LinkProps>
+>(({ target = "_blank", style, ...props }, ref) => (
   <a
     {...props}
+    ref={ref}
     style={{
       color: "#067df7",
       textDecoration: "none",
@@ -20,4 +20,6 @@ export const Link: React.FC<Readonly<LinkProps>> = ({
   >
     {props.children}
   </a>
-);
+));
+
+Link.displayName = "Link";

--- a/packages/markdown/src/markdown.tsx
+++ b/packages/markdown/src/markdown.tsx
@@ -13,17 +13,12 @@ export const Markdown = React.forwardRef<
   Readonly<MarkdownProps>
 >(
   (
-    {
-      children,
-      markdownContainerStyles,
-      markdownCustomStyles,
-      ...props
-    },
+    { children, markdownContainerStyles, markdownCustomStyles, ...props },
     ref,
   ) => {
     const parsedMarkdown = parseMarkdownToJSX({
       markdown: children,
-      customStyles: markdownCustomStyles
+      customStyles: markdownCustomStyles,
     });
 
     return (

--- a/packages/markdown/src/markdown.tsx
+++ b/packages/markdown/src/markdown.tsx
@@ -8,23 +8,34 @@ export interface MarkdownProps {
   markdownContainerStyles?: React.CSSProperties;
 }
 
-export const Markdown: React.FC<MarkdownProps> = ({
-  children,
-  markdownContainerStyles,
-  markdownCustomStyles,
-  ...props
-}) => {
-  const parsedMarkdown = parseMarkdownToJSX({
-    markdown: children,
-    customStyles: markdownCustomStyles,
-  });
+export const Markdown = React.forwardRef<
+  React.ElementRef<"div">,
+  Readonly<MarkdownProps>
+>(
+  (
+    {
+      children,
+      markdownContainerStyles,
+      markdownCustomStyles,
+      ...props
+    },
+    ref,
+  ) => {
+    const parsedMarkdown = parseMarkdownToJSX({
+      markdown: children,
+      customStyles: markdownCustomStyles
+    });
 
-  return (
-    <div
-      {...props}
-      dangerouslySetInnerHTML={{ __html: parsedMarkdown }}
-      data-id="react-email-markdown"
-      style={markdownContainerStyles}
-    />
-  );
-};
+    return (
+      <div
+        {...props}
+        dangerouslySetInnerHTML={{ __html: parsedMarkdown }}
+        data-id="react-email-markdown"
+        ref={ref}
+        style={markdownContainerStyles}
+      />
+    );
+  },
+);
+
+Markdown.displayName = "Markdown";

--- a/packages/preview/src/preview.tsx
+++ b/packages/preview/src/preview.tsx
@@ -8,29 +8,30 @@ export interface PreviewProps extends RootProps {
 
 const PREVIEW_MAX_LENGTH = 150;
 
-export const Preview = React.forwardRef<React.ElementRef<"div">, Readonly<PreviewProps>>(
-  ({ children = "", ...props }, ref) => {
-    let text = Array.isArray(children) ? children.join("") : children;
-    text = text.substr(0, PREVIEW_MAX_LENGTH);
-    return (
-      <div
-        ref={ref}
-        style={{
-          display: "none",
-          overflow: "hidden",
-          lineHeight: "1px",
-          opacity: 0,
-          maxHeight: 0,
-          maxWidth: 0,
-        }}
-        {...props}
-      >
-        {text}
-        {renderWhiteSpace(text)}
-      </div>
-    );
-  },
-);
+export const Preview = React.forwardRef<
+  React.ElementRef<"div">,
+  Readonly<PreviewProps>
+>(({ children = "", ...props }, ref) => {
+  let text = Array.isArray(children) ? children.join("") : children;
+  text = text.substr(0, PREVIEW_MAX_LENGTH);
+  return (
+    <div
+      ref={ref}
+      style={{
+        display: "none",
+        overflow: "hidden",
+        lineHeight: "1px",
+        opacity: 0,
+        maxHeight: 0,
+        maxWidth: 0,
+      }}
+      {...props}
+    >
+      {text}
+      {renderWhiteSpace(text)}
+    </div>
+  );
+});
 
 Preview.displayName = "Preview";
 

--- a/packages/preview/src/preview.tsx
+++ b/packages/preview/src/preview.tsx
@@ -8,29 +8,31 @@ export interface PreviewProps extends RootProps {
 
 const PREVIEW_MAX_LENGTH = 150;
 
-export const Preview: React.FC<Readonly<PreviewProps>> = ({
-  children = "",
-  ...props
-}) => {
-  let text = Array.isArray(children) ? children.join("") : children;
-  text = text.substr(0, PREVIEW_MAX_LENGTH);
-  return (
-    <div
-      style={{
-        display: "none",
-        overflow: "hidden",
-        lineHeight: "1px",
-        opacity: 0,
-        maxHeight: 0,
-        maxWidth: 0,
-      }}
-      {...props}
-    >
-      {text}
-      {renderWhiteSpace(text)}
-    </div>
-  );
-};
+export const Preview = React.forwardRef<React.ElementRef<"div">, Readonly<PreviewProps>>(
+  ({ children = "", ...props }, ref) => {
+    let text = Array.isArray(children) ? children.join("") : children;
+    text = text.substr(0, PREVIEW_MAX_LENGTH);
+    return (
+      <div
+        ref={ref}
+        style={{
+          display: "none",
+          overflow: "hidden",
+          lineHeight: "1px",
+          opacity: 0,
+          maxHeight: 0,
+          maxWidth: 0,
+        }}
+        {...props}
+      >
+        {text}
+        {renderWhiteSpace(text)}
+      </div>
+    );
+  },
+);
+
+Preview.displayName = "Preview";
 
 export const renderWhiteSpace = (text: string) => {
   if (text.length >= PREVIEW_MAX_LENGTH) {

--- a/packages/row/src/row.tsx
+++ b/packages/row/src/row.tsx
@@ -6,11 +6,10 @@ export interface RowProps extends RootProps {
   children: React.ReactNode;
 }
 
-export const Row: React.FC<Readonly<RowProps>> = ({
-  children,
-  style,
-  ...props
-}) => {
+export const Row = React.forwardRef<
+  React.ElementRef<"table">,
+  Readonly<RowProps>
+>(({ children, style, ...props }, ref) => {
   return (
     <table
       align="center"
@@ -19,6 +18,7 @@ export const Row: React.FC<Readonly<RowProps>> = ({
       border={0}
       cellPadding="0"
       cellSpacing="0"
+      ref={ref}
       role="presentation"
       style={style}
     >
@@ -27,4 +27,6 @@ export const Row: React.FC<Readonly<RowProps>> = ({
       </tbody>
     </table>
   );
-};
+});
+
+Row.displayName = "Row";

--- a/packages/section/src/section.tsx
+++ b/packages/section/src/section.tsx
@@ -4,11 +4,10 @@ type RootProps = React.ComponentPropsWithoutRef<"table">;
 
 export type SectionProps = RootProps;
 
-export const Section: React.FC<Readonly<SectionProps>> = ({
-  children,
-  style,
-  ...props
-}) => {
+export const Section = React.forwardRef<
+  React.ElementRef<"table">,
+  Readonly<SectionProps>
+>(({ children, style, ...props }, ref) => {
   return (
     <table
       align="center"
@@ -17,6 +16,7 @@ export const Section: React.FC<Readonly<SectionProps>> = ({
       border={0}
       cellPadding="0"
       cellSpacing="0"
+      ref={ref}
       role="presentation"
       style={style}
     >
@@ -27,4 +27,6 @@ export const Section: React.FC<Readonly<SectionProps>> = ({
       </tbody>
     </table>
   );
-};
+});
+
+Section.displayName = "Section";

--- a/packages/text/src/text.tsx
+++ b/packages/text/src/text.tsx
@@ -4,7 +4,10 @@ type RootProps = React.ComponentPropsWithoutRef<"p">;
 
 export type TextProps = RootProps;
 
-export const Text: React.FC<Readonly<TextProps>> = ({ style, ...props }) => (
+export const Text = React.forwardRef<
+  React.ElementRef<"p">,
+  Readonly<TextProps>
+>(({ style, ...props }) => (
   <p
     {...props}
     style={{
@@ -14,4 +17,6 @@ export const Text: React.FC<Readonly<TextProps>> = ({ style, ...props }) => (
       ...style,
     }}
   />
-);
+));
+
+Text.displayName = "Text";


### PR DESCRIPTION
Our rendering utility is meant to be optional. This comes from our apparent philosophy. Things should be flexible and minimal, from where I see it.
If we are to act on that idea, we need to pay attention to something that is in a few use cases crucial for users: being able to use `ref`s with our components. 

Not forwarding them means that we don't really support all kinds of rendering, but only the static ones.
If the user intends to build something for themselves that is meant to render the email
components in the browser itself with reactivity we shouldn't have something opposing them.

That is not to say that having the `ref`s here is not confusing, but I'd like to argue that 
it is going to be very hard to come across the `ref` unless the user actually wants it
because of all the common element props that we already forward into all the internal elements of our components.

That being said we probably should also add something in our documentation talking about this
and making this clear, open to any ideas of where to put it. My initial thought is to mention
this idea in a page that explains the philosophy of React Email which might be a great idea to have.

Thanks to @advancedtw for bringing this to our attention on #1286.

