### PR TITLE
fix(react-email): Missing Headers on the global context for email templates

### DIFF
--- a/packages/code-block/.prettierignore
+++ b/packages/code-block/.prettierignore
@@ -1,0 +1,1 @@
+src/prism.ts

--- a/packages/code-block/src/prism.ts
+++ b/packages/code-block/src/prism.ts
@@ -7876,8 +7876,8 @@ export { Prism };
       return "string" == typeof e
         ? e
         : Array.isArray(e)
-        ? e.map(d).join("")
-        : d(e.content);
+          ? e.map(d).join("")
+          : d(e.content);
     }
     g.hooks.add("after-tokenize", function (e) {
       e.language in a &&
@@ -10194,8 +10194,8 @@ export { Prism };
       return "string" == typeof e
         ? e
         : Array.isArray(e)
-        ? e.map(a).join("")
-        : a(e.content);
+          ? e.map(a).join("")
+          : a(e.content);
     }
     (e.languages.naniscript = {
       comment: { pattern: /^([\t ]*);.*/m, lookbehind: !0 },
@@ -12582,13 +12582,13 @@ export { Prism };
               : "/>" !== a.content[a.content.length - 1].content &&
                 t.push({ tagName: s(a.content[0].content[1]), openedBraces: 0 })
             : 0 < t.length && "punctuation" === a.type && "{" === a.content
-            ? t[t.length - 1].openedBraces++
-            : 0 < t.length &&
-              0 < t[t.length - 1].openedBraces &&
-              "punctuation" === a.type &&
-              "}" === a.content
-            ? t[t.length - 1].openedBraces--
-            : (r = !0)),
+              ? t[t.length - 1].openedBraces++
+              : 0 < t.length &&
+                  0 < t[t.length - 1].openedBraces &&
+                  "punctuation" === a.type &&
+                  "}" === a.content
+                ? t[t.length - 1].openedBraces--
+                : (r = !0)),
           (r || "string" == typeof a) &&
             0 < t.length &&
             0 === t[t.length - 1].openedBraces &&
@@ -12608,8 +12608,8 @@ export { Prism };
         ? "string" == typeof e
           ? e
           : "string" == typeof e.content
-          ? e.content
-          : e.content.map(s).join("")
+            ? e.content
+            : e.content.map(s).join("")
         : "";
     };
     i.hooks.add("after-tokenize", function (e) {
@@ -15477,23 +15477,23 @@ export { Prism };
               : "/>" !== a.content[a.content.length - 1].content &&
                 t.push({ tagName: s(a.content[0].content[1]), openedBraces: 0 })
             : !(
-                0 < t.length &&
+                  0 < t.length &&
+                  "punctuation" === a.type &&
+                  "{" === a.content
+                ) ||
+                (e[n + 1] &&
+                  "punctuation" === e[n + 1].type &&
+                  "{" === e[n + 1].content) ||
+                (e[n - 1] &&
+                  "plain-text" === e[n - 1].type &&
+                  "{" === e[n - 1].content)
+              ? 0 < t.length &&
+                0 < t[t.length - 1].openedBraces &&
                 "punctuation" === a.type &&
-                "{" === a.content
-              ) ||
-              (e[n + 1] &&
-                "punctuation" === e[n + 1].type &&
-                "{" === e[n + 1].content) ||
-              (e[n - 1] &&
-                "plain-text" === e[n - 1].type &&
-                "{" === e[n - 1].content)
-            ? 0 < t.length &&
-              0 < t[t.length - 1].openedBraces &&
-              "punctuation" === a.type &&
-              "}" === a.content
-              ? t[t.length - 1].openedBraces--
-              : "comment" !== a.type && (r = !0)
-            : t[t.length - 1].openedBraces++),
+                "}" === a.content
+                ? t[t.length - 1].openedBraces--
+                : "comment" !== a.type && (r = !0)
+              : t[t.length - 1].openedBraces++),
           (r || "string" == typeof a) &&
             0 < t.length &&
             0 === t[t.length - 1].openedBraces &&
@@ -15514,8 +15514,8 @@ export { Prism };
       return "string" == typeof e
         ? e
         : "string" == typeof e.content
-        ? e.content
-        : e.content.map(s).join("");
+          ? e.content
+          : e.content.map(s).join("");
     };
     i.hooks.add("after-tokenize", function (e) {
       "xquery" === e.language && o(e.tokens);

--- a/packages/code-block/src/prism.ts
+++ b/packages/code-block/src/prism.ts
@@ -7876,8 +7876,8 @@ export { Prism };
       return "string" == typeof e
         ? e
         : Array.isArray(e)
-          ? e.map(d).join("")
-          : d(e.content);
+        ? e.map(d).join("")
+        : d(e.content);
     }
     g.hooks.add("after-tokenize", function (e) {
       e.language in a &&
@@ -10194,8 +10194,8 @@ export { Prism };
       return "string" == typeof e
         ? e
         : Array.isArray(e)
-          ? e.map(a).join("")
-          : a(e.content);
+        ? e.map(a).join("")
+        : a(e.content);
     }
     (e.languages.naniscript = {
       comment: { pattern: /^([\t ]*);.*/m, lookbehind: !0 },
@@ -12582,13 +12582,13 @@ export { Prism };
               : "/>" !== a.content[a.content.length - 1].content &&
                 t.push({ tagName: s(a.content[0].content[1]), openedBraces: 0 })
             : 0 < t.length && "punctuation" === a.type && "{" === a.content
-              ? t[t.length - 1].openedBraces++
-              : 0 < t.length &&
-                  0 < t[t.length - 1].openedBraces &&
-                  "punctuation" === a.type &&
-                  "}" === a.content
-                ? t[t.length - 1].openedBraces--
-                : (r = !0)),
+            ? t[t.length - 1].openedBraces++
+            : 0 < t.length &&
+              0 < t[t.length - 1].openedBraces &&
+              "punctuation" === a.type &&
+              "}" === a.content
+            ? t[t.length - 1].openedBraces--
+            : (r = !0)),
           (r || "string" == typeof a) &&
             0 < t.length &&
             0 === t[t.length - 1].openedBraces &&
@@ -12608,8 +12608,8 @@ export { Prism };
         ? "string" == typeof e
           ? e
           : "string" == typeof e.content
-            ? e.content
-            : e.content.map(s).join("")
+          ? e.content
+          : e.content.map(s).join("")
         : "";
     };
     i.hooks.add("after-tokenize", function (e) {
@@ -15477,23 +15477,23 @@ export { Prism };
               : "/>" !== a.content[a.content.length - 1].content &&
                 t.push({ tagName: s(a.content[0].content[1]), openedBraces: 0 })
             : !(
-                  0 < t.length &&
-                  "punctuation" === a.type &&
-                  "{" === a.content
-                ) ||
-                (e[n + 1] &&
-                  "punctuation" === e[n + 1].type &&
-                  "{" === e[n + 1].content) ||
-                (e[n - 1] &&
-                  "plain-text" === e[n - 1].type &&
-                  "{" === e[n - 1].content)
-              ? 0 < t.length &&
-                0 < t[t.length - 1].openedBraces &&
+                0 < t.length &&
                 "punctuation" === a.type &&
-                "}" === a.content
-                ? t[t.length - 1].openedBraces--
-                : "comment" !== a.type && (r = !0)
-              : t[t.length - 1].openedBraces++),
+                "{" === a.content
+              ) ||
+              (e[n + 1] &&
+                "punctuation" === e[n + 1].type &&
+                "{" === e[n + 1].content) ||
+              (e[n - 1] &&
+                "plain-text" === e[n - 1].type &&
+                "{" === e[n - 1].content)
+            ? 0 < t.length &&
+              0 < t[t.length - 1].openedBraces &&
+              "punctuation" === a.type &&
+              "}" === a.content
+              ? t[t.length - 1].openedBraces--
+              : "comment" !== a.type && (r = !0)
+            : t[t.length - 1].openedBraces++),
           (r || "string" == typeof a) &&
             0 < t.length &&
             0 === t[t.length - 1].openedBraces &&
@@ -15514,8 +15514,8 @@ export { Prism };
       return "string" == typeof e
         ? e
         : "string" == typeof e.content
-          ? e.content
-          : e.content.map(s).join("");
+        ? e.content
+        : e.content.map(s).join("");
     };
     i.hooks.add("after-tokenize", function (e) {
       "xquery" === e.language && o(e.tokens);

--- a/packages/react-email/src/utils/get-email-component.ts
+++ b/packages/react-email/src/utils/get-email-component.ts
@@ -12,10 +12,10 @@ export const getEmailComponent = async (
   emailPath: string,
 ): Promise<
   | {
-    emailComponent: EmailComponent;
+      emailComponent: EmailComponent;
 
-    sourceMapToOriginalFile: RawSourceMap;
-  }
+      sourceMapToOriginalFile: RawSourceMap;
+    }
   | { error: ErrorObject }
 > => {
   let outputFiles: OutputFile[];

--- a/packages/react-email/src/utils/get-email-component.ts
+++ b/packages/react-email/src/utils/get-email-component.ts
@@ -12,10 +12,10 @@ export const getEmailComponent = async (
   emailPath: string,
 ): Promise<
   | {
-      emailComponent: EmailComponent;
+    emailComponent: EmailComponent;
 
-      sourceMapToOriginalFile: RawSourceMap;
-    }
+    sourceMapToOriginalFile: RawSourceMap;
+  }
   | { error: ErrorObject }
 > => {
   let outputFiles: OutputFile[];
@@ -63,6 +63,7 @@ export const getEmailComponent = async (
     ReadableStream,
     URL,
     URLSearchParams,
+    Headers,
     module: { exports: { default: undefined as unknown } },
     __filanem: emailPath,
     __dirname: path.dirname(emailPath),


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

Hello, I noticed `Headers` doesn't in the `get-email-component.ts`. Because of this, you can't see the preview of your email template if you are using `Headers` in your code. This PR should fix it. 

(BTW I spent 4 hours while investigating why tf is this can't find Headers 🤣)
