### PR TITLE
feat(docs): Section for the Tailwind component's known limitations and improved style support callout

### DIFF
--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -117,7 +117,7 @@ than a class lookup.
 This is because we optimistically look into the selectors for class names
 and look them up later on the elements, and since `prose` by using more complicated selectors cannot be 
 directly inlined without resolving elements it won't work. 
-This might also mean some other utilities might not work either, like the [`space-*` utility](https://tailwindcss.com/docs/space).
+This might also means some other utilities might not work either, like the [`space-*` utility](https://tailwindcss.com/docs/space).
 
 The only exception for this inlining of styles is with media queries, as they are not inlinable. We do not
 do the same for `hover:` styles though, but since [their support is not best](https://www.caniemail.com/features/css-pseudo-class-hover/), you probably won't need it.

--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -97,6 +97,57 @@ do the same for `hover:´ styles though, but since [their support is not best](h
 In the future, we will be inlining all the styles we can by actually matching the 
 selectors *against the elements* themselves.
 
+### Limitations when trying to manipulate classes
+
+Currently, the component works, at a high level, going through the following steps:
+
+1. Do a very surface-level rendering on the children to have something resembling the HTML
+2. Run `tailwind` as a `postcss` plugin in the new fake rendered email template to generate a CSS stylesheet with all the styles of the template
+3. Generate a map of all the class names pointing to their respective styles
+4. Run recursively through all elements, and their children, by looking up class by class to add the appropriate styles to it while removing the classes
+
+The biggest cause of limitation here is going to be `1.`. Since that fake rendering process does not render
+the components, that means that, if a class name doesn't appear in the resulting HTML, it won't have
+its style either, so the class isn't removed. Here's an example:
+
+```jsx
+const Component = ({ className, style }) => {
+  console.log(className, style);
+  return <div className={`bg-red-500`} style={style} />;
+};
+
+export default function Email() {
+  return <Tailwind>
+    <Component className="bg-blue-400" />
+  </Tailwind>;
+};
+```
+
+The prop for `className` will come in as `bg-blue-400` which would seem like you can manipulate the className,
+but once you add it somewhere to the resulting HTML, like:
+
+```jsx
+const Component = ({ className, style }) => {
+  console.log(className, style);
+  return <div className={`bg-red-500 ${className}`} style={style} />;
+};
+
+export default function Email() {
+  return <Tailwind>
+    <Component className="bg-blue-400" />
+  </Tailwind>;
+};
+```
+
+The email will render with a red background and a `class="undefined"` attribute as the class will have
+been removed. This means that manipulations are very unstable at the current version. 
+
+In a future version, the behavior is going to be of resolving the styles regardless of them appearing
+in the HTML, and along with the `className` not being removed for React elements that are components,
+so that you are able to manipulate both of them at the same time.
+
+On small email templates this is most likely not going to be an issue, though.
+
 ## Props
 
 <ResponseField name="config" type="object">

--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -102,10 +102,16 @@ selectors *against the elements* themselves.
 <ResponseField name="config" type="object">
   Customize the default theme for your project with the available properties in
   [Tailwind docs](https://tailwindcss.com/docs/theme).
-  <Info>
-    <p class="my-0">Note: Most email clients are style-limited and some styles may not work.</p>
-  </Info>
 </ResponseField>
+
+<Info>
+    Most email clients are style-limited and some styles may not work.
+
+    One example of this is how Tailwind will uses `rem` as it's main unit for better accessbility. 
+    This is not going to be supported by [some email clients](https://www.caniemail.com/features/css-unit-rem/)
+    and we recommend that you define a Tailwind config to override these if you care
+    about the support for those email clients. We will not do this ourselves, though.
+</Info>
 
 ## Live example
 

--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -75,7 +75,7 @@ const Email = () => {
   Customize the default theme for your project with the available properties in
   [Tailwind docs](https://tailwindcss.com/docs/theme).
   <Info>
-    Note: Most email clients are style-limited and some styles may not work.
+    <p class="my-0">Note: Most email clients are style-limited and some styles may not work.</p>
   </Info>
 </ResponseField>
 

--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -115,8 +115,9 @@ be resolved into selectors that are relatively complex. That is, selectors with 
 than a class lookup.
 
 This is because we optimistically look into the selectors for class names
-and look them up later on the elements, and since `prose` by using more complicated selectors cannot be inlined,
-this means `prose` does not work. This might also mean some other utilities might not work either.
+and look them up later on the elements, and since `prose` by using more complicated selectors cannot be 
+directly inlined without resolving elements it won't work. 
+This might also mean some other utilities might not work either, like the [`space-*` utility](https://tailwindcss.com/docs/space).
 
 The only exception for this inlining of styles is with media queries, as they are not inlinable. We do not
 do the same for `hover:` styles though, but since [their support is not best](https://www.caniemail.com/features/css-pseudo-class-hover/), you probably won't need it.

--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -115,9 +115,11 @@ be resolved into selectors that are relatively complex. That is, selectors with 
 than a class lookup.
 
 This is because we optimistically look into the selectors for class names
-and look them up later on the elements, and since `prose` by using more complicated selectors cannot be 
-directly inlined without resolving elements it won't work. 
-This might also means some other utilities might not work either, like the [`space-*` utility](https://tailwindcss.com/docs/space).
+and look these up later on the elements, and since `prose`, by using more complicated selectors, 
+cannot be directly inlined without matching the selectors to the elements, it isn't able to
+match the selectors appropriately.
+
+This also means some other utilities do not work either, like the [`space-*` utility](https://tailwindcss.com/docs/space).
 
 The only exception for this inlining of styles is with media queries, as they are not inlinable. We do not
 do the same for `hover:` styles though, but since [their support is not best](https://www.caniemail.com/features/css-pseudo-class-hover/), you probably won't need it.

--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -69,6 +69,34 @@ const Email = () => {
 };
 ```
 
+## Know limitations
+
+### Not yet Tailwind v3.4
+
+Due to an internal technical limitation, we are still running on Tailwind `3.3.2`. This is 
+because Tailwind migrated into using async APIs internally after [`3.3.3`](https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.3.3)
+and the only way we can migrate is by using Suspense on the Tailwind component which would
+force everyone into using only `renderAsync`.
+
+You can track our progress on this on [this issue](https://github.com/resend/react-email/issues/1372)
+or by checking this page once in a while.
+
+### No supoprt for `prose` from `@tailwindcss/typography`
+
+We do not yet support `prose`, and beyond that, we don't yet support classes that might
+be resolved into selectors that are relatively complex. That is, selectors with more
+than a class lookup.
+
+This is because we optimistically look into the selectors for class names
+and look them up later on the elements, and since `prose` by using more complicated selectors cannot be inlined,
+this means `prose` does not work. This might also mean some other utilities might not work either.
+
+The only exception for this inlining of styles is with media queries, as they are not inlinable. We do not
+do the same for `hover:´ styles though, but since [their support is not best](https://www.caniemail.com/features/css-pseudo-class-hover/), you probably won't need it.
+
+In the future, we will be inlining all the styles we can by actually matching the 
+selectors *against the elements* themselves.
+
 ## Props
 
 <ResponseField name="config" type="object">

--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -119,7 +119,7 @@ and look them up later on the elements, and since `prose` by using more complica
 this means `prose` does not work. This might also mean some other utilities might not work either.
 
 The only exception for this inlining of styles is with media queries, as they are not inlinable. We do not
-do the same for `hover:´ styles though, but since [their support is not best](https://www.caniemail.com/features/css-pseudo-class-hover/), you probably won't need it.
+do the same for `hover:` styles though, but since [their support is not best](https://www.caniemail.com/features/css-pseudo-class-hover/), you probably won't need it.
 
 In the future, we will be inlining all the styles we can by actually matching the 
 selectors *against the elements* themselves.

--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -78,10 +78,10 @@ because Tailwind migrated into using async APIs internally after [`3.3.3`](https
 and the only way we can migrate is by using Suspense on the Tailwind component which would
 force everyone into using only `renderAsync`.
 
-You can track our progress on this on [this issue](https://github.com/resend/react-email/issues/1372)
+You can track our progress on [this issue](https://github.com/resend/react-email/issues/1372)
 or by checking this page once in a while.
 
-### No supoprt for `prose` from `@tailwindcss/typography`
+### No support for `prose` from `@tailwindcss/typography`
 
 We do not yet support `prose`, and beyond that, we don't yet support classes that might
 be resolved into selectors that are relatively complex. That is, selectors with more

--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -69,21 +69,48 @@ const Email = () => {
 };
 ```
 
-## Know limitations
+## Props
 
-### Not yet Tailwind v3.4
+<ResponseField name="config" type="object">
+  Customize the default theme for your project with the available properties in
+  [Tailwind docs](https://tailwindcss.com/docs/theme).
+</ResponseField>
 
-Due to an internal technical limitation, we are still running on Tailwind `3.3.2`. This is 
+<Info>
+    Most email clients are style-limited and some styles may not work.
+
+    One example of this is how Tailwind will uses `rem` as it's main unit for better accessbility. 
+    This is not going to be supported by [some email clients](https://www.caniemail.com/features/css-unit-rem/)
+    and we recommend that you define a Tailwind config to override these if you care
+    about the support for those email clients. We will not do this ourselves, though.
+</Info>
+
+## Live example
+
+<Card
+  title="Tailwind Demo"
+  icon="arrow-up-right-from-square"
+  iconType="duotone"
+  href="https://demo.react.email/preview/notifications/vercel-invite-user"
+>
+  See the full demo and source code.
+</Card>
+
+<Snippet file="support.mdx" />
+
+## Known limitations
+
+<AccordionGroup>
+  <Accordion title="Support up to Tailwind v3.3.2">
+    Due to an internal technical limitation, we are still running on Tailwind `3.3.2`. This is 
 because Tailwind migrated into using async APIs internally after [`3.3.3`](https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.3.3)
 and the only way we can migrate is by using Suspense on the Tailwind component which would
 force everyone into using only `renderAsync`.
 
-You can track our progress on [this issue](https://github.com/resend/react-email/issues/1372)
-or by checking this page once in a while.
-
-### No support for `prose` from `@tailwindcss/typography`
-
-We do not yet support `prose`, and beyond that, we don't yet support classes that might
+You can track our progress on [this issue](https://github.com/resend/react-email/issues/1372).
+  </Accordion>
+  <Accordion title="No support for prose from @tailwindcss/typography">
+    We do not yet support `prose`, and beyond that, we don't yet support classes that might
 be resolved into selectors that are relatively complex. That is, selectors with more
 than a class lookup.
 
@@ -96,10 +123,9 @@ do the same for `hover:´ styles though, but since [their support is not best](h
 
 In the future, we will be inlining all the styles we can by actually matching the 
 selectors *against the elements* themselves.
-
-### Limitations when trying to manipulate classes
-
-Currently, the component works, at a high level, going through the following steps:
+  </Accordion>
+  <Accordion title="Limitations when trying to manipulate classes">
+    Currently, the component works, at a high level, going through the following steps:
 
 1. Do a very surface-level rendering on the children to have something resembling the HTML
 2. Run `tailwind` as a `postcss` plugin in the new fake rendered email template to generate a CSS stylesheet with all the styles of the template
@@ -147,32 +173,5 @@ in the HTML, and along with the `className` not being removed for React elements
 so that you are able to manipulate both of them at the same time.
 
 On small email templates this is most likely not going to be an issue, though.
-
-## Props
-
-<ResponseField name="config" type="object">
-  Customize the default theme for your project with the available properties in
-  [Tailwind docs](https://tailwindcss.com/docs/theme).
-</ResponseField>
-
-<Info>
-    Most email clients are style-limited and some styles may not work.
-
-    One example of this is how Tailwind will uses `rem` as it's main unit for better accessbility. 
-    This is not going to be supported by [some email clients](https://www.caniemail.com/features/css-unit-rem/)
-    and we recommend that you define a Tailwind config to override these if you care
-    about the support for those email clients. We will not do this ourselves, though.
-</Info>
-
-## Live example
-
-<Card
-  title="Tailwind Demo"
-  icon="arrow-up-right-from-square"
-  iconType="duotone"
-  href="https://demo.react.email/preview/notifications/vercel-invite-user"
->
-  See the full demo and source code.
-</Card>
-
-<Snippet file="support.mdx" />
+  </Accordion>
+</AccordionGroup>

--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -152,7 +152,7 @@ export default function Email() {
 };
 ```
 
-The prop for `className` will come in as `bg-blue-400` which would seem like you can manipulate the className,
+The prop for `className` will come in as `bg-blue-400` which would seem like you can manipulate the `className`,
 but once you add it somewhere to the resulting HTML, like:
 
 ```jsx
@@ -169,11 +169,11 @@ export default function Email() {
 ```
 
 The email will render with a red background and a `class="undefined"` attribute as the class will have
-been removed. This means that manipulations are very unstable at the current version. 
+been removed. This means that manipulations are very unstable in the current version. 
 
 In a future version, the behavior is going to be of resolving the styles regardless of them appearing
-in the HTML, and along with the `className` not being removed for React elements that are components,
-so that you are able to manipulate both of them at the same time.
+in the HTML, and it will not remove the classes that were inlined if they were done in a React component,
+so that you are able to manipulate both the `className` and `style` at the same time.
 
 On small email templates this is most likely not going to be an issue, though.
   </Accordion>


### PR DESCRIPTION
This adds two things to the Tailwind component's docs. Mainly it adds a "Known limitations" section to make users aware
of limitations we currently have and are working towards improving. The limitations I wrote on were:
- Not yet Tailwind v3.4
- No support for `prose` from `@tailwindcss/typography`
- Limitations when trying to manipulate classes

The other, smaller, thing is an example of how Tailwind generated styles might not be compatible with all email clients.