### PR TITLE
chore(react-email, create-email, components, tailwind): Bump for canary release

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -59,7 +59,7 @@
     "@react-email/render": "0.0.12",
     "@react-email/row": "0.0.7",
     "@react-email/section": "0.0.11",
-    "@react-email/tailwind": "0.0.14",
+    "@react-email/tailwind": "0.0.15-canary.0",
     "@react-email/text": "0.0.7"
   },
   "peerDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/components",
-  "version": "0.0.16-canary.0",
+  "version": "0.0.16-canary.1",
   "description": "A collection of all components React Email.",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/create-email/package.json
+++ b/packages/create-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-email",
-  "version": "0.0.24-canary.0",
+  "version": "0.0.24-canary.1",
   "description": "The easiest way to get started with React Email",
   "main": "src/index.js",
   "type": "module",

--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -8,8 +8,8 @@
     "export": "email export"
   },
   "dependencies": {
-    "@react-email/components": "0.0.15",
-    "react-email": "2.1.0",
+    "@react-email/components": "0.0.16-canary.1",
+    "react-email": "2.1.1-canary.1",
     "react": "18.2.0"
   },
   "devDependencies": {

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -32,7 +32,7 @@
     "@radix-ui/react-slot": "1.0.2",
     "@radix-ui/react-toggle-group": "1.0.4",
     "@radix-ui/react-tooltip": "1.0.6",
-    "@react-email/components": "0.0.16-canary.0",
+    "@react-email/components": "0.0.16-canary.1",
     "@react-email/render": "0.0.12",
     "@swc/core": "1.3.101",
     "@types/react": "^18.2.0",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-email",
-  "version": "2.1.1-canary.0",
+  "version": "2.1.1-canary.1",
   "description": "A live preview of your emails right in your browser.",
   "bin": {
     "email": "./cli/index.js"

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/tailwind",
-  "version": "0.0.14",
+  "version": "0.0.15-canary.0",
   "description": "A React component to wrap emails with Tailwind CSS",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,7 +327,7 @@ importers:
         specifier: 0.0.11
         version: link:../section
       '@react-email/tailwind':
-        specifier: 0.0.14
+        specifier: 0.0.15-canary.0
         version: link:../tailwind
       '@react-email/text':
         specifier: 0.0.7
@@ -630,7 +630,7 @@ importers:
         specifier: 1.0.6
         version: 1.0.6(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
       '@react-email/components':
-        specifier: 0.0.16-canary.0
+        specifier: 0.0.16-canary.1
         version: link:../components
       '@react-email/render':
         specifier: 0.0.12


### PR DESCRIPTION
`@react-email/tailwind` -> `0.0.15-canary.0`
`react-email` -> `2.1.1-canary.1`
`@react-email/components` -> `0.0.16-canary.1`
`create-email` -> `0.0.24-canary.1`