### PR TITLE
chore: use ^18.2.0 instead of 18.2.0 for all react dependency entries

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@react-email/components": "0.0.13",
     "@react-email/tailwind": "0.0.14",
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-dom": "18.2.0",
     "react-email": "2.1.0"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "classnames": "2.3.2",
     "next": "13.5.6",
     "prism-react-renderer": "2.1.0",
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-dom": "18.2.0",
     "resend": "3.2.0"
   },

--- a/benchmarks/tailwind-component/package.json
+++ b/benchmarks/tailwind-component/package.json
@@ -23,7 +23,7 @@
     "@react-email/components": "workspace:*",
     "@react-email/render": "workspace:*",
     "@react-email/tailwind": "0.0.12",
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "tinybench": "2.5.1"
   },
   "devDependencies": {

--- a/examples/aws-ses/package.json
+++ b/examples/aws-ses/package.json
@@ -25,7 +25,7 @@
     "@react-email/button": "*",
     "@react-email/html": "*",
     "@react-email/render": "*",
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "eslint": "8.23.1",

--- a/examples/mailersend/package.json
+++ b/examples/mailersend/package.json
@@ -25,7 +25,7 @@
     "@react-email/html": "*",
     "@react-email/render": "*",
     "mailersend": "^2.0.0",
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "eslint": "8.23.1",

--- a/examples/nodemailer/package.json
+++ b/examples/nodemailer/package.json
@@ -25,7 +25,7 @@
     "@react-email/html": "*",
     "@react-email/render": "*",
     "nodemailer": "6.9.9",
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@types/nodemailer": "6.4.6",

--- a/examples/plunk/package.json
+++ b/examples/plunk/package.json
@@ -25,7 +25,7 @@
     "@react-email/html": "*",
     "@react-email/render": "*",
     "@plunk/node": "1.1.1",
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "eslint": "8.23.1",

--- a/examples/postmark/package.json
+++ b/examples/postmark/package.json
@@ -25,7 +25,7 @@
     "@react-email/html": "*",
     "@react-email/render": "*",
     "postmark": "3.0.14",
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "eslint": "8.23.1",

--- a/examples/resend/package.json
+++ b/examples/resend/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "next": "13.5.0",
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-dom": "18.2.0",
     "resend": "0.15.1"
   },

--- a/examples/scaleway/next/package.json
+++ b/examples/scaleway/next/package.json
@@ -14,7 +14,7 @@
     "@react-email/render": "0.0.6",
     "@scaleway/sdk": "1.5.0",
     "next": "13.5.0",
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-dom": "18.2.0"
   },
   "devDependencies": {

--- a/examples/scaleway/node/package.json
+++ b/examples/scaleway/node/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@react-email/components": "0.0.4",
     "@scaleway/sdk": "1.4.0",
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@types/node": "^18.15.10",

--- a/examples/sendgrid/package.json
+++ b/examples/sendgrid/package.json
@@ -25,7 +25,7 @@
     "@react-email/html": "*",
     "@react-email/render": "*",
     "@sendgrid/mail": "7.7.0",
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "eslint": "8.23.1",

--- a/packages/body/package.json
+++ b/packages/body/package.json
@@ -31,7 +31,7 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/core": "7.23.9",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -43,7 +43,7 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/code-block/package.json
+++ b/packages/code-block/package.json
@@ -41,7 +41,7 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/code-inline/package.json
+++ b/packages/code-inline/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/column/package.json
+++ b/packages/column/package.json
@@ -43,7 +43,7 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -63,7 +63,7 @@
     "@react-email/text": "0.0.7"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -43,7 +43,7 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@react-email/components": "0.0.17-canary.1",
     "react-email": "2.1.2-canary.0",
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@types/react": "18.2.33",

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -31,7 +31,7 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -43,7 +43,7 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/heading/package.json
+++ b/packages/heading/package.json
@@ -46,7 +46,7 @@
     "@radix-ui/react-slot": "1.0.2"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/hr/package.json
+++ b/packages/hr/package.json
@@ -43,7 +43,7 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -43,7 +43,7 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -43,7 +43,7 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -43,7 +43,7 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -47,7 +47,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -43,7 +43,7 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "html-to-text": "9.0.5",
     "js-beautify": "^1.14.11",
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-dom": "18.2.0"
   },
   "devDependencies": {

--- a/packages/row/package.json
+++ b/packages/row/package.json
@@ -43,7 +43,7 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/section/package.json
+++ b/packages/section/package.json
@@ -43,7 +43,7 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -44,10 +44,10 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/core": "7.23.9",

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -43,7 +43,7 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
         specifier: 2.1.0
         version: 2.1.0(react@18.2.0)
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
       react-dom:
         specifier: 18.2.0
@@ -123,7 +123,7 @@ importers:
         specifier: 0.0.12
         version: 0.0.12(react@18.2.0)
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
       tinybench:
         specifier: 2.5.1
@@ -148,7 +148,7 @@ importers:
   packages/body:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/core':
@@ -173,7 +173,7 @@ importers:
   packages/button:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -198,7 +198,7 @@ importers:
         specifier: 1.29.0
         version: 1.29.0
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -223,7 +223,7 @@ importers:
   packages/code-inline:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -251,7 +251,7 @@ importers:
   packages/column:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -333,7 +333,7 @@ importers:
         specifier: 0.0.7
         version: link:../text
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -352,7 +352,7 @@ importers:
   packages/container:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -408,7 +408,7 @@ importers:
   packages/font:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -430,7 +430,7 @@ importers:
   packages/head:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -455,7 +455,7 @@ importers:
         specifier: 1.0.2
         version: 1.0.2(@types/react@18.2.33)(react@18.2.0)
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -477,7 +477,7 @@ importers:
   packages/hr:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -499,7 +499,7 @@ importers:
   packages/html:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -521,7 +521,7 @@ importers:
   packages/img:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -543,7 +543,7 @@ importers:
   packages/link:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -568,7 +568,7 @@ importers:
         specifier: 5.0.2
         version: 5.0.2(react@18.2.0)
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -590,7 +590,7 @@ importers:
   packages/preview:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -781,7 +781,7 @@ importers:
         specifier: ^1.14.11
         version: 1.15.1
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
       react-dom:
         specifier: 18.2.0
@@ -818,7 +818,7 @@ importers:
   packages/row:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -840,7 +840,7 @@ importers:
   packages/section:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':
@@ -862,7 +862,7 @@ importers:
   packages/tailwind:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/core':
@@ -938,7 +938,7 @@ importers:
   packages/text:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
       '@babel/preset-react':


### PR DESCRIPTION
This PR just changes all of our uses of React from exact `18.2.0`
to `^18.2.0` so that they all can use the new `18.3.0`. We already had
this for the `react-email` package (our CLI), but after the new version
released it was causing errors due to `@react-email/components` requiring
`react` exactly at `18.2.0` instead of `^18.2.0`, so this PR changes
those versions into using `^18.2.0`.

This is meant for #1432.
