### PR TITLE
fix(create-email): Tailwind imported from @react-email/tailwind which is not installed

### DIFF
--- a/packages/create-email/template/emails/vercel-invite-user.tsx
+++ b/packages/create-email/template/emails/vercel-invite-user.tsx
@@ -13,7 +13,7 @@ import {
   Row,
   Section,
   Text,
-  Tailwind
+  Tailwind,
 } from "@react-email/components";
 import * as React from "react";
 

--- a/packages/create-email/template/emails/vercel-invite-user.tsx
+++ b/packages/create-email/template/emails/vercel-invite-user.tsx
@@ -13,8 +13,8 @@ import {
   Row,
   Section,
   Text,
+  Tailwind
 } from "@react-email/components";
-import { Tailwind } from "@react-email/tailwind";
 import * as React from "react";
 
 interface VercelInviteUserEmailProps {


### PR DESCRIPTION
The example imports Tailwind from `@react-email/tailwind` which is not install yet in package.json, so if user run the example and click `vercel-invite-user` demo, error occurs.
![image](https://github.com/resend/react-email/assets/7701032/a7e2ec55-dcb7-45fa-9bc6-fee06bc71fcc)
