### PR TITLE
fix(@react-email/tailwind): Treat React as a peer dependency

### DIFF
--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -43,9 +43,6 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "dependencies": {
-    "react": "^18.2.0"
-  },
   "peerDependencies": {
     "react": "^18.2.0"
   },


### PR DESCRIPTION
`@react-email/tailwind` declared `react` both as a direct and peer dependency. This means the peer dependency is rendered useless since the package manager will install a version of `react` right next to `@react-email/tailwind` instead of where it makes most sense to result in a single version `react` being used.

This is consistent with the other packages.