### PR TITLE
fix(react-email): Possible file system race conditions

### DIFF
--- a/packages/react-email/src/actions/get-emails-directory-metadata.ts
+++ b/packages/react-email/src/actions/get-emails-directory-metadata.ts
@@ -12,6 +12,13 @@ const isFileAnEmail = (fullPath: string): boolean => {
 
   if (!['.js', '.tsx', '.jsx'].includes(ext)) return false;
 
+  // This is to avoid a possible race condition where the file doesn't exist anymore
+  // once we are checking if it is an actual email, this couuld cause issues that
+  // would be very hard to debug and find out the why of it happening.
+  if (!fs.existsSync(fullPath)) {
+    return false;
+  }
+
   // check with a heuristic to see if the file has at least
   // a default export
   const fileContents = fs.readFileSync(fullPath, 'utf8');

--- a/packages/react-email/src/cli/utils/preview/serve-static-file.ts
+++ b/packages/react-email/src/cli/utils/preview/serve-static-file.ts
@@ -32,8 +32,18 @@ export const serveStaticFile = async (
     return;
   }
 
-  const fileData = await fs.readFile(fileAbsolutePath);
-  // if the file is found, set Content-type and send data
-  res.setHeader('Content-type', lookup(ext) || 'text/plain');
-  res.end(fileData);
+  try {
+    const fileData = await fs.readFile(fileAbsolutePath);
+
+    // if the file is found, set Content-type and send data
+    res.setHeader('Content-type', lookup(ext) || 'text/plain');
+    res.end(fileData);
+  } catch (exception) {
+    console.error(`Could not read file at ${fileAbsolutePath} to be served, here's the exception:`, exception);
+
+    res.statusCode = 500;
+    res.end(`Could not read file at ${pathname} to be served!`);
+
+    return;
+  }
 };

--- a/packages/react-email/src/cli/utils/preview/serve-static-file.ts
+++ b/packages/react-email/src/cli/utils/preview/serve-static-file.ts
@@ -19,7 +19,7 @@ export const serveStaticFile = async (
   const doesFileExist = existsSync(fileAbsolutePath);
   if (!doesFileExist) {
     res.statusCode = 404;
-    res.end(`File ${pathname} not found!`);
+    res.end(`File not found!`);
 
     return;
   }
@@ -27,7 +27,7 @@ export const serveStaticFile = async (
   const fileStat = await fs.stat(fileAbsolutePath);
   if (fileStat.isDirectory()) {
     res.statusCode = 404;
-    res.end(`File ${pathname} not found!`);
+    res.end(`We can't serve a directory here, try changing the URL to go into one of the files inside of the directory instead.`);
 
     return;
   }
@@ -45,7 +45,7 @@ export const serveStaticFile = async (
     );
 
     res.statusCode = 500;
-    res.end(`Could not read file at ${pathname} to be served!`);
+    res.end(`Could not read file to be served! Check your terminal for more information.`);
 
     return;
   }

--- a/packages/react-email/src/cli/utils/preview/serve-static-file.ts
+++ b/packages/react-email/src/cli/utils/preview/serve-static-file.ts
@@ -39,7 +39,10 @@ export const serveStaticFile = async (
     res.setHeader('Content-type', lookup(ext) || 'text/plain');
     res.end(fileData);
   } catch (exception) {
-    console.error(`Could not read file at ${fileAbsolutePath} to be served, here's the exception:`, exception);
+    console.error(
+      `Could not read file at ${fileAbsolutePath} to be served, here's the exception:`,
+      exception,
+    );
 
     res.statusCode = 500;
     res.end(`Could not read file at ${pathname} to be served!`);

--- a/packages/react-email/src/cli/utils/preview/serve-static-file.ts
+++ b/packages/react-email/src/cli/utils/preview/serve-static-file.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import type http from 'node:http';
 import path from 'node:path';
-import { promises as fs, existsSync } from 'node:fs';
+import { promises as fs } from 'node:fs';
 import type url from 'node:url';
 import { lookup } from 'mime-types';
 
@@ -16,26 +16,10 @@ export const serveStaticFile = async (
 
   let fileAbsolutePath = path.join(staticBaseDir, pathname);
 
-  const doesFileExist = existsSync(fileAbsolutePath);
-  if (!doesFileExist) {
-    res.statusCode = 404;
-    res.end(`File not found!`);
-
-    return;
-  }
-
-  const fileStat = await fs.stat(fileAbsolutePath);
-  if (fileStat.isDirectory()) {
-    res.statusCode = 404;
-    res.end(
-      `We can't serve a directory here, try changing the URL to go into one of the files inside of the directory instead.`,
-    );
-
-    return;
-  }
+  const fileHandle = await fs.open(fileAbsolutePath, 'r');
 
   try {
-    const fileData = await fs.readFile(fileAbsolutePath);
+    const fileData = await fs.readFile(fileHandle);
 
     // if the file is found, set Content-type and send data
     res.setHeader('Content-type', lookup(ext) || 'text/plain');

--- a/packages/react-email/src/cli/utils/preview/serve-static-file.ts
+++ b/packages/react-email/src/cli/utils/preview/serve-static-file.ts
@@ -27,7 +27,9 @@ export const serveStaticFile = async (
   const fileStat = await fs.stat(fileAbsolutePath);
   if (fileStat.isDirectory()) {
     res.statusCode = 404;
-    res.end(`We can't serve a directory here, try changing the URL to go into one of the files inside of the directory instead.`);
+    res.end(
+      `We can't serve a directory here, try changing the URL to go into one of the files inside of the directory instead.`,
+    );
 
     return;
   }
@@ -45,7 +47,9 @@ export const serveStaticFile = async (
     );
 
     res.statusCode = 500;
-    res.end(`Could not read file to be served! Check your terminal for more information.`);
+    res.end(
+      `Could not read file to be served! Check your terminal for more information.`,
+    );
 
     return;
   }

--- a/packages/react-email/src/cli/utils/preview/serve-static-file.ts
+++ b/packages/react-email/src/cli/utils/preview/serve-static-file.ts
@@ -20,15 +20,20 @@ export const serveStaticFile = async (
   if (!doesFileExist) {
     res.statusCode = 404;
     res.end(`File ${pathname} not found!`);
-  } else {
-    const fileStat = await fs.stat(fileAbsolutePath);
-    if (fileStat.isDirectory()) {
-      fileAbsolutePath += `/index${ext}`;
-    }
 
-    const fileData = await fs.readFile(fileAbsolutePath);
-    // if the file is found, set Content-type and send data
-    res.setHeader('Content-type', lookup(ext) || 'text/plain');
-    res.end(fileData);
+    return;
   }
+
+  const fileStat = await fs.stat(fileAbsolutePath);
+  if (fileStat.isDirectory()) {
+    res.statusCode = 404;
+    res.end(`File ${pathname} not found!`);
+
+    return;
+  }
+
+  const fileData = await fs.readFile(fileAbsolutePath);
+  // if the file is found, set Content-type and send data
+  res.setHeader('Content-type', lookup(ext) || 'text/plain');
+  res.end(fileData);
 };


### PR DESCRIPTION
This fixes two security vulnerabilities pointed out by automatic
code analysis that could have caused access to files that don't
exist causing errors that could be quite hard to debug and find the cause of.

The first issue was inside of the function we use to server the user's static files,
i.e. `emails/static`, where if it found a certain path access was for a directory
like `http://localhost:3000/static/vercel` it would go directly into the index file without checking
it existed, which quite didn't make sense anymore so I removed that behavior and just respond
with a `404` in case the URL points into a directory.

The second issue was inside of the code we check if a file is an email,
inside of the server action called `getEmailsDirectoryMetadata`. It was reading
the file based on its full path without first checking it existed,
and as it could not exist anymore at that point it could cause a race condition
as well. Fixed by just checking if the file exists before, and if it doesn't
return false, thus ignoring the file as not an email.
