### PR TITLE
chore(react-email, create-email, markdown, components): Bump for canary release

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -54,7 +54,7 @@
     "@react-email/html": "0.0.7",
     "@react-email/img": "0.0.7",
     "@react-email/link": "0.0.7",
-    "@react-email/markdown": "0.0.8",
+    "@react-email/markdown": "0.0.9-canary.0",
     "@react-email/preview": "0.0.8",
     "@react-email/render": "0.0.12",
     "@react-email/row": "0.0.7",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/components",
-  "version": "0.0.15",
+  "version": "0.0.16-canary.0",
   "description": "A collection of all components React Email.",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/create-email/package.json
+++ b/packages/create-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-email",
-  "version": "0.0.23",
+  "version": "0.0.24-canary.0",
   "description": "The easiest way to get started with React Email",
   "main": "src/index.js",
   "type": "module",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/markdown",
-  "version": "0.0.8",
+  "version": "0.0.9-canary.0",
   "description": "Convert Markdown to valid React Email template code.",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-email",
-  "version": "2.1.0",
+  "version": "2.1.1-canary.0",
   "description": "A live preview of your emails right in your browser.",
   "bin": {
     "email": "./cli/index.js"

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -32,7 +32,7 @@
     "@radix-ui/react-slot": "1.0.2",
     "@radix-ui/react-toggle-group": "1.0.4",
     "@radix-ui/react-tooltip": "1.0.6",
-    "@react-email/components": "0.0.15",
+    "@react-email/components": "0.0.16-canary.0",
     "@react-email/render": "0.0.12",
     "@swc/core": "1.3.101",
     "@types/react": "^18.2.0",


### PR DESCRIPTION
- react-email  -> 2.1.1-canary.0
- create-eamil -> 0.0.24-canary.0
- markdown     -> 0.0.9-canary.0
- components   -> 0.0.16-canary.0
