### PR TITLE
fix(create-email): add react-email/tailwind dependency

### DIFF
--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -8,6 +8,7 @@
     "export": "email export"
   },
   "dependencies": {
+    "react-email/tailwind": "0.0.15",
     "@react-email/components": "0.0.17-canary.1",
     "react-email": "2.1.2-canary.0",
     "react": "18.2.0"


### PR DESCRIPTION
The `vercel-invite-user` example fails because the tailwind module was not found.

Adding this to the dependency fixes it but not sure if this belongs here or as a peer-dep in the react-email/components package?