### PR TITLE
fix(tailwind): Head component minification issue

### DIFF
--- a/packages/tailwind/src/__snapshots__/tailwind.spec.tsx.snap
+++ b/packages/tailwind/src/__snapshots__/tailwind.spec.tsx.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Responsive styles > should throw an error when used without a <head/> 1`] = `
+"You are trying to use the following Tailwind classes that have media queries: sm:bg-red-500.
+For the media queries to work properly on rendering, they need to be added into a <style> tag inside of a <head> tag,
+the Tailwind component tried finding a <head> element but just wasn't able to find it.
+
+Make sure that you have either a <head> element at some point inside of the <Tailwind> component at any depth.
+
+If you do already have a <head> element at some depth, please file a bug https://github.com/resend/react-email/issues/new?assignees=&labels=Type%3A+Bug&projects=&template=1.bug_report.yml."
+`;

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -167,7 +167,7 @@ describe("Responsive styles", () => {
 
     const MyHead = (props: Record<string, any>) => {
       return <head {...props} />;
-    }
+    };
 
     expect(
       render(
@@ -210,8 +210,7 @@ describe("Responsive styles", () => {
             {/* <Head></Head> */}
             <div className="bg-red-200 sm:bg-red-500" />
           </html>
-        </Tailwind>
-        ,
+        </Tailwind>,
       );
     }
     expect(noHead).toThrowErrorMatchingSnapshot();

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -138,6 +138,53 @@ describe("Tailwind component", () => {
 });
 
 describe("Responsive styles", () => {
+  /*
+    This test is because of https://github.com/resend/react-email/issues/1112
+    which was being caused because we required to, either have our <Head> component,
+    or a <head> element directly inside the <Tailwind> component for media queries to be applied
+    onto. The problem with this approach was that the check to see if an element was an instance of
+    the <Head> component fails after minification as we did it by the function name.
+
+    The best solution is to check for the Head element on arbitrarily deep levels of the React tree
+    and apply the styles there. This also fixes the issue where it would not be allowed to use
+    Tailwind classes on the <html> element as the <head> would be required directly bellow Tailwind.
+  */
+  it.only("should work with arbitrarily deep (in the React tree) <head> elements", () => {
+    expect(
+      render(
+        <Tailwind>
+          <html lang="en">
+            <head />
+            <body>
+              <div className="bg-red-200 sm:bg-red-300 md:bg-red-400 lg:bg-red-500" />
+            </body>
+          </html>
+        </Tailwind>,
+      ),
+    ).toMatchInlineSnapshot(
+      '"<html lang=\\"en\\"><head><style>@media(min-width:640px){.sm_bg-red-300{background-color:rgb(252,165,165)!important}}@media(min-width:768px){.md_bg-red-400{background-color:rgb(248,113,113)!important}}@media(min-width:1024px){.lg_bg-red-500{background-color:rgb(239,68,68)!important}}</style></head><body><div class=\\"sm_bg-red-300 md_bg-red-400 lg_bg-red-500\\" style=\\"background-color:rgb(254,202,202)\\"></div></body></html>"',
+    );
+
+    const MyHead = (props: Record<string, any>) => {
+      return <head {...props} />;
+    }
+
+    expect(
+      render(
+        <Tailwind>
+          <html lang="en">
+            <MyHead />
+            <body>
+              <div className="bg-red-200 sm:bg-red-300 md:bg-red-400 lg:bg-red-500" />
+            </body>
+          </html>
+        </Tailwind>,
+      ),
+    ).toMatchInlineSnapshot(
+      '"<html lang=\\"en\\"><head><style>@media(min-width:640px){.sm_bg-red-300{background-color:rgb(252,165,165)!important}}@media(min-width:768px){.md_bg-red-400{background-color:rgb(248,113,113)!important}}@media(min-width:1024px){.lg_bg-red-500{background-color:rgb(239,68,68)!important}}</style></head><body><div class=\\"sm_bg-red-300 md_bg-red-400 lg_bg-red-500\\" style=\\"background-color:rgb(254,202,202)\\"></div></body></html>"',
+    );
+  });
+
   it("should add css to <head/> and keep responsive class names", () => {
     const actualOutput = render(
       <html lang="en">

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -149,7 +149,7 @@ describe("Responsive styles", () => {
     and apply the styles there. This also fixes the issue where it would not be allowed to use
     Tailwind classes on the <html> element as the <head> would be required directly bellow Tailwind.
   */
-  it.only("should work with arbitrarily deep (in the React tree) <head> elements", () => {
+  it("should work with arbitrarily deep (in the React tree) <head> elements", () => {
     expect(
       render(
         <Tailwind>
@@ -205,17 +205,16 @@ describe("Responsive styles", () => {
   it("should throw an error when used without a <head/>", () => {
     function noHead() {
       render(
-        <html lang="en">
-          <Tailwind>
+        <Tailwind>
+          <html lang="en">
             {/* <Head></Head> */}
             <div className="bg-red-200 sm:bg-red-500" />
-          </Tailwind>
-        </html>,
+          </html>
+        </Tailwind>
+        ,
       );
     }
-    expect(noHead).toThrowErrorMatchingInlineSnapshot(
-      `"Tailwind: To use responsive styles you must have a <head> element as a direct child of the Tailwind component."`,
-    );
+    expect(noHead).toThrowErrorMatchingSnapshot();
   });
 
   it("should persist existing <head/> elements", () => {

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -28,10 +28,31 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
     (style) => style.trim().length > 0,
   );
 
+  const hasNonInlineStylesToApply = nonInlineStylesToApply.length > 0;
+  let hasAppliedNonInlineStyles = false as boolean;
+
   function processElement(
     element: React.ReactElement<EmailElementProps>,
   ): React.ReactElement<EmailElementProps> {
     const propsToOverwrite = {} as Partial<EmailElementProps>;
+
+    if (!hasAppliedNonInlineStyles && hasNonInlineStylesToApply) {
+      if (element.type === "head") {
+        hasAppliedNonInlineStyles = true;
+
+        /*                   only minify here since it is the only place that is going to be in the DOM */
+        const styleElement = (
+          <style>{minifyCss(nonInlineStylesToApply.join(""))}</style>
+        );
+
+        return React.cloneElement(
+          element,
+          element.props,
+          element.props.children,
+          styleElement,
+        );
+      }
+    }
 
     if (element.props.children) {
       propsToOverwrite.children = React.Children.map(
@@ -94,36 +115,10 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
     return React.cloneElement(element, newProps, newChildren);
   }
 
-  const hasNonInlineStylesToApply = nonInlineStylesToApply.length > 0;
-  let hasAppliedNonInlineStyles = false as boolean;
-
   const childrenArray =
     React.Children.map(children, (child) => {
       if (React.isValidElement<EmailElementProps>(child)) {
         const element = child;
-
-        if (!hasAppliedNonInlineStyles && hasNonInlineStylesToApply) {
-          if (
-            element.type === "head" ||
-            (typeof element.type === "function" &&
-              "name" in element.type &&
-              element.type.name === "Head")
-          ) {
-            hasAppliedNonInlineStyles = true;
-
-            /*                   only minify here since it is the only place that is going to be in the DOM */
-            const styleElement = (
-              <style>{minifyCss(nonInlineStylesToApply.join(""))}</style>
-            );
-
-            return React.cloneElement(
-              element,
-              element.props,
-              element.props.children,
-              styleElement,
-            );
-          }
-        }
 
         return processElement(element);
       }

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -4,7 +4,6 @@ import { useTailwindStyles } from "./hooks/use-tailwind-styles";
 import { useStyleInlining } from "./hooks/use-style-inlining";
 import { sanitizeClassName } from "./utils/compatibility/sanitize-class-name";
 import { minifyCss } from "./utils/css/minify-css";
-import { quickSafeRenderToString } from "./utils/quick-safe-render-to-string";
 
 export type TailwindConfig = Omit<TailwindOriginalConfig, "content">;
 

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -126,7 +126,9 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
 
   if (hasNonInlineStylesToApply && !hasAppliedNonInlineStyles) {
     throw new Error(
-      `You are trying to use the following Tailwind classes that have media queries: ${nonInlinableClasses.join(" ")}.
+      `You are trying to use the following Tailwind classes that have media queries: ${nonInlinableClasses.join(
+        " ",
+      )}.
 For the media queries to work properly on rendering, they need to be added into a <style> tag inside of a <head> tag,
 the Tailwind component tried finding a <head> element but just wasn't able to find it.
 

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -4,6 +4,7 @@ import { useTailwindStyles } from "./hooks/use-tailwind-styles";
 import { useStyleInlining } from "./hooks/use-style-inlining";
 import { sanitizeClassName } from "./utils/compatibility/sanitize-class-name";
 import { minifyCss } from "./utils/css/minify-css";
+import { quickSafeRenderToString } from "./utils/quick-safe-render-to-string";
 
 export type TailwindConfig = Omit<TailwindOriginalConfig, "content">;
 
@@ -126,7 +127,13 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
 
   if (hasNonInlineStylesToApply && !hasAppliedNonInlineStyles) {
     throw new Error(
-      "Tailwind: To use responsive styles you must have a <head> element as a direct child of the Tailwind component.",
+      `You are trying to use the following Tailwind classes that have media queries: ${nonInlinableClasses.join(" ")}.
+For the media queries to work properly on rendering, they need to be added into a <style> tag inside of a <head> tag,
+the Tailwind component tried finding a <head> element but just wasn't able to find it.
+
+Make sure that you have either a <head> element at some point inside of the <Tailwind> component at any depth.
+
+If you do already have a <head> element at some depth, please file a bug https://github.com/resend/react-email/issues/new?assignees=&labels=Type%3A+Bug&projects=&template=1.bug_report.yml.`,
     );
   }
 


### PR DESCRIPTION
## Background

After the Tailwind performance improvements, we changed things so that the
requirement for the `<head>` element being there — when using Tailwind classes that
had media queries — went from being

> You need to have a `<html>` followed by a `<head>` element or `<Head>` component

to being

> You need a `<head>` directly bellow your `<tailwind>` component

This change was for two reasons mostly:

1. To avoid having to execute regexes on the rendered markup to determine if the 
elements were included
2. To making the error message more clear while still being concise

This ended up causing two issues: 

1. You just could not use Tailwind classes on your `<Html>` tag anymore
2. Upon being minifying the function's name for our `<Head>` component would be changed
to something other than "Head" which ended up breaking our check for the `<Head>` component
    * The one reported at #1112.

## How does this fix the issue?

This fixes the issue by keeping track of whether the `<head>` element was found
and if the non-inlinable styles — currently Tailwind classes with media 
queries — were applied to it. The solution also required that I changed
the current error message, as it just didn't apply anymore, and make it a bit more
detailed to whoever is having it.

This solution is also not a breaking change, actually it's more backwards compatible
than the one after the performance improvements.

## How can I make sure that it's fixed?

I've added in a unit test with a detailed comment to the code that ensures
that the Tailwind component still applies the styles without throwing
the error. It tests for a custom component that contains the `<head>` element,
and it tests with it inside a `<html>` inside the `<Tailwind>` component.

