### PR TITLE
fix(tailwind): Root non-valid element nodes not rendering

### DIFF
--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -28,11 +28,13 @@ describe("Tailwind component", () => {
         <Button className="mt-8 rounded-md bg-blue-600 px-3 py-2 text-sm text-gray-200">
           Testing button
         </Button>
+        
+        Testing
       </Tailwind>,
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<a style=\\"line-height:1.25rem;text-decoration:none;display:inline-block;max-width:100%;margin-top:2rem;border-radius:0.375rem;background-color:rgb(37,99,235);padding-left:0.75rem;padding-right:0.75rem;padding-top:0.5rem;padding-bottom:0.5rem;font-size:0.875rem;color:rgb(229,231,235);padding:8px 12px 8px 12px\\" target=\\"_blank\\"><span><!--[if mso]><i style=\\"letter-spacing: 12px;mso-font-width:-100%;mso-text-raise:12\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:6px\\">Testing button</span><span><!--[if mso]><i style=\\"letter-spacing: 12px;mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a>"`,
+      `"<a style=\\"line-height:1.25rem;text-decoration:none;display:inline-block;max-width:100%;margin-top:2rem;border-radius:0.375rem;background-color:rgb(37,99,235);padding-left:0.75rem;padding-right:0.75rem;padding-top:0.5rem;padding-bottom:0.5rem;font-size:0.875rem;color:rgb(229,231,235);padding:8px 12px 8px 12px\\" target=\\"_blank\\"><span><!--[if mso]><i style=\\"letter-spacing: 12px;mso-font-width:-100%;mso-text-raise:12\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:6px\\">Testing button</span><span><!--[if mso]><i style=\\"letter-spacing: 12px;mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a>Testing"`,
     );
   });
 

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -122,6 +122,8 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
 
         return processElement(element);
       }
+
+      return child;
     }) ?? [];
 
   if (hasNonInlineStylesToApply && !hasAppliedNonInlineStyles) {


### PR DESCRIPTION
Very simple fix here, this is an oversight after the small refactor that I did on #1351
which was causing something like:

```jsx
<Tailwind>
    Text Node

    <a href="https://git.new/email">click for a new email experience</div>
</Tailwind>
```

To end up rendering like:

```html
<a href="https://git.new/email">click for a new email experience</a>
```

Which was ignoring the root text node. The fix for this is very simple, as it was simply
a missing return from the `React.Children.map` that Tailwind currently does.
