### PR TITLE
fix(react-email): Different react-dom version being used to render email templates

### DIFF
--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -34,7 +34,6 @@
     "@radix-ui/react-slot": "1.0.2",
     "@radix-ui/react-toggle-group": "1.0.4",
     "@radix-ui/react-tooltip": "1.0.7",
-    "@react-email/components": "0.0.17-canary.1",
     "@react-email/render": "0.0.13",
     "@swc/core": "1.3.101",
     "@types/react": "^18.2.0",

--- a/packages/react-email/src/actions/render-email-by-path.tsx
+++ b/packages/react-email/src/actions/render-email-by-path.tsx
@@ -25,7 +25,7 @@ export const renderEmailByPath = async (
     return { error: result.error };
   }
 
-  const { emailComponent: Email, sourceMapToOriginalFile } = result;
+  const { emailComponent: Email, renderAsync, sourceMapToOriginalFile } = result;
 
   const previewProps = Email.PreviewProps || {};
   const EmailComponent = Email as React.FC;

--- a/packages/react-email/src/actions/render-email-by-path.tsx
+++ b/packages/react-email/src/actions/render-email-by-path.tsx
@@ -25,7 +25,11 @@ export const renderEmailByPath = async (
     return { error: result.error };
   }
 
-  const { emailComponent: Email, renderAsync, sourceMapToOriginalFile } = result;
+  const {
+    emailComponent: Email,
+    renderAsync,
+    sourceMapToOriginalFile,
+  } = result;
 
   const previewProps = Email.PreviewProps || {};
   const EmailComponent = Email as React.FC;

--- a/packages/react-email/src/actions/render-email-by-path.tsx
+++ b/packages/react-email/src/actions/render-email-by-path.tsx
@@ -34,7 +34,6 @@ export const renderEmailByPath = async (
   const previewProps = Email.PreviewProps || {};
   const EmailComponent = Email as React.FC;
   try {
-    const { renderAsync } = await import('@react-email/render');
     const markup = await renderAsync(<EmailComponent {...previewProps} />, {
       pretty: true,
     });

--- a/packages/react-email/src/utils/__snapshots__/get-email-component.spec.ts.snap
+++ b/packages/react-email/src/utils/__snapshots__/get-email-component.spec.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`getEmailComponent() with a demo email template 1`] = `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><div>Hello <!-- -->Gabriel<!-- -->!</div>"`;

--- a/packages/react-email/src/utils/get-email-component.spec.ts
+++ b/packages/react-email/src/utils/get-email-component.spec.ts
@@ -1,0 +1,25 @@
+import path from 'node:path';
+import * as React from 'react';
+import { getEmailComponent } from './get-email-component';
+
+test('getEmailComponent() with a demo email template', async () => {
+  const result = await getEmailComponent(
+    path.resolve(__dirname, './testing/email-template.tsx'),
+  );
+
+  if ('error' in result) {
+    console.log(result.error);
+    expect('error' in result).toBe(false);
+  } else {
+    expect(result.emailComponent).toBeTruthy();
+    expect(result.sourceMapToOriginalFile).toBeTruthy();
+
+    const emailHtml = await result.renderAsync(
+      React.createElement(
+        result.emailComponent,
+        result.emailComponent.PreviewProps,
+      ),
+    );
+    expect(emailHtml).toMatchSnapshot();
+  }
+});

--- a/packages/react-email/src/utils/get-email-component.ts
+++ b/packages/react-email/src/utils/get-email-component.ts
@@ -6,6 +6,7 @@ import { type RawSourceMap } from 'source-map-js';
 import {
   type OutputFile,
   build,
+  type ResolveOptions,
   type BuildFailure,
   type Loader,
 } from 'esbuild';
@@ -49,26 +50,22 @@ export const getEmailComponent = async (
             b.onResolve(
               { filter: /^react-email-module-that-will-export-render$/ },
               async (args) => {
-                let result = await b.resolve('@react-email/render', {
+                const options: ResolveOptions = {
                   kind: 'import-statement',
                   importer: args.importer,
                   resolveDir: args.resolveDir,
                   namespace: args.namespace,
-                });
+                };
+                let result = await b.resolve('@react-email/render', options);
                 if (result.errors.length === 0) {
                   return result;
                 }
 
                 // If @react-email/render does not exist, resolve to @react-email/components
-                result = await b.resolve('@react-email/components', {
-                  kind: 'import-statement',
-                  importer: args.importer,
-                  resolveDir: args.resolveDir,
-                  namespace: args.namespace,
-                });
+                result = await b.resolve('@react-email/components', options);
                 if (result.errors.length > 0) {
                   result.errors[0]!.text =
-                    "Trying to resolve `renderAsync` from both `@react-email/render` and `@react-email/components` to be able to render your email template. Maybe you don't have the required dependencies installed?";
+                    "Failed trying to import `renderAsync` from either `@react-email/render` or `@react-email/components` to be able to render your email template.\n Maybe you don't have either of them installed?";
                 }
                 return result;
               },

--- a/packages/react-email/src/utils/get-email-component.ts
+++ b/packages/react-email/src/utils/get-email-component.ts
@@ -3,7 +3,12 @@ import path from 'node:path';
 import vm from 'node:vm';
 import fs from 'node:fs/promises';
 import { type RawSourceMap } from 'source-map-js';
-import { type OutputFile, build, type BuildFailure, type Loader } from 'esbuild';
+import {
+  type OutputFile,
+  build,
+  type BuildFailure,
+  type Loader,
+} from 'esbuild';
 import type { renderAsync } from '@react-email/render';
 import type { EmailTemplate as EmailComponent } from './types/email-template';
 import type { ErrorObject } from './types/error-object';
@@ -14,12 +19,12 @@ export const getEmailComponent = async (
   emailPath: string,
 ): Promise<
   | {
-    emailComponent: EmailComponent;
+      emailComponent: EmailComponent;
 
-    renderAsync: typeof renderAsync;
+      renderAsync: typeof renderAsync;
 
-    sourceMapToOriginalFile: RawSourceMap;
-  }
+      sourceMapToOriginalFile: RawSourceMap;
+    }
   | { error: ErrorObject }
 > => {
   let outputFiles: OutputFile[];
@@ -37,7 +42,7 @@ export const getEmailComponent = async (
                 contents: `${await fs.readFile(emailPath, 'utf8')};
 
 export { renderAsync } from '@react-email/render'`,
-                loader: path.extname(emailPath).slice(1) as Loader, 
+                loader: path.extname(emailPath).slice(1) as Loader,
               }),
             );
           },

--- a/packages/react-email/src/utils/testing/email-template.tsx
+++ b/packages/react-email/src/utils/testing/email-template.tsx
@@ -1,0 +1,9 @@
+const TestingEmailTemplate = (props: { name: string }) => {
+  return <div>Hello {props.name}!</div>;
+};
+
+TestingEmailTemplate.PreviewProps = {
+  name: 'Gabriel'
+};
+
+export default TestingEmailTemplate;

--- a/packages/react-email/src/utils/testing/email-template.tsx
+++ b/packages/react-email/src/utils/testing/email-template.tsx
@@ -3,7 +3,7 @@ const TestingEmailTemplate = (props: { name: string }) => {
 };
 
 TestingEmailTemplate.PreviewProps = {
-  name: 'Gabriel'
+  name: 'Gabriel',
 };
 
 export default TestingEmailTemplate;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -657,9 +657,6 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: 1.0.7
         version: 1.0.7(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
-      '@react-email/components':
-        specifier: 0.0.17-canary.1
-        version: link:../components
       '@react-email/render':
         specifier: 0.0.13
         version: link:../render


### PR DESCRIPTION
This fixes the issues that were causing #649. What was causing that issue
was that `@react-email/render` would import `react-dom` as the Next 
bundled version, which would not be the same React instance used
inside the email templates, this caused that globals such as their
dispatcher would not have the expected values. 

I noticed this was the cause of that issue after looking at our
updated trace on the error, and it pointed down into the
bundled version of `react-dom` inside `next`. The same issue was
also happening for versions prior to `2.0`, so this was not a regression either.

To fix this, I added a simple esbuild plugin to when the email template
is loaded, so that it adds a `export { renderAsync } from '@react-email/render'`
at the end of it. This way, it would also give us access to the `renderAsync`
and `react-dom` used in the user's project, so that this mismatch is not there
anymore. 

Since I was experimenting a bit as well, I added in a test to make
sure the `getEmailComponent` function works properly at least with a local
very simple file.

## How can I test this?

1. Run `pnpm install` and `turbo build` inside `packages/react-email`
2. Add the following email template at `apps/demo/emails/test.tsx`
```tsx
import React from "react";

export default function Test() {
  const containerRef = React.useRef<HTMLDivElement>(null);

  return <div ref={containerRef}>Hello world!</div>;
}
```
3. Run `npx tsx ../../packages/react-email/src/cli/index.ts dev` inside `apps/demo`
4. Open http://localhost:3000/preview/test and verify the error from #649 does not happen
