### PR TITLE
feat(react-email): Remove existing `out` directory when running `email export`

### DIFF
--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -38,8 +38,8 @@ export const exportTemplates = async (
   options: Options,
 ) => {
   /* Delete the out directory if it already exists */
-  if (import_node_fs4.default.existsSync(pathToWhereEmailMarkupShouldBeDumped)) {
-    import_shelljs.rm('-rf', pathToWhereEmailMarkupShouldBeDumped);
+  if (fs.existsSync(pathToWhereEmailMarkupShouldBeDumped)) {
+    fs.rmSync(pathToWhereEmailMarkupShouldBeDumped, { recursive: true });
   }
   
   const spinner = ora('Preparing files...\n').start();

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -41,7 +41,7 @@ export const exportTemplates = async (
   if (fs.existsSync(pathToWhereEmailMarkupShouldBeDumped)) {
     fs.rmSync(pathToWhereEmailMarkupShouldBeDumped, { recursive: true });
   }
-  
+
   const spinner = ora('Preparing files...\n').start();
   closeOraOnSIGNIT(spinner);
 

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -37,6 +37,11 @@ export const exportTemplates = async (
   emailsDirectoryPath: string,
   options: Options,
 ) => {
+  /* Delete the out directory if it already exists */
+  if (import_node_fs4.default.existsSync(pathToWhereEmailMarkupShouldBeDumped)) {
+    import_shelljs.rm('-rf', pathToWhereEmailMarkupShouldBeDumped);
+  }
+  
   const spinner = ora('Preparing files...\n').start();
   closeOraOnSIGNIT(spinner);
 


### PR DESCRIPTION
add in code to delete the PathToWhereEmailMarkupShouldBeDumped , out by default, if it already exists to make sure the directory only displays current and correct files when exporting to remove the chance of duplications and errors.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->
