### PR TITLE
fix(@react-email/tailwind): Stop inlining JSX runtime

### DIFF
--- a/packages/tailwind/vite.config.ts
+++ b/packages/tailwind/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       // - polyfill libraries
       //   - process
       //   - memfs
-      external: ["react", "react-dom", /react-dom\/.*/],
+      external: ["react", /react\/.*/, "react-dom", /react-dom\/.*/],
     },
     lib: {
       entry: resolve(__dirname, "src/index.ts"),


### PR DESCRIPTION
Current builds of `@react-email/tailwind` have the JSX runtime inlined (see occurences of `ReactCurrentOwner` in https://unpkg.com/@react-email/tailwind@0.0.16-canary.1/dist/index.js). It should be treated as an external package just like `react` and `react-dom`. Otherwise it may break between any release since React packages need to be used in lockstep. However, inlining the JSX runtime could mean that a consumer has 18.3 installed, while the library was published with an inlined version of 18.2


