### PR TITLE
fix(docs): Unclear mention of `rem` to `px` conversion on Tailwind page

### DIFF
--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -81,13 +81,15 @@ const Email = () => {
 <Info>
     Most email clients are style-limited and some styles may not work.
 
-    One example of this is how Tailwind will uses `rem` as it's main unit for better accessbility. 
+    One example of this is how Tailwind will use `rem` as its main unit for better accessbility. 
     This is not going to be supported by [some email clients](https://www.caniemail.com/features/css-unit-rem/)
-    and we recommend that you define a Tailwind config to override these. We can't really apply
-    this configuration for you as it would have a few [drawbacks](https://x.com/gabrielmfern/status/1788937281019027614).
+    and we recommend that you define a Tailwind config to override these. 
 
-    <Accordion title="Here's a good starter configuration for you to use to avoid issues:">
-        ```javascript
+    We can't really apply this configuration for you as it would have a few drawbacks. 
+    But, here's a good starter configuration for you to use to avoid issues:
+
+    <Accordion title="Tailwind configuration with px instead of rem">
+        ```typescript
         import type { TailwindConfig } from "@react-email/tailwind";
 
         export default {

--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -83,8 +83,71 @@ const Email = () => {
 
     One example of this is how Tailwind will uses `rem` as it's main unit for better accessbility. 
     This is not going to be supported by [some email clients](https://www.caniemail.com/features/css-unit-rem/)
-    and we recommend that you define a Tailwind config to override these if you care
-    about the support for those email clients. We will not do this ourselves, though.
+    and we recommend that you define a Tailwind config to override these. We can't really apply
+    this configuration for you as it would have a few [drawbacks](https://x.com/gabrielmfern/status/1788937281019027614).
+
+    <Accordion title="Here's a good starter configuration for you to use to avoid issues:">
+        ```javascript
+        import type { TailwindConfig } from "@react-email/tailwind";
+
+        export default {
+          theme: {
+            fontSize: {
+              xs: ["12px", { lineHeight: "16px" }],
+              sm: ["14px", { lineHeight: "20px" }],
+              base: ["16px", { lineHeight: "24px" }],
+              lg: ["18px", { lineHeight: "28px" }],
+              xl: ["20px", { lineHeight: "28px" }],
+              "2xl": ["24px", { lineHeight: "32px" }],
+              "3xl": ["30px", { lineHeight: "36px" }],
+              "4xl": ["36px", { lineHeight: "36px" }],
+              "5xl": ["48px", { lineHeight: "1" }],
+              "6xl": ["60px", { lineHeight: "1" }],
+              "7xl": ["72px", { lineHeight: "1" }],
+              "8xl": ["96px", { lineHeight: "1" }],
+              "9xl": ["144px", { lineHeight: "1" }],
+            },
+            spacing: {
+              px: "1px",
+              0: "0",
+              0.5: "2px",
+              1: "4px",
+              1.5: "6px",
+              2: "8px",
+              2.5: "10px",
+              3: "12px",
+              3.5: "14px",
+              4: "16px",
+              5: "20px",
+              6: "24px",
+              7: "28px",
+              8: "32px",
+              9: "36px",
+              10: "40px",
+              11: "44px",
+              12: "48px",
+              14: "56px",
+              16: "64px",
+              20: "80px",
+              24: "96px",
+              28: "112px",
+              32: "128px",
+              36: "144px",
+              40: "160px",
+              44: "176px",
+              48: "192px",
+              52: "208px",
+              56: "224px",
+              60: "240px",
+              64: "256px",
+              72: "288px",
+              80: "320px",
+              96: "384px",
+            },
+          },
+        } satisfies TailwindConfig;
+        ```
+    </Accordion>
 </Info>
 
 ## Live example

--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -89,7 +89,7 @@ const Email = () => {
     But, here's a good starter configuration for you to use to avoid issues:
 
     <Accordion title="Tailwind configuration with px instead of rem">
-        ```typescript
+        ```typescript tailwind.config.ts
         import type { TailwindConfig } from "@react-email/tailwind";
 
         export default {

--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -81,12 +81,14 @@ const Email = () => {
 <Info>
     Most email clients are style-limited and some styles may not work.
 
-    One example of this is how Tailwind will use `rem` as its main unit for better accessbility. 
-    This is not going to be supported by [some email clients](https://www.caniemail.com/features/css-unit-rem/)
-    and we recommend that you define a Tailwind config to override these. 
+    One example of this is how Tailwind will use `rem` as its main unit for
+    better accessibility. This is not supported by [some email
+    clients](https://www.caniemail.com/features/css-unit-rem/), if you want you
+    can override the Tailwind config.
 
-    We can't really apply this configuration for you as it would have a few drawbacks. 
-    But, here's a good starter configuration for you to use to avoid issues:
+    We can't really apply this configuration for you as it would have a few
+    drawbacks. We will probably provide a preset to remediate this. But, here's a
+    good starter configuration for you can use to avoid issues:
 
     <Accordion title="Tailwind configuration with px instead of rem">
         ```typescript tailwind.config.ts

--- a/apps/docs/components/tailwind.mdx
+++ b/apps/docs/components/tailwind.mdx
@@ -87,8 +87,8 @@ const Email = () => {
     can override the Tailwind config.
 
     We can't really apply this configuration for you as it would have a few
-    drawbacks. We will probably provide a preset to remediate this. But, here's a
-    good starter configuration for you can use to avoid issues:
+    drawbacks. In the future, we will probably provide a preset to remediate this.
+    But, for now, here's a good starter configuration you can use to avoid these issues:
 
     <Accordion title="Tailwind configuration with px instead of rem">
         ```typescript tailwind.config.ts


### PR DESCRIPTION
This part of the documentation was not clear enough to help users by guiding
them to change their config, and it read in a way that would get users
frustrated.

The reason we don't convert `rem` to `px` is because we are trying to avoid
doing “magical” behavior, and want our component to work as well as it can with
Tailwind's intellisense, so, our recommendation to deal with this issue is to
override the `rem` unit with `px` from the Tailwind configuration.

This PR both makes it clearer that we can't apply the configuration for them
ourselves, instead of making it sound like we don't want to. It also adds in a
starting point users can go to so that they have their Tailwind configured
properly without issues.
