### PR TITLE
chore(docs): Fix "monorepos" typo in Manual Setup guide

### DIFF
--- a/apps/docs/getting-started/manual-setup.mdx
+++ b/apps/docs/getting-started/manual-setup.mdx
@@ -6,7 +6,7 @@ description: "Create a brand-new folder with packages powered by React Email."
 icon: "hammer"
 ---
 
-<Note>Are you using monoorepos? Then we recommend you follow our [monorepos setup](/getting-started/monorepo-setup/choose-package-manager).</Note>
+<Note>Are you using monorepos? Then we recommend you follow our [monorepos setup](/getting-started/monorepo-setup/choose-package-manager).</Note>
 
 ## 1. Create directory
 


### PR DESCRIPTION
Simple fix after going through the docs 🫡 - `monoorepos` -> `monorepos`