### PR TITLE
chore(components, create-email, mardown, react-email): Bump for stable release

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -54,7 +54,7 @@
     "@react-email/html": "0.0.7",
     "@react-email/img": "0.0.7",
     "@react-email/link": "0.0.7",
-    "@react-email/markdown": "0.0.9-canary.0",
+    "@react-email/markdown": "0.0.9",
     "@react-email/preview": "0.0.8",
     "@react-email/render": "0.0.12",
     "@react-email/row": "0.0.7",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -59,7 +59,7 @@
     "@react-email/render": "0.0.12",
     "@react-email/row": "0.0.7",
     "@react-email/section": "0.0.11",
-    "@react-email/tailwind": "0.0.15-canary.1",
+    "@react-email/tailwind": "0.0.15",
     "@react-email/text": "0.0.7"
   },
   "peerDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/components",
-  "version": "0.0.16-canary.1",
+  "version": "0.0.16",
   "description": "A collection of all components React Email.",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/create-email/package.json
+++ b/packages/create-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-email",
-  "version": "0.0.24-canary.1",
+  "version": "0.0.24",
   "description": "The easiest way to get started with React Email",
   "main": "src/index.js",
   "type": "module",

--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -8,7 +8,7 @@
     "export": "email export"
   },
   "dependencies": {
-    "@react-email/components": "0.0.16-canary.1",
+    "@react-email/components": "0.0.16",
     "react-email": "2.1.1-canary.1",
     "react": "18.2.0"
   },

--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@react-email/components": "0.0.16",
-    "react-email": "2.1.1-canary.1",
+    "react-email": "2.1.1",
     "react": "18.2.0"
   },
   "devDependencies": {

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/markdown",
-  "version": "0.0.9-canary.0",
+  "version": "0.0.9",
   "description": "Convert Markdown to valid React Email template code.",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -34,7 +34,7 @@
     "@radix-ui/react-slot": "1.0.2",
     "@radix-ui/react-toggle-group": "1.0.4",
     "@radix-ui/react-tooltip": "1.0.6",
-    "@react-email/components": "0.0.16-canary.1",
+    "@react-email/components": "0.0.16",
     "@react-email/render": "0.0.12",
     "@swc/core": "1.3.101",
     "@types/react": "^18.2.0",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-email",
-  "version": "2.1.1-canary.1",
+  "version": "2.1.1",
   "description": "A live preview of your emails right in your browser.",
   "bin": {
     "email": "./cli/index.js"

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/tailwind",
-  "version": "0.0.15-canary.1",
+  "version": "0.0.15",
   "description": "A React component to wrap emails with Tailwind CSS",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,7 +312,7 @@ importers:
         specifier: 0.0.7
         version: link:../link
       '@react-email/markdown':
-        specifier: 0.0.9-canary.0
+        specifier: 0.0.9
         version: link:../markdown
       '@react-email/preview':
         specifier: 0.0.8
@@ -327,7 +327,7 @@ importers:
         specifier: 0.0.11
         version: link:../section
       '@react-email/tailwind':
-        specifier: 0.0.15-canary.1
+        specifier: 0.0.15
         version: link:../tailwind
       '@react-email/text':
         specifier: 0.0.7
@@ -633,7 +633,7 @@ importers:
         specifier: 1.0.6
         version: 1.0.6(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
       '@react-email/components':
-        specifier: 0.0.16-canary.1
+        specifier: 0.0.16
         version: link:../components
       '@react-email/render':
         specifier: 0.0.12


### PR DESCRIPTION
- **chore(tailwind): Bump to 0.0.15**
- **chore(components): Bump dependency on @react-email/markdown to 0.0.9**
- **chore(components): Bump dependency on @react-email/tailwind to 0.0.15**
- **chore(components): Bump to 0.0.16**
- **chore(react-email): Bump dependency on @react-email/components to 0.0.16**
- **chore(react-email): Bump to 2.1.1**
- **chore(create-email): Bump template's dependency on @react-email/components to 0.0.16**
- **chore(create-email): Bump template's dependency on react-email to 2.1.1**
- **chore(create-email): Bump to 0.0.24**
- **chore(markdown): Bump to 0.0.9**
- **chore: Update lock**
