### PR TITLE
feat(react-email): Hot reloading with changes detection on dependencies of an email template

### DIFF
--- a/packages/react-email/.gitignore
+++ b/packages/react-email/.gitignore
@@ -5,5 +5,6 @@ cli
 
 # for testing
 .react-email
+.for-dependency-graph.ts
 emails
 static

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -9,6 +9,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",
+    "test:watch": "vitest",
     "clean": "rm -rf dist",
     "lint": "eslint . && tsc"
   },
@@ -26,6 +27,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@babel/parser": "7.24.1",
     "@radix-ui/colors": "1.0.1",
     "@radix-ui/react-collapsible": "1.0.3",
     "@radix-ui/react-popover": "1.0.7",
@@ -39,6 +41,7 @@
     "@types/react-dom": "^18.2.0",
     "@types/webpack": "5.28.5",
     "autoprefixer": "10.4.14",
+    "babel-walk": "3.0.0",
     "chalk": "4.1.2",
     "chokidar": "3.5.3",
     "clsx": "2.1.0",

--- a/packages/react-email/src/cli/commands/dev.ts
+++ b/packages/react-email/src/cli/commands/dev.ts
@@ -18,7 +18,7 @@ export const dev = async ({ dir: emailsDirRelativePath, port }: Args) => {
       parseInt(port),
     );
 
-    setupHotreloading(devServer, emailsDirRelativePath);
+    await setupHotreloading(devServer, emailsDirRelativePath);
   } catch (error) {
     console.log(error);
     process.exit(1);

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.spec.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.spec.ts
@@ -42,7 +42,7 @@ test('createDependencyGraph()', async () => {
     'create-dependency-graph.ts': {
       path: 'create-dependency-graph.ts',
       dependencyPaths: ['get-imported-modules.ts'],
-      dependentPaths: ['create-dependency-graph.spec.ts'],
+      dependentPaths: ['create-dependency-graph.spec.ts', 'setup-hot-reloading.ts'],
       moduleDependencies: ['node:path', 'node:fs'],
     },
     'create-dependency-graph.spec.ts': {
@@ -68,7 +68,7 @@ test('createDependencyGraph()', async () => {
     },
     'setup-hot-reloading.ts': {
       path: 'setup-hot-reloading.ts',
-      dependencyPaths: ['../../../../utils/types/hot-reload-change.ts'],
+      dependencyPaths: ['../../../../utils/types/hot-reload-change.ts', 'create-dependency-graph.ts'],
       dependentPaths: [],
       moduleDependencies: [
         'node:http',
@@ -121,7 +121,8 @@ import {} from './create-dependency-graph.ts';
         dependencyPaths: ['get-imported-modules.ts'],
         dependentPaths: [
           'create-dependency-graph.spec.ts',
-          '.for-dependency-graph.ts',
+          'setup-hot-reloading.ts',
+          '.for-dependency-graph.ts'
         ],
         moduleDependencies: ['node:path', 'node:fs'],
       },
@@ -149,7 +150,7 @@ import {} from './create-dependency-graph.ts';
       },
       'setup-hot-reloading.ts': {
         path: 'setup-hot-reloading.ts',
-        dependencyPaths: ['../../../../utils/types/hot-reload-change.ts'],
+        dependencyPaths: ['../../../../utils/types/hot-reload-change.ts', 'create-dependency-graph.ts'],
         dependentPaths: ['.for-dependency-graph.ts'],
         moduleDependencies: [
           'node:http',
@@ -198,6 +199,7 @@ import {} from './create-dependency-graph.ts';
         dependencyPaths: ['get-imported-modules.ts'],
         dependentPaths: [
           'create-dependency-graph.spec.ts',
+          'setup-hot-reloading.ts',
           '.for-dependency-graph.ts',
         ],
         moduleDependencies: ['node:path', 'node:fs'],
@@ -226,7 +228,7 @@ import {} from './create-dependency-graph.ts';
       },
       'setup-hot-reloading.ts': {
         path: 'setup-hot-reloading.ts',
-        dependencyPaths: ['../../../../utils/types/hot-reload-change.ts'],
+        dependencyPaths: ['../../../../utils/types/hot-reload-change.ts', 'create-dependency-graph.ts'],
         dependentPaths: ['.for-dependency-graph.ts'],
         moduleDependencies: [
           'node:http',

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.spec.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.spec.ts
@@ -18,19 +18,19 @@ test('createDependencyGraph()', async () => {
   const [dependencyGraph, updateDependencyGraph] =
     await createDependencyGraph(__dirname);
 
+  const toAbsolute = (relativePath: string) => {
+    return path.resolve(__dirname, relativePath);
+  };
+
   const convertPathsToAbsolute = (graph: DependencyGraph) => {
     return Object.fromEntries(
       Object.entries(graph).map(([relativePath, module]) => {
         return [
-          path.resolve(__dirname, relativePath),
+          toAbsolute(relativePath),
           {
-            path: path.resolve(__dirname, relativePath),
-            dependencyPaths: module.dependencyPaths.map((p) =>
-              path.resolve(__dirname, p),
-            ),
-            dependentPaths: module.dependentPaths.map((p) =>
-              path.resolve(__dirname, p),
-            ),
+            path: toAbsolute(relativePath),
+            dependencyPaths: module.dependencyPaths.map((p) => toAbsolute(p)),
+            dependentPaths: module.dependentPaths.map((p) => toAbsolute(p)),
             moduleDependencies: module.moduleDependencies,
           },
         ];
@@ -42,7 +42,10 @@ test('createDependencyGraph()', async () => {
     'create-dependency-graph.ts': {
       path: 'create-dependency-graph.ts',
       dependencyPaths: ['get-imported-modules.ts'],
-      dependentPaths: ['create-dependency-graph.spec.ts', 'setup-hot-reloading.ts'],
+      dependentPaths: [
+        'create-dependency-graph.spec.ts',
+        'setup-hot-reloading.ts',
+      ],
       moduleDependencies: ['node:path', 'node:fs'],
     },
     'create-dependency-graph.spec.ts': {
@@ -68,7 +71,10 @@ test('createDependencyGraph()', async () => {
     },
     'setup-hot-reloading.ts': {
       path: 'setup-hot-reloading.ts',
-      dependencyPaths: ['../../../../utils/types/hot-reload-change.ts', 'create-dependency-graph.ts'],
+      dependencyPaths: [
+        '../../../../utils/types/hot-reload-change.ts',
+        'create-dependency-graph.ts',
+      ],
       dependentPaths: [],
       moduleDependencies: [
         'node:http',
@@ -102,154 +108,57 @@ import {} from './create-dependency-graph.ts';
   );
   await updateDependencyGraph('add', pathToFileForTestingDependencyGraph);
   expect(
-    dependencyGraph,
-    'should update properly when adding new files in',
-  ).toEqual(
-    convertPathsToAbsolute({
-      '.for-dependency-graph.ts': {
-        path: 'setup-hot-reloading.ts',
-        dependencyPaths: [
-          'setup-hot-reloading.ts',
-          'get-imported-modules.ts',
-          'create-dependency-graph.ts',
-        ],
-        dependentPaths: [],
-        moduleDependencies: [],
-      },
-      'create-dependency-graph.ts': {
-        path: 'create-dependency-graph.ts',
-        dependencyPaths: ['get-imported-modules.ts'],
-        dependentPaths: [
-          'create-dependency-graph.spec.ts',
-          'setup-hot-reloading.ts',
-          '.for-dependency-graph.ts'
-        ],
-        moduleDependencies: ['node:path', 'node:fs'],
-      },
-      'create-dependency-graph.spec.ts': {
-        path: 'create-dependency-graph.spec.ts',
-        dependencyPaths: ['create-dependency-graph.ts'],
-        dependentPaths: [],
-        moduleDependencies: ['node:path', 'node:fs'],
-      },
-      'get-imported-modules.ts': {
-        path: 'get-imported-modules',
-        dependentPaths: [
-          'create-dependency-graph.ts',
-          'get-imported-modules.spec.ts',
-          '.for-dependency-graph.ts',
-        ],
-        dependencyPaths: [],
-        moduleDependencies: ['@babel/parser', 'babel-walk'],
-      },
-      'get-imported-modules.spec.ts': {
-        path: 'get-imported-modules.spec.ts',
-        dependencyPaths: ['get-imported-modules.ts'],
-        dependentPaths: [],
-        moduleDependencies: ['node:fs'],
-      },
-      'setup-hot-reloading.ts': {
-        path: 'setup-hot-reloading.ts',
-        dependencyPaths: ['../../../../utils/types/hot-reload-change.ts', 'create-dependency-graph.ts'],
-        dependentPaths: ['.for-dependency-graph.ts'],
-        moduleDependencies: [
-          'node:http',
-          'node:path',
-          'socket.io',
-          'chokidar',
-          'debounce',
-        ],
-      },
-      '../../../../utils/types/hot-reload-change.ts': {
-        path: '../../../../utils/types/hot-reload-change.ts',
-        dependencyPaths: [],
-        dependentPaths: ['setup-hot-reloading.ts'],
-        moduleDependencies: [],
-      },
-    } satisfies DependencyGraph),
-  );
+    dependencyGraph[pathToFileForTestingDependencyGraph],
+    'added file to have proper dependency paths',
+  ).toEqual({
+    path: pathToFileForTestingDependencyGraph,
+    dependentPaths: [],
+    dependencyPaths: [
+      toAbsolute('setup-hot-reloading.ts'),
+      toAbsolute('get-imported-modules.ts'),
+      toAbsolute('create-dependency-graph.ts'),
+    ],
+    moduleDependencies: [],
+  } satisfies DependencyGraph[number]);
+  expect(
+    dependencyGraph[toAbsolute('setup-hot-reloading.ts')]?.dependentPaths,
+  ).toContain(pathToFileForTestingDependencyGraph);
+  expect(
+    dependencyGraph[toAbsolute('get-imported-modules.ts')]?.dependentPaths,
+  ).toContain(pathToFileForTestingDependencyGraph);
+  expect(
+    dependencyGraph[toAbsolute('create-dependency-graph.ts')]?.dependentPaths,
+  ).toContain(pathToFileForTestingDependencyGraph);
 
   await fs.writeFile(
     pathToFileForTestingDependencyGraph,
     `
 import {} from './setup-hot-reloading';
-import {} from './get-imported-modules';
 import {} from './create-dependency-graph.ts';
 `,
     'utf8',
   );
   await updateDependencyGraph('change', pathToFileForTestingDependencyGraph);
   expect(
-    dependencyGraph,
-    'should update properly when modifying existing files',
-  ).toEqual(
-    convertPathsToAbsolute({
-      '.for-dependency-graph.ts': {
-        path: 'setup-hot-reloading.ts',
-        dependencyPaths: [
-          'setup-hot-reloading.ts',
-          'get-imported-modules.ts',
-          'create-dependency-graph.ts',
-        ],
-        dependentPaths: [],
-        moduleDependencies: [],
-      },
-      'create-dependency-graph.ts': {
-        path: 'create-dependency-graph.ts',
-        dependencyPaths: ['get-imported-modules.ts'],
-        dependentPaths: [
-          'create-dependency-graph.spec.ts',
-          'setup-hot-reloading.ts',
-          '.for-dependency-graph.ts',
-        ],
-        moduleDependencies: ['node:path', 'node:fs'],
-      },
-      'create-dependency-graph.spec.ts': {
-        path: 'create-dependency-graph.spec.ts',
-        dependencyPaths: ['create-dependency-graph.ts'],
-        dependentPaths: [],
-        moduleDependencies: ['node:path', 'node:fs'],
-      },
-      'get-imported-modules.ts': {
-        path: 'get-imported-modules',
-        dependentPaths: [
-          'create-dependency-graph.ts',
-          'get-imported-modules.spec.ts',
-          '.for-dependency-graph.ts',
-        ],
-        dependencyPaths: [],
-        moduleDependencies: ['@babel/parser', 'babel-walk'],
-      },
-      'get-imported-modules.spec.ts': {
-        path: 'get-imported-modules.spec.ts',
-        dependencyPaths: ['get-imported-modules.ts'],
-        dependentPaths: [],
-        moduleDependencies: ['node:fs'],
-      },
-      'setup-hot-reloading.ts': {
-        path: 'setup-hot-reloading.ts',
-        dependencyPaths: ['../../../../utils/types/hot-reload-change.ts', 'create-dependency-graph.ts'],
-        dependentPaths: ['.for-dependency-graph.ts'],
-        moduleDependencies: [
-          'node:http',
-          'node:path',
-          'socket.io',
-          'chokidar',
-          'debounce',
-        ],
-      },
-      '../../../../utils/types/hot-reload-change.ts': {
-        path: '../../../../utils/types/hot-reload-change.ts',
-        dependencyPaths: [],
-        dependentPaths: ['setup-hot-reloading.ts'],
-        moduleDependencies: [],
-      },
-    } satisfies DependencyGraph),
-  );
-
-  await fs.rm(pathToFileForTestingDependencyGraph);
-  await updateDependencyGraph('unlink', pathToFileForTestingDependencyGraph);
-  expect(dependencyGraph, 'should work when deleting files').toEqual(
-    initialDependencyGraph,
-  );
+    dependencyGraph[pathToFileForTestingDependencyGraph],
+    'changed file to have updated dependencyPaths',
+  ).toEqual({
+    path: pathToFileForTestingDependencyGraph,
+    dependentPaths: [],
+    dependencyPaths: [
+      toAbsolute('setup-hot-reloading.ts'),
+      toAbsolute('create-dependency-graph.ts'),
+    ],
+    moduleDependencies: [],
+  } satisfies DependencyGraph[number]);
+  expect(
+    dependencyGraph[toAbsolute('setup-hot-reloading.ts')]?.dependentPaths,
+  ).toContain(pathToFileForTestingDependencyGraph);
+  expect(
+    dependencyGraph[toAbsolute('get-imported-modules.ts')]?.dependentPaths,
+    'when removing dependency on a file, the dependency should have its dependents updated to not have the testing file again',
+  ).not.toContain(pathToFileForTestingDependencyGraph);
+  expect(
+    dependencyGraph[toAbsolute('create-dependency-graph.ts')]?.dependentPaths,
+  ).toContain(pathToFileForTestingDependencyGraph);
 });

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.spec.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.spec.ts
@@ -161,4 +161,20 @@ import {} from './create-dependency-graph.ts';
   expect(
     dependencyGraph[toAbsolute('create-dependency-graph.ts')]?.dependentPaths,
   ).toContain(pathToFileForTestingDependencyGraph);
+
+  await fs.rm(pathToFileForTestingDependencyGraph);
+  await updateDependencyGraph('unlink', pathToFileForTestingDependencyGraph);
+  expect(dependencyGraph[pathToFileForTestingDependencyGraph]).toBeUndefined();
+  expect(
+    dependencyGraph[toAbsolute('setup-hot-reloading.ts')]?.dependentPaths,
+    "should remove itself from dependents once it's unlinked",
+  ).not.toContain(pathToFileForTestingDependencyGraph);
+  expect(
+    dependencyGraph[toAbsolute('get-imported-modules.ts')]?.dependentPaths,
+    "should remove itself from dependents once it's unlinked",
+  ).not.toContain(pathToFileForTestingDependencyGraph);
+  expect(
+    dependencyGraph[toAbsolute('create-dependency-graph.ts')]?.dependentPaths,
+    "should remove itself from dependents once it's unlinked",
+  ).not.toContain(pathToFileForTestingDependencyGraph);
 });

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.spec.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.spec.ts
@@ -1,0 +1,253 @@
+import path from 'node:path';
+import { existsSync, promises as fs } from 'node:fs';
+import {
+  DependencyGraph,
+  createDependencyGraph,
+} from './create-dependency-graph';
+
+const pathToFileForTestingDependencyGraph = path.join(
+  __dirname,
+  '.for-dependency-graph.ts',
+);
+
+test('createDependencyGraph()', async () => {
+  if (existsSync(pathToFileForTestingDependencyGraph)) {
+    await fs.rm(pathToFileForTestingDependencyGraph);
+  }
+
+  const [dependencyGraph, updateDependencyGraph] =
+    await createDependencyGraph(__dirname);
+
+  const convertPathsToAbsolute = (graph: DependencyGraph) => {
+    return Object.fromEntries(
+      Object.entries(graph).map(([relativePath, module]) => {
+        return [
+          path.resolve(__dirname, relativePath),
+          {
+            path: path.resolve(__dirname, relativePath),
+            dependencyPaths: module.dependencyPaths.map((p) =>
+              path.resolve(__dirname, p),
+            ),
+            dependentPaths: module.dependentPaths.map((p) =>
+              path.resolve(__dirname, p),
+            ),
+            moduleDependencies: module.moduleDependencies,
+          },
+        ];
+      }),
+    );
+  };
+
+  const initialDependencyGraph = convertPathsToAbsolute({
+    'create-dependency-graph.ts': {
+      path: 'create-dependency-graph.ts',
+      dependencyPaths: ['get-imported-modules.ts'],
+      dependentPaths: ['create-dependency-graph.spec.ts'],
+      moduleDependencies: ['node:path', 'node:fs'],
+    },
+    'create-dependency-graph.spec.ts': {
+      path: 'create-dependency-graph.spec.ts',
+      dependencyPaths: ['create-dependency-graph.ts'],
+      dependentPaths: [],
+      moduleDependencies: ['node:path', 'node:fs'],
+    },
+    'get-imported-modules.ts': {
+      path: 'get-imported-modules',
+      dependentPaths: [
+        'create-dependency-graph.ts',
+        'get-imported-modules.spec.ts',
+      ],
+      dependencyPaths: [],
+      moduleDependencies: ['@babel/parser', 'babel-walk'],
+    },
+    'get-imported-modules.spec.ts': {
+      path: 'get-imported-modules.spec.ts',
+      dependencyPaths: ['get-imported-modules.ts'],
+      dependentPaths: [],
+      moduleDependencies: ['node:fs'],
+    },
+    'setup-hot-reloading.ts': {
+      path: 'setup-hot-reloading.ts',
+      dependencyPaths: ['../../../../utils/types/hot-reload-change.ts'],
+      dependentPaths: [],
+      moduleDependencies: [
+        'node:http',
+        'node:path',
+        'socket.io',
+        'chokidar',
+        'debounce',
+      ],
+    },
+    '../../../../utils/types/hot-reload-change.ts': {
+      path: '../../../../utils/types/hot-reload-change.ts',
+      dependencyPaths: [],
+      dependentPaths: ['setup-hot-reloading.ts'],
+      moduleDependencies: [],
+    },
+  } satisfies DependencyGraph);
+
+  expect(
+    dependencyGraph,
+    'the initial value for the dependency graph should work with the directory of this testing file',
+  ).toEqual(initialDependencyGraph);
+
+  await fs.writeFile(
+    pathToFileForTestingDependencyGraph,
+    `
+import {} from './setup-hot-reloading';
+import {} from './get-imported-modules';
+import {} from './create-dependency-graph.ts';
+`,
+    'utf8',
+  );
+  await updateDependencyGraph('add', pathToFileForTestingDependencyGraph);
+  expect(
+    dependencyGraph,
+    'should update properly when adding new files in',
+  ).toEqual(
+    convertPathsToAbsolute({
+      '.for-dependency-graph.ts': {
+        path: 'setup-hot-reloading.ts',
+        dependencyPaths: [
+          'setup-hot-reloading.ts',
+          'get-imported-modules.ts',
+          'create-dependency-graph.ts',
+        ],
+        dependentPaths: [],
+        moduleDependencies: [],
+      },
+      'create-dependency-graph.ts': {
+        path: 'create-dependency-graph.ts',
+        dependencyPaths: ['get-imported-modules.ts'],
+        dependentPaths: [
+          'create-dependency-graph.spec.ts',
+          '.for-dependency-graph.ts',
+        ],
+        moduleDependencies: ['node:path', 'node:fs'],
+      },
+      'create-dependency-graph.spec.ts': {
+        path: 'create-dependency-graph.spec.ts',
+        dependencyPaths: ['create-dependency-graph.ts'],
+        dependentPaths: [],
+        moduleDependencies: ['node:path', 'node:fs'],
+      },
+      'get-imported-modules.ts': {
+        path: 'get-imported-modules',
+        dependentPaths: [
+          'create-dependency-graph.ts',
+          'get-imported-modules.spec.ts',
+          '.for-dependency-graph.ts',
+        ],
+        dependencyPaths: [],
+        moduleDependencies: ['@babel/parser', 'babel-walk'],
+      },
+      'get-imported-modules.spec.ts': {
+        path: 'get-imported-modules.spec.ts',
+        dependencyPaths: ['get-imported-modules.ts'],
+        dependentPaths: [],
+        moduleDependencies: ['node:fs'],
+      },
+      'setup-hot-reloading.ts': {
+        path: 'setup-hot-reloading.ts',
+        dependencyPaths: ['../../../../utils/types/hot-reload-change.ts'],
+        dependentPaths: ['.for-dependency-graph.ts'],
+        moduleDependencies: [
+          'node:http',
+          'node:path',
+          'socket.io',
+          'chokidar',
+          'debounce',
+        ],
+      },
+      '../../../../utils/types/hot-reload-change.ts': {
+        path: '../../../../utils/types/hot-reload-change.ts',
+        dependencyPaths: [],
+        dependentPaths: ['setup-hot-reloading.ts'],
+        moduleDependencies: [],
+      },
+    } satisfies DependencyGraph),
+  );
+
+  await fs.writeFile(
+    pathToFileForTestingDependencyGraph,
+    `
+import {} from './setup-hot-reloading';
+import {} from './get-imported-modules';
+import {} from './create-dependency-graph.ts';
+`,
+    'utf8',
+  );
+  await updateDependencyGraph('change', pathToFileForTestingDependencyGraph);
+  expect(
+    dependencyGraph,
+    'should update properly when modifying existing files',
+  ).toEqual(
+    convertPathsToAbsolute({
+      '.for-dependency-graph.ts': {
+        path: 'setup-hot-reloading.ts',
+        dependencyPaths: [
+          'setup-hot-reloading.ts',
+          'get-imported-modules.ts',
+          'create-dependency-graph.ts',
+        ],
+        dependentPaths: [],
+        moduleDependencies: [],
+      },
+      'create-dependency-graph.ts': {
+        path: 'create-dependency-graph.ts',
+        dependencyPaths: ['get-imported-modules.ts'],
+        dependentPaths: [
+          'create-dependency-graph.spec.ts',
+          '.for-dependency-graph.ts',
+        ],
+        moduleDependencies: ['node:path', 'node:fs'],
+      },
+      'create-dependency-graph.spec.ts': {
+        path: 'create-dependency-graph.spec.ts',
+        dependencyPaths: ['create-dependency-graph.ts'],
+        dependentPaths: [],
+        moduleDependencies: ['node:path', 'node:fs'],
+      },
+      'get-imported-modules.ts': {
+        path: 'get-imported-modules',
+        dependentPaths: [
+          'create-dependency-graph.ts',
+          'get-imported-modules.spec.ts',
+          '.for-dependency-graph.ts',
+        ],
+        dependencyPaths: [],
+        moduleDependencies: ['@babel/parser', 'babel-walk'],
+      },
+      'get-imported-modules.spec.ts': {
+        path: 'get-imported-modules.spec.ts',
+        dependencyPaths: ['get-imported-modules.ts'],
+        dependentPaths: [],
+        moduleDependencies: ['node:fs'],
+      },
+      'setup-hot-reloading.ts': {
+        path: 'setup-hot-reloading.ts',
+        dependencyPaths: ['../../../../utils/types/hot-reload-change.ts'],
+        dependentPaths: ['.for-dependency-graph.ts'],
+        moduleDependencies: [
+          'node:http',
+          'node:path',
+          'socket.io',
+          'chokidar',
+          'debounce',
+        ],
+      },
+      '../../../../utils/types/hot-reload-change.ts': {
+        path: '../../../../utils/types/hot-reload-change.ts',
+        dependencyPaths: [],
+        dependentPaths: ['setup-hot-reloading.ts'],
+        moduleDependencies: [],
+      },
+    } satisfies DependencyGraph),
+  );
+
+  await fs.rm(pathToFileForTestingDependencyGraph);
+  await updateDependencyGraph('unlink', pathToFileForTestingDependencyGraph);
+  expect(dependencyGraph, 'should work when deleting files').toEqual(
+    initialDependencyGraph,
+  );
+});

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
@@ -91,7 +91,9 @@ export const createDependencyGraph = async (directory: string) => {
             for it being a javascript module fails, then we can assume it has the same as the `filePath`
           */
           if (!isJavascriptModule(pathToDependencyFromDirectory)) {
-            pathToDependencyFromDirectory = `${pathToDependencyFromDirectory}${path.extname(filePath)}`;
+            pathToDependencyFromDirectory = `${pathToDependencyFromDirectory}${path.extname(
+              filePath,
+            )}`;
           }
 
           return pathToDependencyFromDirectory;

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
@@ -181,11 +181,11 @@ export const createDependencyGraph = async (directory: string) => {
     const module = graph[filePath];
     if (module) {
       for (const dependencyPath of module.dependencyPaths) {
-        if (dependencyPath in graph) {
+        if (graph[dependencyPath]) {
           graph[dependencyPath]!.dependentPaths = graph[
             dependencyPath
           ]!.dependentPaths.filter(
-            (dependentPath) => dependentPath !== dependencyPath,
+            (dependentPath) => dependentPath !== filePath,
           );
         }
       }

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
@@ -1,0 +1,221 @@
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import { getImportedModules } from './get-imported-modules';
+
+interface Module {
+  path: string;
+
+  dependencyPaths: string[];
+  dependentPaths: string[];
+
+  moduleDependencies: string[];
+}
+
+export type DependencyGraph = Record</* path to module */ string, Module>;
+
+const readAllFilesInsideDirectory = async (directory: string) => {
+  let allFilePaths: string[] = [];
+
+  const topLevelDirents = await fs.readdir(directory, { withFileTypes: true });
+
+  for await (const dirent of topLevelDirents) {
+    const pathToDirent = path.join(directory, dirent.name);
+    if (dirent.isDirectory()) {
+      allFilePaths = allFilePaths.concat(
+        await readAllFilesInsideDirectory(pathToDirent),
+      );
+    } else {
+      allFilePaths.push(pathToDirent);
+    }
+  }
+
+  return allFilePaths;
+};
+
+const isJavascriptModule = (filePath: string) => {
+  const extensionName = path.extname(filePath);
+
+  return ['.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs'].includes(extensionName);
+};
+
+/**
+ * Creates a stateful dependency graph that is structured in a way that you can get
+ * the dependents of a module from its path.
+ *
+ * Stateful in the sense that it provides a `getter` and an "`updater`". The updater
+ * will receive changes to the files, that can be perceived through some file watching mechanism,
+ * so that it doesn't need to recompute the entire dependency graph but only the parts changed.
+ */
+export const createDependencyGraph = async (directory: string) => {
+  const filePaths = await readAllFilesInsideDirectory(directory);
+  const modulePaths = filePaths.filter(isJavascriptModule);
+  const graph: DependencyGraph = Object.fromEntries(
+    modulePaths.map((path) => [
+      path,
+      {
+        path,
+        dependencyPaths: [],
+        dependentPaths: [],
+        moduleDependencies: [],
+      },
+    ]),
+  );
+
+  const addModuleToGraph = async (filePath: string) => {
+    if (!graph[filePath]) {
+      graph[filePath] = {
+        path: filePath,
+        dependencyPaths: [],
+        dependentPaths: [],
+        moduleDependencies: [],
+      }
+    }
+    const contents = await fs.readFile(filePath, 'utf8');
+
+    const importedPaths = getImportedModules(contents);
+    const importedPathsRelativeToDirectory = importedPaths.map(
+      (dependencyPath) => {
+        const isModulePath = !dependencyPath.startsWith('.');
+        /*
+          path.isAbsolute will return false if the path looks like JavaScript module imports
+          e.g. path.isAbsolute('react-dom/server') will return false, but for our purposes this
+          path is not a relative one.
+        */
+        if (!isModulePath && !path.isAbsolute(dependencyPath)) {
+          let pathToDependencyFromDirectory = path.resolve(
+            /*
+              path.resolve resolves paths differently from what imports on javascript do.
+
+              So if we wouldn't do this, for an email at "/path/to/email.tsx" with a dependecy path of "./other-email" 
+              would end up going into /path/to/email.tsx/other-email instead of /path/to/other-email which is the
+              one the import is meant to go to
+            */
+            path.dirname(filePath),
+            dependencyPath,
+          );
+
+          /*
+            If the path to the dependency does not include a file extension, such that our check
+            for it being a javascript module fails, then we can assume it has the same as the `filePath`
+          */
+          if (!isJavascriptModule(pathToDependencyFromDirectory)) {
+            pathToDependencyFromDirectory = `${pathToDependencyFromDirectory}${path.extname(filePath)}`;
+          }
+
+          return pathToDependencyFromDirectory;
+        } else {
+          // when either the path is a module or is absolute
+          return dependencyPath;
+        }
+      },
+    );
+
+    graph[filePath]!.moduleDependencies =
+      importedPathsRelativeToDirectory.filter(
+        (dependencyPath) =>
+          !dependencyPath.startsWith('.') && !path.isAbsolute(dependencyPath),
+      );
+
+    const nonNodeModuleImportPathsRelativeToDirectory = importedPathsRelativeToDirectory.filter(
+      (dependencyPath) =>
+        dependencyPath.startsWith('.') || path.isAbsolute(dependencyPath),
+    )
+    for (const importPath of nonNodeModuleImportPathsRelativeToDirectory) {
+      graph[filePath]!.dependencyPaths.push(importPath);
+      if (graph[importPath]) {
+        graph[importPath]!.dependentPaths.push(filePath);
+      } else {
+        /*
+          This import path might have not been initialized as it can be outside
+          of the original directory.
+        */
+        graph[importPath] = {
+          path: importPath,
+          moduleDependencies: [],
+          dependencyPaths: [],
+          dependentPaths: [filePath],
+        };
+      }
+    }
+  };
+
+  for (const filePath of modulePaths) {
+    await addModuleToGraph(filePath);
+  }
+
+  const removeModuleFromGraph = (filePath: string) => {
+    const module = graph[filePath];
+    if (module) {
+      for (const dependentPath of module.dependentPaths) {
+        const dependentModule = graph[dependentPath];
+        if (dependentModule) {
+          dependentModule.dependencyPaths =
+            dependentModule.dependencyPaths.filter(
+              (dependencyPath) => dependencyPath !== filePath,
+            );
+        }
+      }
+      for (const dependencyPath of module.dependencyPaths) {
+        const dependencyModule = graph[dependencyPath];
+        if (dependencyModule) {
+          dependencyModule.dependentPaths =
+            dependencyModule.dependentPaths.filter(
+              (dependentPath) => dependentPath !== filePath,
+            );
+        }
+      }
+      delete graph[filePath];
+    }
+  };
+
+  return [
+    graph,
+    /**
+      * @param pathToModified - A path relative to the previosuly provided {@link directory}.
+      */
+    async (
+      event: 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir',
+      pathToModified: string,
+    ) => {
+      switch (event) {
+        case 'change':
+          if (isJavascriptModule(pathToModified)) {
+            if (graph[pathToModified] !== undefined) {
+              removeModuleFromGraph(pathToModified);
+            }
+
+            await addModuleToGraph(pathToModified);
+          }
+          break;
+        case 'add':
+          if (isJavascriptModule(pathToModified)) {
+            await addModuleToGraph(pathToModified);
+          }
+          break;
+        case 'addDir':
+          const filesInsideAddedDirectory =
+            await readAllFilesInsideDirectory(pathToModified);
+          const modulesInsideAddedDirectory =
+            filesInsideAddedDirectory.filter(isJavascriptModule);
+          for await (const filePath of modulesInsideAddedDirectory) {
+            await addModuleToGraph(filePath);
+          }
+          break;
+        case 'unlink':
+          if (isJavascriptModule(pathToModified)) {
+            removeModuleFromGraph(pathToModified);
+          }
+          break;
+        case 'unlinkDir':
+          const filesInsideDeletedDirectory =
+            await readAllFilesInsideDirectory(pathToModified);
+          const modulesInsideDeletedDirectory =
+            filesInsideDeletedDirectory.filter(isJavascriptModule);
+          for await (const filePath of modulesInsideDeletedDirectory) {
+            removeModuleFromGraph(filePath);
+          }
+          break;
+      }
+    },
+  ] as const;
+};

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/get-imported-modules.spec.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/get-imported-modules.spec.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'node:fs';
-import { getImportedModules } from "./get-imported-modules";
+import { getImportedModules } from './get-imported-modules';
 
 describe('getImportedModules()', () => {
   it('should work with this test file', async () => {
@@ -7,8 +7,8 @@ describe('getImportedModules()', () => {
 
     expect(getImportedModules(contents)).toEqual([
       'node:fs',
-      './get-imported-modules'
-    ])
+      './get-imported-modules',
+    ]);
   });
 
   it('should work with regular imports and double quotes', () => {
@@ -38,7 +38,7 @@ import * as React from "react";
       '@react-email/tailwind',
       '../../my-component',
       'react',
-    ])
+    ]);
   });
 
   it('should work with regular imports and single quotes', () => {
@@ -68,7 +68,7 @@ import * as React from 'react';
       '@react-email/tailwind',
       '../../my-component',
       'react',
-    ])
+    ]);
   });
 
   it('should work with commonjs require with double quotes', () => {
@@ -98,7 +98,7 @@ const React = require("react");
       '@react-email/tailwind',
       '../../my-component',
       'react',
-    ])
+    ]);
   });
 
   it('should work with commonjs require with single quotes', () => {
@@ -128,6 +128,6 @@ const React = require('react');
       '@react-email/tailwind',
       '../../my-component',
       'react',
-    ])
+    ]);
   });
 });

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/get-imported-modules.spec.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/get-imported-modules.spec.ts
@@ -1,0 +1,133 @@
+import { promises as fs } from 'node:fs';
+import { getImportedModules } from "./get-imported-modules";
+
+describe('getImportedModules()', () => {
+  it('should work with this test file', async () => {
+    const contents = await fs.readFile(__filename, 'utf8');
+
+    expect(getImportedModules(contents)).toEqual([
+      'node:fs',
+      './get-imported-modules'
+    ])
+  });
+
+  it('should work with regular imports and double quotes', () => {
+    const contents = `import {
+  Body,
+  Button,
+  Container,
+  Column,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Row,
+  Section,
+  Text,
+} from "@react-email/components";
+import { Tailwind } from "@react-email/tailwind";
+import { Component } from '../../my-component';
+
+import * as React from "react";
+    `;
+    expect(getImportedModules(contents)).toEqual([
+      '@react-email/components',
+      '@react-email/tailwind',
+      '../../my-component',
+      'react',
+    ])
+  });
+
+  it('should work with regular imports and single quotes', () => {
+    const contents = `import {
+  Body,
+  Button,
+  Container,
+  Column,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Row,
+  Section,
+  Text,
+} from '@react-email/components';
+import { Tailwind } from '@react-email/tailwind';
+import { Component } from '../../my-component';
+
+import * as React from 'react';
+    `;
+    expect(getImportedModules(contents)).toEqual([
+      '@react-email/components',
+      '@react-email/tailwind',
+      '../../my-component',
+      'react',
+    ])
+  });
+
+  it('should work with commonjs require with double quotes', () => {
+    const contents = `const {
+  Body,
+  Button,
+  Container,
+  Column,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Row,
+  Section,
+  Text,
+} = require("@react-email/components");
+const { Tailwind } = require("@react-email/tailwind");
+const { Component } = require("../../my-component");
+
+const React = require("react");
+    `;
+    expect(getImportedModules(contents)).toEqual([
+      '@react-email/components',
+      '@react-email/tailwind',
+      '../../my-component',
+      'react',
+    ])
+  });
+
+  it('should work with commonjs require with single quotes', () => {
+    const contents = `const {
+  Body,
+  Button,
+  Container,
+  Column,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Row,
+  Section,
+  Text,
+} = require('@react-email/components');
+const { Tailwind } = require('@react-email/tailwind');
+const { Component } = require('../../my-component');
+
+const React = require('react');
+    `;
+    expect(getImportedModules(contents)).toEqual([
+      '@react-email/components',
+      '@react-email/tailwind',
+      '../../my-component',
+      'react',
+    ])
+  });
+});

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/get-imported-modules.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/get-imported-modules.ts
@@ -14,7 +14,7 @@ const importVisitor = walk.simple<string[]>({
         }
       }
     }
-  }
+  },
 });
 
 export const getImportedModules = (contents: string) => {
@@ -23,10 +23,7 @@ export const getImportedModules = (contents: string) => {
     sourceType: 'unambiguous',
     strictMode: false,
     errorRecovery: true,
-    plugins: [
-      "jsx",
-      "typescript"
-    ]
+    plugins: ['jsx', 'typescript'],
   });
 
   importVisitor(parsedContents, importedPaths);

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/get-imported-modules.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/get-imported-modules.ts
@@ -1,0 +1,35 @@
+import { parse } from '@babel/parser';
+import * as walk from 'babel-walk';
+
+const importVisitor = walk.simple<string[]>({
+  ImportDeclaration(node, importedPaths) {
+    importedPaths.push(node.source.value);
+  },
+  CallExpression(node, importedPaths) {
+    if ('name' in node.callee && node.callee.name === 'require') {
+      if (node.arguments.length === 1) {
+        const importPathNode = node.arguments[0]!;
+        if (importPathNode!.type === 'StringLiteral') {
+          importedPaths.push(importPathNode.value);
+        }
+      }
+    }
+  }
+});
+
+export const getImportedModules = (contents: string) => {
+  const importedPaths: string[] = [];
+  const parsedContents = parse(contents, {
+    sourceType: 'unambiguous',
+    strictMode: false,
+    errorRecovery: true,
+    plugins: [
+      "jsx",
+      "typescript"
+    ]
+  });
+
+  importVisitor(parsedContents, importedPaths);
+
+  return importedPaths;
+};

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/setup-hot-reloading.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/setup-hot-reloading.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { Server as SocketServer, type Socket } from 'socket.io';
 import { watch } from 'chokidar';
 import debounce from 'debounce';
-import type { HotReloadChange } from '../../../utils/types/hot-reload-change';
+import type { HotReloadChange } from '../../../../utils/types/hot-reload-change';
 
 export const setupHotreloading = (
   devServer: http.Server,

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/setup-hot-reloading.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/setup-hot-reloading.ts
@@ -47,7 +47,10 @@ export const setupHotreloading = async (
     changes = [];
   }, 150);
 
-  const absolutePathToEmailsDirectory = path.resolve(process.cwd(), emailDirRelativePath);
+  const absolutePathToEmailsDirectory = path.resolve(
+    process.cwd(),
+    emailDirRelativePath,
+  );
   const [dependencyGraph, updateDependencyGraph] = await createDependencyGraph(
     absolutePathToEmailsDirectory,
   );
@@ -57,7 +60,10 @@ export const setupHotreloading = async (
     if (file.length === 0) {
       return;
     }
-    const pathToChangeTarget = path.resolve(process.cwd(), relativePathToChangeTarget);
+    const pathToChangeTarget = path.resolve(
+      process.cwd(),
+      relativePathToChangeTarget,
+    );
     await updateDependencyGraph(event, pathToChangeTarget);
 
     changes.push({

--- a/packages/react-email/src/cli/utils/preview/index.ts
+++ b/packages/react-email/src/cli/utils/preview/index.ts
@@ -1,2 +1,2 @@
-export * from './setup-hot-reloading';
+export * from './hot-reloading/setup-hot-reloading';
 export * from './start-dev-server';

--- a/packages/react-email/src/cli/utils/tree.spec.ts
+++ b/packages/react-email/src/cli/utils/tree.spec.ts
@@ -3,10 +3,10 @@ import { tree } from './tree';
 test('tree(__dirname, 2)', async () => {
   expect(await tree(__dirname, 2)).toMatchInlineSnapshot(`"utils
 ├── preview
+│   ├── hot-reloading
 │   ├── get-env-variables-for-preview-app.ts
 │   ├── index.ts
 │   ├── serve-static-file.ts
-│   ├── setup-hot-reloading.ts
 │   └── start-dev-server.ts
 ├── close-ora-on-sigint.ts
 ├── index.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 patchedDependencies:
   postcss-css-variables@0.19.0:
     hash: 2wxqv7k2gzlwmmem3fifiqjawa
@@ -38,7 +42,7 @@ importers:
         version: link:packages/tsconfig
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.3.101)(postcss@8.4.35)(typescript@5.1.6)
+        version: 7.2.0(typescript@5.1.6)
       turbo:
         specifier: 1.11.3
         version: 1.11.3
@@ -136,7 +140,7 @@ importers:
         version: link:../../packages/tsconfig
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.3.101)(postcss@8.4.35)(typescript@5.1.6)
+        version: 7.2.0(postcss@8.4.31)(typescript@5.1.6)
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -236,7 +240,7 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.3.101)(postcss@8.4.35)(typescript@5.1.6)
+        version: 7.2.0(typescript@5.1.6)
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -607,6 +611,9 @@ importers:
 
   packages/react-email:
     dependencies:
+      '@babel/parser':
+        specifier: 7.24.1
+        version: 7.24.1
       '@radix-ui/colors':
         specifier: 1.0.1
         version: 1.0.1
@@ -646,6 +653,9 @@ importers:
       autoprefixer:
         specifier: 10.4.14
         version: 10.4.14(postcss@8.4.35)
+      babel-walk:
+        specifier: 3.0.0
+        version: 3.0.0
       chalk:
         specifier: 4.1.2
         version: 4.1.2
@@ -1130,20 +1140,20 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
-  /@babel/parser@7.23.6:
-    resolution: {integrity: sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.23.6
-    dev: true
-
   /@babel/parser@7.23.9:
     resolution: {integrity: sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
       '@babel/types': 7.23.9
+
+  /@babel/parser@7.24.1:
+    resolution: {integrity: sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.23.9
+    dev: false
 
   /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.23.9):
     resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
@@ -3898,7 +3908,7 @@ packages:
   /@vue/compiler-core@3.3.9:
     resolution: {integrity: sha512-+/Lf68Vr/nFBA6ol4xOtJrW+BQWv3QWKfRwGSm70jtXwfhZNF4R/eRgyVJYoxFRhdCTk/F6g99BP0ffPgZihfQ==}
     dependencies:
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.23.9
       '@vue/shared': 3.3.9
       estree-walker: 2.0.2
       source-map-js: 1.0.2
@@ -4333,6 +4343,13 @@ packages:
     dependencies:
       dequal: 2.0.3
     dev: true
+
+  /babel-walk@3.0.0:
+    resolution: {integrity: sha512-fdRxJkQ9MUSEi4jH2DcV3FAPFktk0wefilxrwNyUuWpoWawQGN7G7cB+fOYTtFfI6XNkFgwqJ/D3G18BoJJ/jg==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@babel/types': 7.23.9
+    dev: false
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -7799,6 +7816,23 @@ packages:
       camelcase-css: 2.0.1
       postcss: 8.4.35
 
+  /postcss-load-config@4.0.1(postcss@8.4.31):
+    resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.1.0
+      postcss: 8.4.31
+      yaml: 2.3.2
+    dev: true
+
   /postcss-load-config@4.0.1(postcss@8.4.35):
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
@@ -7841,7 +7875,6 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: false
 
   /postcss@8.4.35:
     resolution: {integrity: sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==}
@@ -9120,6 +9153,79 @@ packages:
       - ts-node
     dev: true
 
+  /tsup@7.2.0(postcss@8.4.31)(typescript@5.1.6):
+    resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
+    engines: {node: '>=16.14'}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.1.0'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      bundle-require: 4.0.2(esbuild@0.18.20)
+      cac: 6.7.14
+      chokidar: 3.5.3
+      debug: 4.3.4
+      esbuild: 0.18.20
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      postcss: 8.4.31
+      postcss-load-config: 4.0.1(postcss@8.4.31)
+      resolve-from: 5.0.0
+      rollup: 3.29.4
+      source-map: 0.8.0-beta.0
+      sucrase: 3.34.0
+      tree-kill: 1.2.2
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
+
+  /tsup@7.2.0(typescript@5.1.6):
+    resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
+    engines: {node: '>=16.14'}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.1.0'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      bundle-require: 4.0.2(esbuild@0.18.20)
+      cac: 6.7.14
+      chokidar: 3.5.3
+      debug: 4.3.4
+      esbuild: 0.18.20
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      postcss-load-config: 4.0.1(postcss@8.4.31)
+      resolve-from: 5.0.0
+      rollup: 3.29.4
+      source-map: 0.8.0-beta.0
+      sucrase: 3.34.0
+      tree-kill: 1.2.2
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
+
   /tsutils@3.21.0(typescript@5.1.6):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -10213,7 +10319,3 @@ packages:
     optionalDependencies:
       commander: 9.4.1
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Background

Our hot reloading currenlty works in the following way:

1. The user makes a change inside of the `emails` directory
2. `chokidar` detects it
3. We do a bit of debouncing to batch these changes together
4. We send them, through `socket.io`, into our preview Next app

Then in the Next app, we have a hook — specifically `useHotreload` — which receives
all the changes and then checks for email templates it knows exists to re-build
and re-render them.

## What is this for?

This is mostly intended for #1366. It makes it so that, once a dependency of an email template changes,
the email template hot reloads. This improves the experience a bit more for users that have
separate components that they re-use across email templates.

Take the following email file structure:

```bash
emails/
├── _components
│   └── my-component.tsx
└── my-email.tsx
```

Before this PR, if the user would change the component at `emails/_components/my-component.tsx`, even
if it was imported inside `emails/my-email.tsx`, the email was not hot-reloaded for the user.
After this PR, this email template should be hot reloaded once this dependency changes.

## What does it change?

It adds a new `createDependencyGraph` utility that is stateful across chokidar detected changes
that allows for triggering changes for all the dependents of the changed path.
Along with this utility, I also added a few tests to ensure that it works across the chokidar style
changes.

So if we have the same file structure I mentioned before:

```bash
emails/
├── _components
│   └── my-component.tsx
└── my-email.tsx
```

And the user makes a change to `emails/_components/my-component.tsx`, chokidar will yield a change like:

```json
{
    "event": "change",
    "filename": "emails/_components/my-component.tsx"
}
```

Our dependency graph is updated with this change, and then it knows that the file at `emails/my-email.tsx`
is a dependent of this component file which allows us to also append a new change together with
the given chokidar change. So it now, it will send, through `socket.io`, into the preview app, the following:

```json
[
    {
        "event": "change",
        "filename": "emails/_components/my-component.tsx"
    },
    {
        "event": "change",
        "filename": "emails/my-email.tsx"
    },
]
```

Which then, in the preview Next app, will allow for directly hot reloading the email template that has 
this dependency.

## How can I test to make sure it is fixed?

First for setting things up:

1. Create a new file under `apps/demo/emails/_components/test.tsx` 
2. Add something like the following to its contents:
```tsx
export const Test = () => {
  return <h1>hello</h1>;
}
```
3. Import this component into any email template
4. Add the component inside the email template
5. Run `tsx ../../packages/react-email/src/cli/index.ts dev` inside of `apps/demo`
6. Open http://localhost:3000

To check if the hot reloading will work with changing the testing component:
1. Update the testing component file under `apps/demo/emails/_components/test.tsx` 
2. See that the email template has been changed accordingly

To check if the hot reloading will work when deleting the testing component:
1. Delete the component
2. See that the email template has hot reloaded with the error overlay saying that it can't find the testing component
