### PR TITLE
fix(react-email, render): Dependabot security vulnerabilities from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tsconfig": "workspace:*",
     "tsup": "7.2.0",
     "turbo": "1.11.3",
-    "vite": "4.5.2",
+    "vite": "5.0.12",
     "vitest": "0.34.6"
   },
   "packageManager": "pnpm@8.14.1",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -80,7 +80,7 @@
     "@vercel/style-guide": "5.1.0",
     "eslint": "8.50.0",
     "tsup": "7.2.0",
-    "tsx": "4.7.0",
+    "tsx": "4.7.1",
     "vitest": "1.1.3"
   }
 }

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -80,8 +80,7 @@
     "@vercel/style-guide": "5.1.0",
     "eslint": "8.50.0",
     "tsup": "7.2.0",
-    "tsx": "4.7.1",
-    "vitest": "1.1.3",
-    "watch": "1.0.2"
+    "tsx": "4.7.0",
+    "vitest": "1.1.3"
   }
 }

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -57,7 +57,7 @@
     "jsdom": "23.0.1",
     "tsconfig": "workspace:*",
     "typescript": "5.1.6",
-    "vitest": "1.1.0"
+    "vitest": "1.1.2"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,8 +47,8 @@ importers:
         specifier: 1.11.3
         version: 1.11.3
       vite:
-        specifier: 4.5.2
-        version: 4.5.2(@types/node@18.18.0)
+        specifier: 5.0.12
+        version: 5.0.12(@types/node@18.18.0)
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.2.2)
@@ -246,7 +246,7 @@ importers:
         version: 5.1.6
       vitest:
         specifier: 1.1.0
-        version: 1.1.0(@edge-runtime/vm@3.1.8)(@types/node@18.18.0)(happy-dom@12.2.2)(jsdom@23.0.1)
+        version: 1.1.0(@types/node@18.18.0)(happy-dom@12.2.2)
 
   packages/column:
     dependencies:
@@ -815,8 +815,8 @@ importers:
         specifier: 5.1.6
         version: 5.1.6
       vitest:
-        specifier: 1.1.0
-        version: 1.1.0(@edge-runtime/vm@3.1.8)(@types/node@18.18.0)(happy-dom@12.2.2)(jsdom@23.0.1)
+        specifier: 1.1.2
+        version: 1.1.2(@edge-runtime/vm@3.1.8)(@types/node@18.18.0)(happy-dom@12.2.2)(jsdom@23.0.1)
 
   packages/row:
     dependencies:
@@ -3773,6 +3773,14 @@ packages:
       chai: 4.4.1
     dev: true
 
+  /@vitest/expect@1.1.2:
+    resolution: {integrity: sha512-1aOqDLbgkvJ2e1nLQ/5dkUX54V1Alwt2e6M2u03Oy7wGbDYHV5ZLKm1XbcT45h8TMXtc2q/BPtkeIjyRv1oDHQ==}
+    dependencies:
+      '@vitest/spy': 1.1.2
+      '@vitest/utils': 1.1.2
+      chai: 4.4.1
+    dev: true
+
   /@vitest/expect@1.1.3:
     resolution: {integrity: sha512-MnJqsKc1Ko04lksF9XoRJza0bGGwTtqfbyrsYv5on4rcEkdo+QgUdITenBQBUltKzdxW7K3rWh+nXRULwsdaVg==}
     dependencies:
@@ -3793,6 +3801,14 @@ packages:
     resolution: {integrity: sha512-zdNLJ00pm5z/uhbWF6aeIJCGMSyTyWImy3Fcp9piRGvueERFlQFbUwCpzVce79OLm2UHk9iwaMSOaU9jVHgNVw==}
     dependencies:
       '@vitest/utils': 1.1.0
+      p-limit: 5.0.0
+      pathe: 1.1.2
+    dev: true
+
+  /@vitest/runner@1.1.2:
+    resolution: {integrity: sha512-oTqXCGtZzu9EaXq9cO/QDGnC721iryuTPs5rLyVZUJsdm33IQeIOwTRIWUB7EYFwpJsI+qMiCiuGZS49+DP5hA==}
+    dependencies:
+      '@vitest/utils': 1.1.2
       p-limit: 5.0.0
       pathe: 1.1.2
     dev: true
@@ -3821,6 +3837,14 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
+  /@vitest/snapshot@1.1.2:
+    resolution: {integrity: sha512-hXXd5KjURGt6GCrmw55A+PNIlrOaE6x6KcdEANXac76xmvVbJZXSiNVJ1JuMCiyvLLTzdpPnrgWyCX9/CepFCQ==}
+    dependencies:
+      magic-string: 0.30.9
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+    dev: true
+
   /@vitest/snapshot@1.1.3:
     resolution: {integrity: sha512-U0r8pRXsLAdxSVAyGNcqOU2H3Z4Y2dAAGGelL50O0QRMdi1WWeYHdrH/QWpN1e8juWfVKsb8B+pyJwTC+4Gy9w==}
     dependencies:
@@ -3837,6 +3861,12 @@ packages:
 
   /@vitest/spy@1.1.0:
     resolution: {integrity: sha512-sNOVSU/GE+7+P76qYo+VXdXhXffzWZcYIPQfmkiRxaNCSPiLANvQx5Mx6ZURJ/ndtEkUJEpvKLXqAYTKEY+lTg==}
+    dependencies:
+      tinyspy: 2.2.1
+    dev: true
+
+  /@vitest/spy@1.1.2:
+    resolution: {integrity: sha512-1Nn70K3oY00lhThDXsVQxjslUvJij1YQDzH/4FMxMLgjYxB5u4Aw4yXeICNSSap04wyV2dtGL3RqdBGwoR3sPA==}
     dependencies:
       tinyspy: 2.2.1
     dev: true
@@ -3859,6 +3889,15 @@ packages:
     resolution: {integrity: sha512-z+s510fKmYz4Y41XhNs3vcuFTFhcij2YF7F8VQfMEYAAUfqQh0Zfg7+w9xdgFGhPf3tX3TicAe+8BDITk6ampQ==}
     dependencies:
       diff-sequences: 29.6.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+    dev: true
+
+  /@vitest/utils@1.1.2:
+    resolution: {integrity: sha512-QrXfDieptshDkTkXnA+HmlVQto1h0jengbkSKcJjlbCMeXbSCr3AcALPPzozRQxEOKvFjqx9WHjljz62uxrGew==}
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
     dev: true
@@ -9484,7 +9523,7 @@ packages:
       mlly: 1.6.1
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 4.5.2(@types/node@18.18.0)
+      vite: 5.0.12(@types/node@18.18.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -9505,7 +9544,28 @@ packages:
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.2.8(@types/node@18.18.0)
+      vite: 5.0.12(@types/node@18.18.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vite-node@1.1.2(@types/node@18.18.0):
+    resolution: {integrity: sha512-2S3Y7T68PMrBbFS2H9Oda2GeordkIU5gLx2toubxPUcFZ+LKZ9L6U69pLtofotwQUrb3NcUImP3fl9GfLplebA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      vite: 5.0.12(@types/node@18.18.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -9526,7 +9586,7 @@ packages:
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.2.8(@types/node@18.0.0)
+      vite: 5.0.12(@types/node@18.0.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -9608,6 +9668,78 @@ packages:
       esbuild: 0.18.20
       postcss: 8.4.38
       rollup: 3.29.4
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vite@5.0.12(@types/node@18.0.0):
+    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.0.0
+      esbuild: 0.19.11
+      postcss: 8.4.38
+      rollup: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vite@5.0.12(@types/node@18.18.0):
+    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.18.0
+      esbuild: 0.19.11
+      postcss: 8.4.38
+      rollup: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
@@ -9737,7 +9869,7 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.1
       tinypool: 0.7.0
-      vite: 4.5.2(@types/node@18.18.0)
+      vite: 5.0.12(@types/node@18.18.0)
       vite-node: 0.34.6(@types/node@18.18.0)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
@@ -9750,8 +9882,66 @@ packages:
       - terser
     dev: true
 
-  /vitest@1.1.0(@edge-runtime/vm@3.1.8)(@types/node@18.18.0)(happy-dom@12.2.2)(jsdom@23.0.1):
+  /vitest@1.1.0(@types/node@18.18.0)(happy-dom@12.2.2):
     resolution: {integrity: sha512-oDFiCrw7dd3Jf06HoMtSRARivvyjHJaTxikFxuqJjO76U436PqlVw1uLn7a8OSPrhSfMGVaRakKpA2lePdw79A==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': ^1.0.0
+      '@vitest/ui': ^1.0.0
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 18.18.0
+      '@vitest/expect': 1.1.0
+      '@vitest/runner': 1.1.0
+      '@vitest/snapshot': 1.1.0
+      '@vitest/spy': 1.1.0
+      '@vitest/utils': 1.1.0
+      acorn-walk: 8.3.2
+      cac: 6.7.14
+      chai: 4.4.1
+      debug: 4.3.4
+      execa: 8.0.1
+      happy-dom: 12.2.2
+      local-pkg: 0.5.0
+      magic-string: 0.30.9
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      strip-literal: 1.3.0
+      tinybench: 2.5.1
+      tinypool: 0.8.3
+      vite: 5.2.8(@types/node@18.18.0)
+      vite-node: 1.1.0(@types/node@18.18.0)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest@1.1.2(@edge-runtime/vm@3.1.8)(@types/node@18.18.0)(happy-dom@12.2.2)(jsdom@23.0.1):
+    resolution: {integrity: sha512-nEw58z0PFBARwo3hWx6aKmI0Rob2avL9Mt2IYW+5mH5dS4S39J+VLH9aG8x6KZIgyegdE1p7/3JjZ93FzVCsoQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -9777,11 +9967,11 @@ packages:
     dependencies:
       '@edge-runtime/vm': 3.1.8
       '@types/node': 18.18.0
-      '@vitest/expect': 1.1.0
-      '@vitest/runner': 1.1.0
-      '@vitest/snapshot': 1.1.0
-      '@vitest/spy': 1.1.0
-      '@vitest/utils': 1.1.0
+      '@vitest/expect': 1.1.2
+      '@vitest/runner': 1.1.2
+      '@vitest/snapshot': 1.1.2
+      '@vitest/spy': 1.1.2
+      '@vitest/utils': 1.1.2
       acorn-walk: 8.3.2
       cac: 6.7.14
       chai: 4.4.1
@@ -9797,8 +9987,8 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.1
       tinypool: 0.8.3
-      vite: 5.2.8(@types/node@18.18.0)
-      vite-node: 1.1.0(@types/node@18.18.0)
+      vite: 5.0.12(@types/node@18.18.0)
+      vite-node: 1.1.2(@types/node@18.18.0)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -771,9 +771,6 @@ importers:
       vitest:
         specifier: 1.1.3
         version: 1.1.3(@types/node@18.0.0)(happy-dom@12.2.2)
-      watch:
-        specifier: 1.0.2
-        version: 1.0.2
 
   packages/render:
     dependencies:
@@ -5872,12 +5869,6 @@ packages:
       safe-buffer: 5.2.1
     dev: true
 
-  /exec-sh@0.2.2:
-    resolution: {integrity: sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==}
-    dependencies:
-      merge: 1.2.1
-    dev: true
-
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -7114,10 +7105,6 @@ packages:
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-
-  /merge@1.2.1:
-    resolution: {integrity: sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==}
-    dev: true
 
   /micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
@@ -10086,15 +10073,6 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       xml-name-validator: 5.0.0
-    dev: true
-
-  /watch@1.0.2:
-    resolution: {integrity: sha512-1u+Z5n9Jc1E2c7qDO8SinPoZuHj7FgbgU1olSFoyaklduDvvtX7GMMtlE6OC9FTXq4KvNAOfj6Zu4vI1e9bAKA==}
-    engines: {node: '>=0.1.95'}
-    hasBin: true
-    dependencies:
-      exec-sh: 0.2.2
-      minimist: 1.2.8
     dev: true
 
   /watchpack@2.4.0:


### PR DESCRIPTION
This fixes all the dependency security vulnerabilities pointed out by Dependabot like:

- Vite dev server option `server.fs.deny` can be bypassed when hosted on case-insensitive filesystem
    - due to an older version of `vitest` on `@react-email/render`
- Prototype Pollution in `merge`
    - due to an older version of the, now unused, watch package 

This PR solves these issues by first upgrading `vitest` inside of `@react-email/render`
and by removing the dev dependency of `watch` from `react-email`, which doesn't relate to watching
of the email changes.
