### PR TITLE
fix(button): User styles not being overwritten by ours

### DIFF
--- a/packages/button/src/button.spec.tsx
+++ b/packages/button/src/button.spec.tsx
@@ -24,7 +24,7 @@ describe("<Button> component", () => {
       <Button href="https://example.com" style={{ padding: "12px 20px" }} />,
     );
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><a href=\\"https://example.com\\" style=\\"padding:12px 20px 12px 20px;line-height:100%;text-decoration:none;display:inline-block;max-width:100%\\" target=\\"_blank\\"><span><!--[if mso]><i style=\\"letter-spacing: 20px;mso-font-width:-100%;mso-text-raise:18\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:9px\\"></span><span><!--[if mso]><i style=\\"letter-spacing: 20px;mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a>"',
+      '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><a href=\\"https://example.com\\" style=\\"line-height:100%;text-decoration:none;display:inline-block;max-width:100%;padding:12px 20px 12px 20px\\" target=\\"_blank\\"><span><!--[if mso]><i style=\\"letter-spacing: 20px;mso-font-width:-100%;mso-text-raise:18\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:9px\\"></span><span><!--[if mso]><i style=\\"letter-spacing: 20px;mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a>"',
     );
   });
 

--- a/packages/button/src/button.spec.tsx
+++ b/packages/button/src/button.spec.tsx
@@ -34,4 +34,11 @@ describe("<Button> component", () => {
       '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><a href=\\"https://example.com\\" style=\\"line-height:100%;text-decoration:none;display:inline-block;max-width:100%;padding:0px 0px 0px 0px\\" target=\\"_blank\\"><span><!--[if mso]><i style=\\"letter-spacing: 0px;mso-font-width:-100%;mso-text-raise:0\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:0\\"></span><span><!--[if mso]><i style=\\"letter-spacing: 0px;mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a>"',
     );
   });
+
+  it("should allow users to overwrite style props", () => {
+    const actualOutput = render(<Button style={{ lineHeight: "150%", display: 'block', textDecoration: 'underline red', maxWidth: '50%' }} />);
+    expect(actualOutput).toMatchInlineSnapshot(
+      '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><a style=\\"line-height:150%;text-decoration:underline red;display:block;max-width:50%;padding:0px 0px 0px 0px\\" target=\\"_blank\\"><span><!--[if mso]><i style=\\"letter-spacing: 0px;mso-font-width:-100%;mso-text-raise:0\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:0\\"></span><span><!--[if mso]><i style=\\"letter-spacing: 0px;mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a>"',
+    );
+  });
 });

--- a/packages/button/src/button.spec.tsx
+++ b/packages/button/src/button.spec.tsx
@@ -36,7 +36,16 @@ describe("<Button> component", () => {
   });
 
   it("should allow users to overwrite style props", () => {
-    const actualOutput = render(<Button style={{ lineHeight: "150%", display: 'block', textDecoration: 'underline red', maxWidth: '50%' }} />);
+    const actualOutput = render(
+      <Button
+        style={{
+          lineHeight: "150%",
+          display: "block",
+          textDecoration: "underline red",
+          maxWidth: "50%",
+        }}
+      />,
+    );
     expect(actualOutput).toMatchInlineSnapshot(
       '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><a style=\\"line-height:150%;text-decoration:underline red;display:block;max-width:50%;padding:0px 0px 0px 0px\\" target=\\"_blank\\"><span><!--[if mso]><i style=\\"letter-spacing: 0px;mso-font-width:-100%;mso-text-raise:0\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:0\\"></span><span><!--[if mso]><i style=\\"letter-spacing: 0px;mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a>"',
     );

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -52,11 +52,11 @@ const buttonStyle = (
   const { pt, pr, pb, pl, ...rest } = style || {};
 
   return {
-    ...rest,
     lineHeight: "100%",
     textDecoration: "none",
     display: "inline-block",
     maxWidth: "100%",
+    ...rest,
     padding: `${pt}px ${pr}px ${pb}px ${pl}px`,
   };
 };

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -31,7 +31,7 @@ describe("Tailwind component", () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<a style=\\"margin-top:2rem;border-radius:0.375rem;background-color:rgb(37,99,235);padding-left:0.75rem;padding-right:0.75rem;padding-top:0.5rem;padding-bottom:0.5rem;font-size:0.875rem;line-height:100%;color:rgb(229,231,235);text-decoration:none;display:inline-block;max-width:100%;padding:8px 12px 8px 12px\\" target=\\"_blank\\"><span><!--[if mso]><i style=\\"letter-spacing: 12px;mso-font-width:-100%;mso-text-raise:12\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:6px\\">Testing button</span><span><!--[if mso]><i style=\\"letter-spacing: 12px;mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a>"`,
+      `"<a style=\\"line-height:1.25rem;text-decoration:none;display:inline-block;max-width:100%;margin-top:2rem;border-radius:0.375rem;background-color:rgb(37,99,235);padding-left:0.75rem;padding-right:0.75rem;padding-top:0.5rem;padding-bottom:0.5rem;font-size:0.875rem;color:rgb(229,231,235);padding:8px 12px 8px 12px\\" target=\\"_blank\\"><span><!--[if mso]><i style=\\"letter-spacing: 12px;mso-font-width:-100%;mso-text-raise:12\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:6px\\">Testing button</span><span><!--[if mso]><i style=\\"letter-spacing: 12px;mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a>"`,
     );
   });
 


### PR DESCRIPTION
## What is the issue?

The issue is that if the user were to define a `line-height`, or a few other styles,
through the `style` prop to the Button they would be ignored and ours would be preferred.
This PR changes that in the sense that if the user does provide this, then their value is
used instead of ours. This is not done for the padding prop though as it is already being
just computed from the one the user provides.

## How can I test to make sure 

There is not much of a need for testing manually here since I have added in a unit test
to make sure that the style properties provided by the user do override ours.
