### PR TITLE
fix(react-email): hot reloading rough edges

### DIFF
--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -6,7 +6,7 @@
     "email": "./cli/index.js"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup ",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -6,7 +6,7 @@
     "email": "./cli/index.js"
   },
   "scripts": {
-    "build": "tsup ",
+    "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -27,7 +27,8 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@babel/parser": "7.24.1",
+    "@babel/core": "7.24.5",
+    "@babel/parser": "7.24.5",
     "@radix-ui/colors": "1.0.1",
     "@radix-ui/react-collapsible": "1.0.3",
     "@radix-ui/react-popover": "1.0.7",
@@ -39,7 +40,6 @@
     "@types/react-dom": "^18.2.0",
     "@types/webpack": "5.28.5",
     "autoprefixer": "10.4.14",
-    "babel-walk": "3.0.0",
     "chalk": "4.1.2",
     "chokidar": "3.5.3",
     "clsx": "2.1.0",
@@ -72,6 +72,7 @@
   "devDependencies": {
     "@react-email/components": "0.0.18",
     "@react-email/render": "0.0.14",
+    "@types/babel__core": "7.20.5",
     "@types/fs-extra": "11.0.1",
     "@types/mime-types": "2.1.4",
     "@types/node": "18.0.0",

--- a/packages/react-email/src/actions/get-email-path-from-slug.ts
+++ b/packages/react-email/src/actions/get-email-path-from-slug.ts
@@ -5,7 +5,7 @@ import { emailsDirectoryAbsolutePath } from '../utils/emails-directory-absolute-
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const getEmailPathFromSlug = async (slug: string) => {
-  if (['.tsx', '.jsx', '.js'].includes(path.extname(slug)))
+  if (['.tsx', '.jsx', '.ts', '.js'].includes(path.extname(slug)))
     return path.join(emailsDirectoryAbsolutePath, slug);
 
   const pathWithoutExtension = path.join(emailsDirectoryAbsolutePath, slug);
@@ -14,12 +14,14 @@ export const getEmailPathFromSlug = async (slug: string) => {
     return `${pathWithoutExtension}.tsx`;
   } else if (fs.existsSync(`${pathWithoutExtension}.jsx`)) {
     return `${pathWithoutExtension}.jsx`;
+  } else if (fs.existsSync(`${pathWithoutExtension}.ts`)) {
+    return `${pathWithoutExtension}.ts`;
   } else if (fs.existsSync(`${pathWithoutExtension}.js`)) {
-    return `${pathWithoutExtension}.jsx`;
+    return `${pathWithoutExtension}.js`;
   }
 
   throw new Error(
-    `Could not find your email file based on the slug (${slug}) by guessing the file extension. Tried .tsx, .jsx and .js.
+    `Could not find your email file based on the slug (${slug}) by guessing the file extension. Tried .tsx, .jsx, .ts and .js.
 
     This is most likely not an issue with the preview server. It most likely is that the email doesn't exist.`,
   );

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.spec.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.spec.ts
@@ -88,7 +88,7 @@ test('createDependencyGraph()', async () => {
       path: '../start-dev-server.ts',
       dependencyPaths: [],
       dependentPaths: ['create-dependency-graph.ts'],
-      moduleDependencies: []
+      moduleDependencies: [],
     },
     '../../../../utils/types/hot-reload-change.ts': {
       path: '../../../../utils/types/hot-reload-change.ts',

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.spec.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.spec.ts
@@ -41,7 +41,7 @@ test('createDependencyGraph()', async () => {
   const initialDependencyGraph = convertPathsToAbsolute({
     'create-dependency-graph.ts': {
       path: 'create-dependency-graph.ts',
-      dependencyPaths: ['get-imported-modules.ts'],
+      dependencyPaths: ['get-imported-modules.ts', '../start-dev-server.ts'],
       dependentPaths: [
         'create-dependency-graph.spec.ts',
         'setup-hot-reloading.ts',
@@ -83,6 +83,12 @@ test('createDependencyGraph()', async () => {
         'chokidar',
         'debounce',
       ],
+    },
+    '../start-dev-server.ts': {
+      path: '../start-dev-server.ts',
+      dependencyPaths: [],
+      dependentPaths: ['create-dependency-graph.ts'],
+      moduleDependencies: []
     },
     '../../../../utils/types/hot-reload-change.ts': {
       path: '../../../../utils/types/hot-reload-change.ts',

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.spec.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.spec.ts
@@ -61,7 +61,7 @@ test('createDependencyGraph()', async () => {
         'get-imported-modules.spec.ts',
       ],
       dependencyPaths: [],
-      moduleDependencies: ['@babel/parser', 'babel-walk'],
+      moduleDependencies: ['@babel/core', '@babel/parser'],
     },
     'get-imported-modules.spec.ts': {
       path: 'get-imported-modules.spec.ts',

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
@@ -39,7 +39,9 @@ const isJavascriptModule = (filePath: string) => {
   return ['.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs'].includes(extensionName);
 };
 
-const checkFileExtensionsUntilItExists = (pathWithoutExtension: string): string | undefined => {
+const checkFileExtensionsUntilItExists = (
+  pathWithoutExtension: string,
+): string | undefined => {
   if (existsSync(`${pathWithoutExtension}.ts`)) {
     return `${pathWithoutExtension}.ts`;
   } else if (existsSync(`${pathWithoutExtension}.tsx`)) {
@@ -53,7 +55,7 @@ const checkFileExtensionsUntilItExists = (pathWithoutExtension: string): string 
   } else if (existsSync(`${pathWithoutExtension}.cjs`)) {
     return `${pathWithoutExtension}.cjs`;
   }
-}
+};
 
 /**
  * Creates a stateful dependency graph that is structured in a way that you can get
@@ -110,12 +112,16 @@ export const createDependencyGraph = async (directory: string) => {
           } catch (_) {}
           if (isDirectory) {
             const pathToSubDirectory = pathToDependencyFromDirectory;
-            const pathWithExtension = checkFileExtensionsUntilItExists(`${pathToSubDirectory}/index`);
+            const pathWithExtension = checkFileExtensionsUntilItExists(
+              `${pathToSubDirectory}/index`,
+            );
             if (pathWithExtension) {
               pathToDependencyFromDirectory = pathWithExtension;
             } else if (!isRunningBuilt) {
               // only warn about this on development as it is probably going to be irrelevant otherwise
-              console.warn(`Could not find index file for directory at ${pathToDependencyFromDirectory}. This is probably going to cause issues with both hot reloading and your code.`);
+              console.warn(
+                `Could not find index file for directory at ${pathToDependencyFromDirectory}. This is probably going to cause issues with both hot reloading and your code.`,
+              );
             }
           }
 
@@ -124,12 +130,16 @@ export const createDependencyGraph = async (directory: string) => {
             for it being a javascript module fails, then we can assume it has the same as the `filePath`
           */
           if (!isJavascriptModule(pathToDependencyFromDirectory)) {
-            const pathWithExtension = checkFileExtensionsUntilItExists(pathToDependencyFromDirectory);
+            const pathWithExtension = checkFileExtensionsUntilItExists(
+              pathToDependencyFromDirectory,
+            );
             if (pathWithExtension) {
               pathToDependencyFromDirectory = pathWithExtension;
             } else if (!isRunningBuilt) {
               // only warn about this on development as it is probably going to be irrelevant otherwise
-              console.warn(`Could not determine the file extension for the file at ${pathWithExtension}`);
+              console.warn(
+                `Could not determine the file extension for the file at ${pathWithExtension}`,
+              );
             }
           }
 

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/get-imported-modules.spec.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/get-imported-modules.spec.ts
@@ -11,6 +11,19 @@ describe('getImportedModules()', () => {
     ]);
   });
 
+  it('should work with direct exports', () => {
+    const contents = `export * from './component-a';
+    export { ComponentB } from './component-b'; 
+
+    import { ComponentC } from './component-c';
+    export { ComponentC }`;
+    expect(getImportedModules(contents)).toEqual([
+      './component-a',
+      './component-b',
+      './component-c',
+    ]);
+  });
+
   it('should work with regular imports and double quotes', () => {
     const contents = `import {
   Body,

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/get-imported-modules.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/get-imported-modules.ts
@@ -5,6 +5,14 @@ const importVisitor = walk.simple<string[]>({
   ImportDeclaration(node, importedPaths) {
     importedPaths.push(node.source.value);
   },
+  ExportAllDeclaration(node, importedPaths) {
+    importedPaths.push(node.source.value);
+  },
+  ExportNamedDeclaration(node, importedPaths) {
+    if (node.source) {
+      importedPaths.push(node.source.value);
+    }
+  },
   CallExpression(node, importedPaths) {
     if ('name' in node.callee && node.callee.name === 'require') {
       if (node.arguments.length === 1) {

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/get-imported-modules.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/get-imported-modules.ts
@@ -1,29 +1,5 @@
+import { traverse } from '@babel/core';
 import { parse } from '@babel/parser';
-import * as walk from 'babel-walk';
-
-const importVisitor = walk.simple<string[]>({
-  ImportDeclaration(node, importedPaths) {
-    importedPaths.push(node.source.value);
-  },
-  ExportAllDeclaration(node, importedPaths) {
-    importedPaths.push(node.source.value);
-  },
-  ExportNamedDeclaration(node, importedPaths) {
-    if (node.source) {
-      importedPaths.push(node.source.value);
-    }
-  },
-  CallExpression(node, importedPaths) {
-    if ('name' in node.callee && node.callee.name === 'require') {
-      if (node.arguments.length === 1) {
-        const importPathNode = node.arguments[0]!;
-        if (importPathNode!.type === 'StringLiteral') {
-          importedPaths.push(importPathNode.value);
-        }
-      }
-    }
-  },
-});
 
 export const getImportedModules = (contents: string) => {
   const importedPaths: string[] = [];
@@ -34,7 +10,29 @@ export const getImportedModules = (contents: string) => {
     plugins: ['jsx', 'typescript'],
   });
 
-  importVisitor(parsedContents, importedPaths);
+  traverse(parsedContents, {
+    ImportDeclaration({ node }) {
+      importedPaths.push(node.source.value);
+    },
+    ExportAllDeclaration({ node }) {
+      importedPaths.push(node.source.value);
+    },
+    ExportNamedDeclaration({ node }) {
+      if (node.source) {
+        importedPaths.push(node.source.value);
+      }
+    },
+    CallExpression({ node }) {
+      if ('name' in node.callee && node.callee.name === 'require') {
+        if (node.arguments.length === 1) {
+          const importPathNode = node.arguments[0]!;
+          if (importPathNode!.type === 'StringLiteral') {
+            importedPaths.push(importPathNode.value);
+          }
+        }
+      }
+    },
+  });
 
   return importedPaths;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 18.2.18
       next:
         specifier: 14.1.4
-        version: 14.1.4(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)
+        version: 14.1.4(@babel/core@7.24.5)(react-dom@18.2.0)(react@18.2.0)
       tsx:
         specifier: 4.9.0
         version: 4.9.0
@@ -206,7 +206,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -231,7 +231,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -256,7 +256,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -284,7 +284,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -366,7 +366,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       eslint-config-custom:
         specifier: workspace:*
         version: link:../eslint-config-custom
@@ -385,7 +385,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -441,7 +441,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -463,7 +463,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -488,7 +488,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -510,7 +510,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -532,7 +532,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -554,7 +554,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -576,7 +576,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -601,7 +601,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -623,7 +623,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -639,9 +639,12 @@ importers:
 
   packages/react-email:
     dependencies:
+      '@babel/core':
+        specifier: 7.24.5
+        version: 7.24.5
       '@babel/parser':
-        specifier: 7.24.1
-        version: 7.24.1
+        specifier: 7.24.5
+        version: 7.24.5
       '@radix-ui/colors':
         specifier: 1.0.1
         version: 1.0.1
@@ -675,9 +678,6 @@ importers:
       autoprefixer:
         specifier: 10.4.14
         version: 10.4.14(postcss@8.4.38)
-      babel-walk:
-        specifier: 3.0.0
-        version: 3.0.0
       chalk:
         specifier: 4.1.2
         version: 4.1.2
@@ -716,7 +716,7 @@ importers:
         version: 2.1.35
       next:
         specifier: 14.1.4
-        version: 14.1.4(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)
+        version: 14.1.4(@babel/core@7.24.5)(react-dom@18.2.0)(react@18.2.0)
       normalize-path:
         specifier: 3.0.0
         version: 3.0.0
@@ -769,6 +769,9 @@ importers:
       '@react-email/render':
         specifier: 0.0.14
         version: link:../render
+      '@types/babel__core':
+        specifier: 7.20.5
+        version: 7.20.5
       '@types/fs-extra':
         specifier: 11.0.1
         version: 11.0.1
@@ -820,7 +823,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@edge-runtime/vm':
         specifier: 3.1.8
         version: 3.1.8
@@ -854,7 +857,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -876,7 +879,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -974,7 +977,7 @@ importers:
     devDependencies:
       '@babel/preset-react':
         specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
+        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -1028,7 +1031,7 @@ packages:
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.9)
       '@babel/helpers': 7.24.4
-      '@babel/parser': 7.24.1
+      '@babel/parser': 7.24.5
       '@babel/template': 7.24.0
       '@babel/traverse': 7.24.1
       '@babel/types': 7.24.0
@@ -1039,15 +1042,38 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
-  /@babel/eslint-parser@7.24.1(@babel/core@7.23.9)(eslint@8.50.0):
+  /@babel/core@7.24.5:
+    resolution: {integrity: sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.24.2
+      '@babel/generator': 7.24.5
+      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-module-transforms': 7.24.5(@babel/core@7.24.5)
+      '@babel/helpers': 7.24.5
+      '@babel/parser': 7.24.5
+      '@babel/template': 7.24.0
+      '@babel/traverse': 7.24.5
+      '@babel/types': 7.24.5
+      convert-source-map: 2.0.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/eslint-parser@7.24.1(@babel/core@7.24.5)(eslint@8.50.0):
     resolution: {integrity: sha512-d5guuzMlPeDfZIbpQ8+g1NaCNuAGBBGNECh0HVqz1sjOeVLh2CEaifuOysCH18URW6R7pqXINvf5PaR/dC6jLQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.5
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 8.50.0
       eslint-visitor-keys: 2.1.0
@@ -1059,6 +1085,16 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.24.0
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 2.5.2
+    dev: true
+
+  /@babel/generator@7.24.5:
+    resolution: {integrity: sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.5
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
@@ -1089,13 +1125,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.24.0
-      '@babel/types': 7.24.0
+      '@babel/types': 7.24.5
 
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.24.0
+      '@babel/types': 7.24.5
 
   /@babel/helper-module-imports@7.24.3:
     resolution: {integrity: sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==}
@@ -1115,6 +1151,20 @@ packages:
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
+    dev: true
+
+  /@babel/helper-module-transforms@7.24.5(@babel/core@7.24.5):
+    resolution: {integrity: sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-module-imports': 7.24.3
+      '@babel/helper-simple-access': 7.24.5
+      '@babel/helper-split-export-declaration': 7.24.5
+      '@babel/helper-validator-identifier': 7.24.5
 
   /@babel/helper-plugin-utils@7.24.0:
     resolution: {integrity: sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==}
@@ -1126,12 +1176,26 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.24.0
+    dev: true
+
+  /@babel/helper-simple-access@7.24.5:
+    resolution: {integrity: sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.5
 
   /@babel/helper-split-export-declaration@7.22.6:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.24.0
+    dev: true
+
+  /@babel/helper-split-export-declaration@7.24.5:
+    resolution: {integrity: sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.5
 
   /@babel/helper-string-parser@7.24.1:
     resolution: {integrity: sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==}
@@ -1139,6 +1203,10 @@ packages:
 
   /@babel/helper-validator-identifier@7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-identifier@7.24.5:
+    resolution: {integrity: sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==}
     engines: {node: '>=6.9.0'}
 
   /@babel/helper-validator-option@7.23.5:
@@ -1154,6 +1222,17 @@ packages:
       '@babel/types': 7.24.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@babel/helpers@7.24.5:
+    resolution: {integrity: sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.24.0
+      '@babel/traverse': 7.24.5
+      '@babel/types': 7.24.5
+    transitivePeerDependencies:
+      - supports-color
 
   /@babel/highlight@7.24.2:
     resolution: {integrity: sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==}
@@ -1164,12 +1243,12 @@ packages:
       js-tokens: 4.0.0
       picocolors: 1.0.0
 
-  /@babel/parser@7.24.1:
-    resolution: {integrity: sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==}
+  /@babel/parser@7.24.5:
+    resolution: {integrity: sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.24.0
+      '@babel/types': 7.24.5
 
   /@babel/plugin-syntax-jsx@7.24.1(@babel/core@7.23.9):
     resolution: {integrity: sha512-2eCtxZXf+kbkMIsXS4poTvT4Yu5rXiRa+9xGVT56raghjmBTKMpFNc9R4IDiB4emao9eO22Ox7CxuJG7BgExqA==}
@@ -1178,6 +1257,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.24.0
+    dev: true
+
+  /@babel/plugin-syntax-jsx@7.24.1(@babel/core@7.24.5):
+    resolution: {integrity: sha512-2eCtxZXf+kbkMIsXS4poTvT4Yu5rXiRa+9xGVT56raghjmBTKMpFNc9R4IDiB4emao9eO22Ox7CxuJG7BgExqA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
@@ -1191,6 +1280,16 @@ packages:
       '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
+  /@babel/plugin-transform-react-display-name@7.24.1(@babel/core@7.24.5):
+    resolution: {integrity: sha512-mvoQg2f9p2qlpDQRBC7M3c3XTr0k7cp/0+kFKKO/7Gtu0LSw16eKB+Fabe2bDT/UpsyasTBBkAnbdsLrkD5XMw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.24.0
+    dev: true
+
   /@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.23.9):
     resolution: {integrity: sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==}
     engines: {node: '>=6.9.0'}
@@ -1199,6 +1298,16 @@ packages:
     dependencies:
       '@babel/core': 7.23.9
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.23.9)
+    dev: true
+
+  /@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.24.5):
+    resolution: {integrity: sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.5)
     dev: true
 
   /@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.23.9):
@@ -1215,6 +1324,20 @@ packages:
       '@babel/types': 7.24.0
     dev: true
 
+  /@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.5):
+    resolution: {integrity: sha512-5xOpoPguCZCRbo/JeHlloSkTA8Bld1J/E1/kLfD1nsuiW1m8tduTA1ERCgIZokDflX/IBzKcqR3l7VlRgiIfHA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-module-imports': 7.24.3
+      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.24.5)
+      '@babel/types': 7.24.0
+    dev: true
+
   /@babel/plugin-transform-react-pure-annotations@7.24.1(@babel/core@7.23.9):
     resolution: {integrity: sha512-+pWEAaDJvSm9aFvJNpLiM2+ktl2Sn2U5DdyiWdZBxmLc6+xGt88dvFqsHiAiDS+8WqUwbDfkKz9jRxK3M0k+kA==}
     engines: {node: '>=6.9.0'}
@@ -1222,6 +1345,17 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.9
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
+    dev: true
+
+  /@babel/plugin-transform-react-pure-annotations@7.24.1(@babel/core@7.24.5):
+    resolution: {integrity: sha512-+pWEAaDJvSm9aFvJNpLiM2+ktl2Sn2U5DdyiWdZBxmLc6+xGt88dvFqsHiAiDS+8WqUwbDfkKz9jRxK3M0k+kA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.5
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-plugin-utils': 7.24.0
     dev: true
@@ -1241,6 +1375,21 @@ packages:
       '@babel/plugin-transform-react-pure-annotations': 7.24.1(@babel/core@7.23.9)
     dev: true
 
+  /@babel/preset-react@7.23.3(@babel/core@7.24.5):
+    resolution: {integrity: sha512-tbkHOS9axH6Ysf2OUEqoSZ6T3Fa2SrNH6WTWSPBboxKzdxNc9qOICeLXkNG0ZEwbQ1HY8liwOce4aN/Ceyuq6w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-validator-option': 7.23.5
+      '@babel/plugin-transform-react-display-name': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-pure-annotations': 7.24.1(@babel/core@7.24.5)
+    dev: true
+
   /@babel/runtime@7.24.4:
     resolution: {integrity: sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==}
     engines: {node: '>=6.9.0'}
@@ -1252,7 +1401,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.24.2
-      '@babel/parser': 7.24.1
+      '@babel/parser': 7.24.5
       '@babel/types': 7.24.0
 
   /@babel/traverse@7.24.1:
@@ -1265,8 +1414,26 @@ packages:
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.24.1
+      '@babel/parser': 7.24.5
       '@babel/types': 7.24.0
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/traverse@7.24.5:
+    resolution: {integrity: sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.24.2
+      '@babel/generator': 7.24.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.24.5
+      '@babel/parser': 7.24.5
+      '@babel/types': 7.24.5
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -1278,6 +1445,14 @@ packages:
     dependencies:
       '@babel/helper-string-parser': 7.24.1
       '@babel/helper-validator-identifier': 7.22.20
+      to-fast-properties: 2.0.0
+
+  /@babel/types@7.24.5:
+    resolution: {integrity: sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.24.1
+      '@babel/helper-validator-identifier': 7.24.5
       to-fast-properties: 2.0.0
 
   /@edge-runtime/primitives@4.0.6:
@@ -3304,6 +3479,35 @@ packages:
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
     dev: true
 
+  /@types/babel__core@7.20.5:
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+    dependencies:
+      '@babel/parser': 7.24.5
+      '@babel/types': 7.24.5
+      '@types/babel__generator': 7.6.8
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.20.5
+    dev: true
+
+  /@types/babel__generator@7.6.8:
+    resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
+    dependencies:
+      '@babel/types': 7.24.5
+    dev: true
+
+  /@types/babel__template@7.4.4:
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+    dependencies:
+      '@babel/parser': 7.24.5
+      '@babel/types': 7.24.5
+    dev: true
+
+  /@types/babel__traverse@7.20.5:
+    resolution: {integrity: sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==}
+    dependencies:
+      '@babel/types': 7.24.5
+    dev: true
+
   /@types/chai-subset@1.3.5:
     resolution: {integrity: sha512-c2mPnw+xHtXDoHmdtcCXGwyLMiauiAyxWMzhGpqHC4nqI/Y5G2XhTampslK2rb59kpcuHon03UH8W6iYUzw88A==}
     dependencies:
@@ -3689,8 +3893,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/eslint-parser': 7.24.1(@babel/core@7.23.9)(eslint@8.50.0)
+      '@babel/core': 7.24.5
+      '@babel/eslint-parser': 7.24.1(@babel/core@7.24.5)(eslint@8.50.0)
       '@rushstack/eslint-patch': 1.10.1
       '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.50.0)(typescript@5.1.6)
       '@typescript-eslint/parser': 6.21.0(eslint@8.50.0)(typescript@5.1.6)
@@ -3894,7 +4098,7 @@ packages:
   /@vue/compiler-core@3.4.21:
     resolution: {integrity: sha512-MjXawxZf2SbZszLPYxaFCjxfibYrzr3eYbKxwpLR9EQN+oaziSu3qKVbwBERj1IFIB8OLUewxB5m/BFzi613og==}
     dependencies:
-      '@babel/parser': 7.24.1
+      '@babel/parser': 7.24.5
       '@vue/shared': 3.4.21
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -4343,13 +4547,6 @@ packages:
     dependencies:
       dequal: 2.0.3
     dev: true
-
-  /babel-walk@3.0.0:
-    resolution: {integrity: sha512-fdRxJkQ9MUSEi4jH2DcV3FAPFktk0wefilxrwNyUuWpoWawQGN7G7cB+fOYTtFfI6XNkFgwqJ/D3G18BoJJ/jg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@babel/types': 7.24.0
-    dev: false
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -7203,7 +7400,7 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: false
 
-  /next@14.1.4(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0):
+  /next@14.1.4(@babel/core@7.24.5)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-1WTaXeSrUwlz/XcnhGTY7+8eiaFvdet5z9u3V2jb+Ek1vFo0VhHKSAIJvDWfQpttWjnyw14kBeq28TPq7bTeEQ==}
     engines: {node: '>=18.17.0'}
     hasBin: true
@@ -7226,7 +7423,7 @@ packages:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.9)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.24.5)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.1.4
       '@next/swc-darwin-x64': 14.1.4
@@ -7267,7 +7464,7 @@ packages:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.9)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.24.5)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.3
       '@next/swc-darwin-x64': 14.2.3
@@ -8736,7 +8933,7 @@ packages:
       acorn: 8.11.3
     dev: true
 
-  /styled-jsx@5.1.1(@babel/core@7.23.9)(react@18.2.0):
+  /styled-jsx@5.1.1(@babel/core@7.24.5)(react@18.2.0):
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -8749,7 +8946,7 @@ packages:
       babel-plugin-macros:
         optional: true
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.5
       client-only: 0.0.1
       react: 18.2.0
 


### PR DESCRIPTION
## Background

A bit of time ago I got to implementing an improvement to the preview
server that made it hot reload when there were changes made to the dependencies.

I did this through a sort of dependency graph that connects each module to its
dependents and to its dependencies. This was very useful because it made it so that
it was both easy to update the dependency graph in an optimal way, while still
being easy to resolve through the dependents and notify the Next app 
that they changed.

## What this fixes

The initial implementation I made though, presented a few issues. Not necessarily
in the way I did it, but a few bugs have arisen as mentioned from https://github.com/resend/react-email/issues/1366#issuecomment-2042762918 onwards.

The bugs were, in summary:

- An error, saying that the email template could not be found
- Some situations not hot reloading at all when changing the dependencies
- Not working very well when working with directories and their `index` files  

These, were, in turn, caused by:

- Trying to get the file extension of imports with a very failed heuristic
- Not resolving imports from direct exports (i.e. `export * from 'my-module'`)
- Only notifying the surface-level dependents of a changed module instead of doing it recursively

This PR fixes those such that the issues have gone away. 
