### PR TITLE
chore(react-email, create-email, components, button): Bump for canary release

### DIFF
--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/button",
-  "version": "0.0.13",
+  "version": "0.0.14-canary.0",
   "description": "A link that is styled to look like a button",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/components",
-  "version": "0.0.15-canary.1",
+  "version": "0.0.15-canary.2",
   "description": "A collection of all components React Email.",
   "sideEffects": false,
   "main": "./dist/index.js",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@react-email/body": "0.0.7",
-    "@react-email/button": "0.0.13",
+    "@react-email/button": "0.0.14-canary.0",
     "@react-email/code-block": "0.0.3-canary.1",
     "@react-email/code-inline": "0.0.1",
     "@react-email/column": "0.0.9",

--- a/packages/create-email/package.json
+++ b/packages/create-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-email",
-  "version": "0.0.23-canary.1",
+  "version": "0.0.23-canary.2",
   "description": "The easiest way to get started with React Email",
   "main": "src/index.js",
   "type": "module",

--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -8,8 +8,8 @@
     "export": "email export"
   },
   "dependencies": {
-    "@react-email/components": "0.0.15-canary.1",
-    "react-email": "2.1.0-canary.1",
+    "@react-email/components": "0.0.15-canary.2",
+    "react-email": "2.1.0-canary.2",
     "react": "18.2.0"
   },
   "devDependencies": {

--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emails",
-  "version": "0.0.19-canary.1",
+  "version": "0.0.19-canary.2",
   "private": true,
   "scripts": {
     "build": "email build",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-email",
-  "version": "2.1.0-canary.1",
+  "version": "2.1.0-canary.2",
   "description": "A live preview of your emails right in your browser.",
   "bin": {
     "email": "./cli/index.js"
@@ -32,7 +32,7 @@
     "@radix-ui/react-slot": "1.0.2",
     "@radix-ui/react-toggle-group": "1.0.4",
     "@radix-ui/react-tooltip": "1.0.6",
-    "@react-email/components": "0.0.14",
+    "@react-email/components": "0.0.15-canary.2",
     "@react-email/render": "0.0.12",
     "@swc/core": "1.3.101",
     "@types/react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,7 +276,7 @@ importers:
         specifier: 0.0.7
         version: link:../body
       '@react-email/button':
-        specifier: 0.0.13
+        specifier: 0.0.14-canary.0
         version: link:../button
       '@react-email/code-block':
         specifier: 0.0.3-canary.1
@@ -633,8 +633,8 @@ importers:
         specifier: 1.0.6
         version: 1.0.6(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
       '@react-email/components':
-        specifier: 0.0.14
-        version: 0.0.14(@types/react@18.2.33)(react@18.2.0)
+        specifier: 0.0.15-canary.2
+        version: link:../components
       '@react-email/render':
         specifier: 0.0.12
         version: link:../render
@@ -4552,7 +4552,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.22.1
-      caniuse-lite: 1.0.30001579
+      caniuse-lite: 1.0.30001541
       fraction.js: 4.3.6
       normalize-range: 0.1.2
       picocolors: 1.0.0


### PR DESCRIPTION
button -> 0.0.14-canary.0
components -> 0.0.15-canary.2
react-email -> 2.1.0-canary.2
create-email -> 0.0.23-canary.1
