### PR TITLE
Externalize jsx-runtime

### DIFF
--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -23,7 +23,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "tsc && vite build",
+    "build": "tsc; vite build",
     "dev": "vite build --watch",
     "clean": "rm -rf dist",
     "lint": "eslint .",

--- a/packages/tailwind/vite.config.ts
+++ b/packages/tailwind/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       // - polyfill libraries
       //   - process
       //   - memfs
-      external: ["react", "react-dom", /react-dom\/.*/],
+      external: ["react", /react\/.*/, "react-dom", /react-dom\/.*/],
     },
     lib: {
       entry: resolve(__dirname, "src/index.ts"),


### PR DESCRIPTION
For https://github.com/vercel/front/pull/32311/

Based off of 9945e8d3c1a2ae20ef6427c483a895ea6ae08b4a i.e. `@react-email/tailwing@0.14.0`