### PR TITLE
fix(docs): correct <Image> tag to <Img> to align with import

### DIFF
--- a/apps/docs/getting-started/migrating-to-react-email.mdx
+++ b/apps/docs/getting-started/migrating-to-react-email.mdx
@@ -14,7 +14,7 @@ import NextSteps from '../snippets/next-steps.mdx';
 
 1. Remove the `mjml` npm package and install `react-email` and `@react-email/components`
 2. Find all MJML templates ending with the `.mjml` extension and convert these to React components with the `.tsx` or `.jsx` extension.
-3. Replace MJML standard component tags with React Email component tags where possible, including `<Text>`, `<Image>`, `<Button>` etc.
+3. Replace MJML standard component tags with React Email component tags where possible, including `<Text>`, `<Img>`, `<Button>` etc.
 4. Convert custom MJML components with the `.js` extension to React components with the `.tsx` or `.jsx` extension.
 
 ### Automated


### PR DESCRIPTION
This pull request addresses a discrepancy in the documentation for migrating to React Email. Previously, the documentation referenced an `<Image>` component, which does not exist in react-email. I have adjusted the component to match the available image component `<Img>`.

**Changes:**

- Updated instance of <Image> to <Img> in the migration guide/docs.

This change does not affect any actual code, only the documentation, so no tests are needed. Please review and provide any feedback.

📨