### PR TITLE
feat(font): Include Roboto as a fallback font 

### DIFF
--- a/packages/font/src/font.spec.tsx
+++ b/packages/font/src/font.spec.tsx
@@ -34,7 +34,7 @@ describe("<Font> component", () => {
 
   it("renders with multiple fallback fonts", () => {
     const html = render(
-      <Font fallbackFontFamily={["Helvetica", "Verdana"]} fontFamily="Arial" />,
+      <Font fallbackFontFamily={["Helvetica", "Verdana", "Roboto"]} fontFamily="Arial" />,
     );
 
     expect(html).toContain("font-family: 'Arial', Helvetica, Verdana;");

--- a/packages/font/src/font.tsx
+++ b/packages/font/src/font.tsx
@@ -10,7 +10,8 @@ type FallbackFont =
   | "sans-serif"
   | "monospace"
   | "cursive"
-  | "fantasy";
+  | "fantasy"
+  | "Roboto";
 
 type FontFormat =
   | "woff"
@@ -56,20 +57,18 @@ export const Font: React.FC<Readonly<FontProps>> = ({
       font-family: '${fontFamily}';
       font-style: ${fontStyle};
       font-weight: ${fontWeight};
-      mso-font-alt: '${
-        Array.isArray(fallbackFontFamily)
-          ? fallbackFontFamily[0]
-          : fallbackFontFamily
-      }';
+      mso-font-alt: '${Array.isArray(fallbackFontFamily)
+      ? fallbackFontFamily[0]
+      : fallbackFontFamily
+    }';
       ${src}
     }
 
     * {
-      font-family: '${fontFamily}', ${
-        Array.isArray(fallbackFontFamily)
-          ? fallbackFontFamily.join(", ")
-          : fallbackFontFamily
-      };
+      font-family: '${fontFamily}', ${Array.isArray(fallbackFontFamily)
+      ? fallbackFontFamily.join(", ")
+      : fallbackFontFamily
+    };
     }
   `;
   return <style dangerouslySetInnerHTML={{ __html: style }} />;


### PR DESCRIPTION
Hi, 

Gmail web supports Roboto font natively, include that as a fallback option. 

Please let know if this looks good.

Thanks,
Mayank

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->
