### PR TITLE
fix(tailwind): Children always being transformed into an array

### DIFF
--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -54,6 +54,7 @@
     "@babel/preset-react": "7.23.3",
     "@react-email/button": "workspace:^",
     "@react-email/head": "workspace:*",
+    "@react-email/heading": "workspace:*",
     "@react-email/hr": "workspace:*",
     "@react-email/html": "workspace:*",
     "@testing-library/react": "14.0.0",

--- a/packages/tailwind/src/__snapshots__/tailwind.spec.tsx.snap
+++ b/packages/tailwind/src/__snapshots__/tailwind.spec.tsx.snap
@@ -9,3 +9,5 @@ Make sure that you have either a <head> element at some point inside of the <Tai
 
 If you do already have a <head> element at some depth, please file a bug https://github.com/resend/react-email/issues/new?assignees=&labels=Type%3A+Bug&projects=&template=1.bug_report.yml."
 `;
+
+exports[`Tailwind component > should work with Heading component 1`] = `"Hello<h1>My testing heading</h1>friends"`;

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -3,6 +3,7 @@
 import { renderToStaticMarkup as render } from "react-dom/server";
 import { Hr } from "@react-email/hr";
 import { Html } from "@react-email/html";
+import { Heading } from "@react-email/heading";
 import { Head } from "@react-email/head";
 import { Button } from "@react-email/button";
 import React from "react";
@@ -98,6 +99,20 @@ describe("Tailwind component", () => {
     expect(actualOutput).toMatchInlineSnapshot(
       `"<div style=\\"font-size:50px;line-height:1;margin-top:100px\\">Hello world</div><div style=\\"padding:20px\\"><p style=\\"font-weight:700;font-size:50px\\">React Email</p></div>"`,
     );
+  });
+
+  it("should work with Heading component", () => {
+    const EmailTemplate = () => {
+      return <Tailwind>
+        Hello
+        <Heading>
+          My testing heading
+        </Heading>
+        friends
+      </Tailwind>;
+    }
+
+    expect(render(<EmailTemplate/>)).toMatchSnapshot();
   });
 
   it("should work with components that use React.forwardRef", () => {

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -103,16 +103,16 @@ describe("Tailwind component", () => {
 
   it("should work with Heading component", () => {
     const EmailTemplate = () => {
-      return <Tailwind>
-        Hello
-        <Heading>
-          My testing heading
-        </Heading>
-        friends
-      </Tailwind>;
-    }
+      return (
+        <Tailwind>
+          Hello
+          <Heading>My testing heading</Heading>
+          friends
+        </Tailwind>
+      );
+    };
 
-    expect(render(<EmailTemplate/>)).toMatchSnapshot();
+    expect(render(<EmailTemplate />)).toMatchSnapshot();
   });
 
   it("should work with components that use React.forwardRef", () => {

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -55,7 +55,7 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
     }
 
     if (element.props.children) {
-      propsToOverwrite.children = React.Children.map(
+      const processedChillren = React.Children.map(
         element.props.children,
         (child) => {
           if (React.isValidElement<EmailElementProps>(child)) {
@@ -65,6 +65,10 @@ export const Tailwind: React.FC<TailwindProps> = ({ children, config }) => {
           return child;
         },
       );
+      propsToOverwrite.children =
+        processedChillren && processedChillren.length === 1
+          ? processedChillren[0]
+          : processedChillren;
     }
 
     if (element.props.className) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -880,6 +880,9 @@ importers:
       '@react-email/head':
         specifier: workspace:*
         version: link:../head
+      '@react-email/heading':
+        specifier: workspace:*
+        version: link:../heading
       '@react-email/hr':
         specifier: workspace:*
         version: link:../hr


### PR DESCRIPTION
I noticed that, when testing to make sure that the new canary release of Tailwind actually had
#1391 fixed after #1335 being updated with the small Tailwind refactor from before, the `<Heading>` didn't
work like when I checked before the fixing of the conflitcs.

After debugging for a while, I noticed that, since we use `radix-ui`'s `<Slot>` component on the `<Heading>`,
it expects its children to be exactly one element, not an array, meaning that our mapping of children for elements
was making the `<SlotClone>` return `null` which made the `<Heading>` not render.

The fix for the issue was very simple — just looking at the array and checking if it
has only one value inside, in which case it would return that value instead of the
whole array. Otherwise, is just returning the plain array like it should.

This then fixes the issue, and adds a unit test to make sure that these kinds of issues are 
caught before any release:

https://github.com/resend/react-email/blob/16a998a527ff42f30682c167062878f950014e96/packages/tailwind/src/tailwind.spec.tsx#L104-L116

And you can check that the snapshot actually contains the proper `<h1>` here:

https://github.com/resend/react-email/blob/16a998a527ff42f30682c167062878f950014e96/packages/tailwind/src/__snapshots__/tailwind.spec.tsx.snap#L10-L13
