### PR TITLE
chore: Move all dependency versions of `react-dom` to `^18.2.0`

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -12,7 +12,7 @@
     "@react-email/components": "0.0.13",
     "@react-email/tailwind": "0.0.14",
     "react": "^18.2.0",
-    "react-dom": "18.2.0",
+    "react-dom": "^18.2.0",
     "react-email": "2.1.0"
   },
   "devDependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,7 @@
     "next": "13.5.6",
     "prism-react-renderer": "2.1.0",
     "react": "^18.2.0",
-    "react-dom": "18.2.0",
+    "react-dom": "^18.2.0",
     "resend": "3.2.0"
   },
   "devDependencies": {

--- a/examples/resend/package.json
+++ b/examples/resend/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "next": "13.5.0",
     "react": "^18.2.0",
-    "react-dom": "18.2.0",
+    "react-dom": "^18.2.0",
     "resend": "0.15.1"
   },
   "devDependencies": {

--- a/examples/scaleway/next/package.json
+++ b/examples/scaleway/next/package.json
@@ -15,7 +15,7 @@
     "@scaleway/sdk": "1.5.0",
     "next": "13.5.0",
     "react": "^18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/node": "18.14.6",

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -46,7 +46,7 @@
     "html-to-text": "9.0.5",
     "js-beautify": "^1.14.11",
     "react": "^18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.23.3",

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -65,7 +65,7 @@
     "postcss": "8.4.38",
     "postcss-css-variables": "0.19.0",
     "process": "^0.11.10",
-    "react-dom": "18.2.0",
+    "react-dom": "^18.2.0",
     "tailwindcss": "3.3.2",
     "tsconfig": "workspace:*",
     "tsup": "7.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,7 +83,7 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       react-dom:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       resend:
         specifier: 3.2.0
@@ -784,7 +784,7 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       react-dom:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/preset-react':
@@ -911,7 +911,7 @@ importers:
         specifier: ^0.11.10
         version: 0.11.10(patch_hash=wpk4cjsj5eh7v5jak26jgis56e)
       react-dom:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       tailwindcss:
         specifier: 3.3.2


### PR DESCRIPTION
This was missing from my last PR bumping the React dependency versions to `^18.2.0`. We need this to avoid peer dependency issues for users.

