### PR TITLE
fix(react-email): Export failing when using hooks

### DIFF
--- a/packages/react-email/.gitignore
+++ b/packages/react-email/.gitignore
@@ -4,7 +4,5 @@ cli
 !src/cli
 
 # for testing
-.react-email
 .for-dependency-graph.ts
-emails
 static

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -71,6 +71,7 @@
     "typescript": "5.1.6"
   },
   "devDependencies": {
+    "@react-email/components": "workspace:0.0.18-canary.0",
     "@types/fs-extra": "11.0.1",
     "@types/mime-types": "2.1.4",
     "@types/node": "18.0.0",

--- a/packages/react-email/src/cli/commands/.npmignore
+++ b/packages/react-email/src/cli/commands/.npmignore
@@ -1,0 +1,1 @@
+testing

--- a/packages/react-email/src/cli/commands/build.ts
+++ b/packages/react-email/src/cli/commands/build.ts
@@ -163,6 +163,7 @@ const updatePackageJson = async (builtPreviewAppPath: string) => {
     name: string;
     scripts: Record<string, string>;
     dependencies: Record<string, string>;
+    devDependencies: Record<string, string>;
   };
   packageJson.scripts.build = 'next build';
   packageJson.scripts.start = 'next start';
@@ -174,6 +175,7 @@ const updatePackageJson = async (builtPreviewAppPath: string) => {
   // See `src/actions/render-email-by-path` for more info on how we render the
   // email templates without `@react-email/render` being installed.
   delete packageJson.dependencies['@react-email/render'];
+  delete packageJson.devDependencies['@react-email/components'];
   packageJson.dependencies.sharp = '0.33.2';
   await fs.promises.writeFile(
     packageJsonPath,

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -1,11 +1,10 @@
 import fs, { unlinkSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { glob } from 'glob';
-import { buildSync } from 'esbuild';
+import { BuildFailure, build } from 'esbuild';
 import ora from 'ora';
 import logSymbols from 'log-symbols';
 import type { Options } from '@react-email/render';
-import { render } from '@react-email/render';
 import normalize from 'normalize-path';
 import { cp } from 'shelljs';
 import { closeOraOnSIGNIT } from '../utils/close-ora-on-sigint';
@@ -15,6 +14,7 @@ import {
   getEmailsDirectoryMetadata,
 } from '../../actions/get-emails-directory-metadata';
 import { renderResolver } from '../../utils/render-resolver-esbuild-plugin';
+import { createElement } from 'react';
 
 const getEmailTemplatesFromDirectory = (emailDirectory: EmailsDirectory) => {
   const templatePaths = [] as string[];
@@ -28,6 +28,10 @@ const getEmailTemplatesFromDirectory = (emailDirectory: EmailsDirectory) => {
   return templatePaths;
 };
 
+type ExportTemplatesOptions = Options & {
+  silent?: boolean;
+};
+
 /*
   This first builds all the templates using esbuild and then puts the output in the `.js`
   files. Then these `.js` files are imported dynamically and rendered to `.html` files
@@ -36,58 +40,69 @@ const getEmailTemplatesFromDirectory = (emailDirectory: EmailsDirectory) => {
 export const exportTemplates = async (
   pathToWhereEmailMarkupShouldBeDumped: string,
   emailsDirectoryPath: string,
-  options: Options,
+  options: ExportTemplatesOptions,
 ) => {
   /* Delete the out directory if it already exists */
   if (fs.existsSync(pathToWhereEmailMarkupShouldBeDumped)) {
     fs.rmSync(pathToWhereEmailMarkupShouldBeDumped, { recursive: true });
   }
 
-  const spinner = ora('Preparing files...\n').start();
-  closeOraOnSIGNIT(spinner);
+  let spinner: ora.Ora | undefined;
+  if (!options.silent) {
+    spinner = ora('Preparing files...\n').start();
+    closeOraOnSIGNIT(spinner);
+  }
 
   const emailsDirectoryMetadata = await getEmailsDirectoryMetadata(
     path.resolve(process.cwd(), emailsDirectoryPath),
   );
 
   if (typeof emailsDirectoryMetadata === 'undefined') {
-    spinner.stopAndPersist({
-      symbol: logSymbols.error,
-      text: `Could not find the directory at ${emailsDirectoryPath}`,
-    });
+    if (spinner) {
+      spinner.stopAndPersist({
+        symbol: logSymbols.error,
+        text: `Could not find the directory at ${emailsDirectoryPath}`,
+      });
+    }
     return;
   }
 
   const allTemplates = getEmailTemplatesFromDirectory(emailsDirectoryMetadata);
 
-  const buildResult = buildSync({
-    bundle: true,
-    entryPoints: allTemplates,
-    plugins: [renderResolver],
-    platform: 'node',
-    format: 'cjs',
-    loader: { '.js': 'jsx' },
-    outExtension: { '.js': '.cjs' },
-    jsx: 'transform',
-    write: true,
-    outdir: pathToWhereEmailMarkupShouldBeDumped,
-  });
-  if (buildResult.warnings.length > 0) {
-    console.warn(buildResult.warnings);
-  }
-  if (buildResult.errors.length > 0) {
-    spinner.stopAndPersist({
-      symbol: logSymbols.error,
-      text: 'Failed to build emails',
+  try { 
+    await build({
+      bundle: true,
+      entryPoints: allTemplates,
+      plugins: [renderResolver(allTemplates)],
+      platform: 'node',
+      format: 'cjs',
+      loader: { '.js': 'jsx' },
+      outExtension: { '.js': '.cjs' },
+      jsx: 'transform',
+      write: true,
+      outdir: pathToWhereEmailMarkupShouldBeDumped,
     });
-    console.error(buildResult.errors);
+  } catch (exception) {
+    const buildFailure = exception as BuildFailure;
+    if (spinner) {
+      spinner.stopAndPersist({
+        symbol: logSymbols.error,
+        text: 'Failed to build emails',
+      });
+    }
+
+    console.warn(buildFailure.warnings);
+    console.error(buildFailure.errors);
     throw new Error(
-      `esbuild bundling process for email templates:\n${allTemplates
+      `esbuild bundling process for email templates failed:\n${allTemplates
         .map((p) => `- ${p}`)
         .join('\n')}`,
     );
   }
-  spinner.succeed();
+
+  if (spinner) {
+    spinner.succeed();
+  }
 
   const allBuiltTemplates = glob.sync(
     normalize(`${pathToWhereEmailMarkupShouldBeDumped}/**/*.cjs`),
@@ -98,12 +113,14 @@ export const exportTemplates = async (
 
   for (const template of allBuiltTemplates) {
     try {
-      spinner.text = `rendering ${template.split('/').pop()}`;
-      spinner.render();
+      if (spinner) {
+        spinner.text = `rendering ${template.split('/').pop()}`;
+        spinner.render();
+      }
       delete require.cache[template];
       const emailModule = require(template);
       const rendered = await emailModule.renderAsync(
-        emailModule.default({}),
+        createElement(emailModule.default, {}),
         options,
       );
       const htmlPath = template.replace(
@@ -113,17 +130,21 @@ export const exportTemplates = async (
       writeFileSync(htmlPath, rendered);
       unlinkSync(template);
     } catch (exception) {
-      spinner.stopAndPersist({
-        symbol: logSymbols.error,
-        text: `failed when rendering ${template.split('/').pop()}`,
-      });
+      if (spinner) {
+        spinner.stopAndPersist({
+          symbol: logSymbols.error,
+          text: `failed when rendering ${template.split('/').pop()}`,
+        });
+      }
       console.error(exception);
       throw exception;
     }
   }
-  spinner.succeed('Rendered all files');
-  spinner.text = `Copying static files`;
-  spinner.render();
+  if (spinner) {
+    spinner.succeed('Rendered all files');
+    spinner.text = `Copying static files`;
+    spinner.render();
+  }
 
   // ex: emails/static
   const staticDirectoryPath = path.join(emailsDirectoryPath, 'static');
@@ -144,25 +165,28 @@ export const exportTemplates = async (
       path.join(pathToWhereEmailMarkupShouldBeDumped, 'static'),
     );
     if (result.code > 0) {
-      spinner.stopAndPersist({
-        symbol: logSymbols.error,
-        text: 'Failed to copy static files',
-      });
+      if (spinner) {
+        spinner.stopAndPersist({
+          symbol: logSymbols.error,
+          text: 'Failed to copy static files',
+        });
+      }
       throw new Error(
         `Something went wrong while copying the file to ${pathToWhereEmailMarkupShouldBeDumped}/static, ${result.stderr}`,
       );
     }
   }
-  spinner.succeed();
 
-  const fileTree = await tree(pathToWhereEmailMarkupShouldBeDumped, 4);
+  if (spinner && !options.silent) {
+    spinner.succeed();
 
-  console.log(fileTree);
+    const fileTree = await tree(pathToWhereEmailMarkupShouldBeDumped, 4);
 
-  spinner.stopAndPersist({
-    symbol: logSymbols.success,
-    text: 'Successfully exported emails',
-  });
+    console.log(fileTree);
 
-  process.exit();
+    spinner.stopAndPersist({
+      symbol: logSymbols.success,
+      text: 'Successfully exported emails',
+    });
+  }
 };

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -69,7 +69,7 @@ export const exportTemplates = async (
 
   const allTemplates = getEmailTemplatesFromDirectory(emailsDirectoryMetadata);
 
-  try { 
+  try {
     await build({
       bundle: true,
       entryPoints: allTemplates,

--- a/packages/react-email/src/cli/commands/testing/.gitignore
+++ b/packages/react-email/src/cli/commands/testing/.gitignore
@@ -1,0 +1,2 @@
+# for the `email export` command
+out

--- a/packages/react-email/src/cli/commands/testing/__snapshots__/export.spec.ts.snap
+++ b/packages/react-email/src/cli/commands/testing/__snapshots__/export.spec.ts.snap
@@ -1,0 +1,64 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`email export 1`] = `
+"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <meta name="x-apple-disable-message-reformatting" />
+  </head>
+  <div style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0">Banana boy<div> ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿</div>
+  </div>
+
+  <body style="background-color:rgb(255,255,255);margin-top:auto;margin-bottom:auto;margin-left:auto;margin-right:auto;font-family:ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;;padding-left:0.5rem;padding-right:0.5rem">
+    <table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation" style="max-width:465px;border-width:1px;border-style:solid;border-color:rgb(234,234,234);border-radius:0.25rem;margin-top:40px;margin-bottom:40px;margin-left:auto;margin-right:auto;padding:20px">
+      <tbody>
+        <tr style="width:100%">
+          <td>
+            <table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation" style="margin-top:32px">
+              <tbody>
+                <tr>
+                  <td><img alt="Vercel" height="37" src="/static/vercel-logo.png" style="display:block;outline:none;border:none;text-decoration:none;margin-top:0px;margin-bottom:0px;margin-left:auto;margin-right:auto" width="40" /></td>
+                </tr>
+              </tbody>
+            </table>
+            <h1 style="color:rgb(0,0,0);font-size:24px;font-weight:400;text-align:center;padding:0px;margin-top:30px;margin-bottom:30px;margin-left:0px;margin-right:0px">Join <strong></strong> on <strong>Vercel</strong></h1>
+            <p style="font-size:14px;line-height:24px;margin:16px 0;color:rgb(0,0,0)">Hello <!-- -->,</p>
+            <p style="font-size:14px;line-height:24px;margin:16px 0;color:rgb(0,0,0)"><strong></strong> (<a href="mailto:undefined" style="color:rgb(37,99,235);text-decoration:none;text-decoration-line:none" target="_blank"></a>) has invited you to the <strong></strong> team on<!-- --> <strong>Vercel</strong>.</p>
+            <table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation">
+              <tbody>
+                <tr>
+                  <td>
+                    <table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation">
+                      <tbody style="width:100%">
+                        <tr style="width:100%">
+                          <td align="right" data-id="__react-email-column"><img height="64" style="display:block;outline:none;border:none;text-decoration:none;border-radius:9999px" width="64" /></td>
+                          <td align="center" data-id="__react-email-column"><img alt="invited you to" height="9" src="/static/vercel-arrow.png" style="display:block;outline:none;border:none;text-decoration:none" width="12" /></td>
+                          <td align="left" data-id="__react-email-column"><img height="64" style="display:block;outline:none;border:none;text-decoration:none;border-radius:9999px" width="64" /></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation" style="text-align:center;margin-top:32px;margin-bottom:32px">
+              <tbody>
+                <tr>
+                  <td><a style="line-height:100%;text-decoration:none;display:inline-block;max-width:100%;background-color:rgb(0,0,0);border-radius:0.25rem;color:rgb(255,255,255);font-size:12px;font-weight:600;text-decoration-line:none;text-align:center;padding-left:1.25rem;padding-right:1.25rem;padding-top:0.75rem;padding-bottom:0.75rem;padding:12px 20px 12px 20px" target="_blank"><span><!--[if mso]><i style="letter-spacing: 20px;mso-font-width:-100%;mso-text-raise:18" hidden>&nbsp;</i><![endif]--></span><span style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:9px">Join the team</span><span><!--[if mso]><i style="letter-spacing: 20px;mso-font-width:-100%" hidden>&nbsp;</i><![endif]--></span></a></td>
+                </tr>
+              </tbody>
+            </table>
+            <p style="font-size:14px;line-height:24px;margin:16px 0;color:rgb(0,0,0)">or copy and paste this URL into your browser:<!-- --> <a style="color:rgb(37,99,235);text-decoration:none;text-decoration-line:none" target="_blank"></a></p>
+            <hr style="width:100%;border:none;border-top:1px solid #eaeaea;border-width:1px;border-style:solid;border-color:rgb(234,234,234);margin-top:26px;margin-bottom:26px;margin-left:0px;margin-right:0px" />
+            <p style="font-size:12px;line-height:24px;margin:16px 0;color:rgb(102,102,102)">This invitation was intended for<!-- --> <span style="color:rgb(0,0,0)"></span>. This invite was sent from <span style="color:rgb(0,0,0)"></span> <!-- -->located in<!-- --> <span style="color:rgb(0,0,0)"></span>. If you were not expecting this invitation, you can ignore this email. If you are concerned about your account&#x27;s safety, please reply to this email to get in touch with us.</p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+
+</html>"
+`;

--- a/packages/react-email/src/cli/commands/testing/emails/vercel-invite-user.tsx
+++ b/packages/react-email/src/cli/commands/testing/emails/vercel-invite-user.tsx
@@ -1,0 +1,154 @@
+import {
+  Body,
+  Button,
+  Container,
+  Column,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Row,
+  Section,
+  Text,
+  Tailwind,
+} from "@react-email/components";
+import * as React from "react";
+
+interface VercelInviteUserEmailProps {
+  username?: string;
+  userImage?: string;
+  invitedByUsername?: string;
+  invitedByEmail?: string;
+  teamName?: string;
+  teamImage?: string;
+  inviteLink?: string;
+  inviteFromIp?: string;
+  inviteFromLocation?: string;
+}
+
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : "";
+
+export const VercelInviteUserEmail = ({
+  username,
+  userImage,
+  invitedByUsername,
+  invitedByEmail,
+  teamName,
+  teamImage,
+  inviteLink,
+  inviteFromIp,
+  inviteFromLocation,
+}: VercelInviteUserEmailProps) => {
+  const previewText = `Join ${invitedByUsername} on Vercel`;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{previewText}</Preview>
+      <Tailwind>
+        <Body className="bg-white my-auto mx-auto font-sans px-2">
+          <Container className="border border-solid border-[#eaeaea] rounded my-[40px] mx-auto p-[20px] max-w-[465px]">
+            <Section className="mt-[32px]">
+              <Img
+                src={`${baseUrl}/static/vercel-logo.png`}
+                width="40"
+                height="37"
+                alt="Vercel"
+                className="my-0 mx-auto"
+              />
+            </Section>
+            <Heading className="text-black text-[24px] font-normal text-center p-0 my-[30px] mx-0">
+              Join <strong>{teamName}</strong> on <strong>Vercel</strong>
+            </Heading>
+            <Text className="text-black text-[14px] leading-[24px]">
+              Hello {username},
+            </Text>
+            <Text className="text-black text-[14px] leading-[24px]">
+              <strong>{invitedByUsername}</strong> (
+              <Link
+                href={`mailto:${invitedByEmail}`}
+                className="text-blue-600 no-underline"
+              >
+                {invitedByEmail}
+              </Link>
+              ) has invited you to the <strong>{teamName}</strong> team on{" "}
+              <strong>Vercel</strong>.
+            </Text>
+            <Section>
+              <Row>
+                <Column align="right">
+                  <Img
+                    className="rounded-full"
+                    src={userImage}
+                    width="64"
+                    height="64"
+                  />
+                </Column>
+                <Column align="center">
+                  <Img
+                    src={`${baseUrl}/static/vercel-arrow.png`}
+                    width="12"
+                    height="9"
+                    alt="invited you to"
+                  />
+                </Column>
+                <Column align="left">
+                  <Img
+                    className="rounded-full"
+                    src={teamImage}
+                    width="64"
+                    height="64"
+                  />
+                </Column>
+              </Row>
+            </Section>
+            <Section className="text-center mt-[32px] mb-[32px]">
+              <Button
+                className="bg-[#000000] rounded text-white text-[12px] font-semibold no-underline text-center px-5 py-3"
+                href={inviteLink}
+              >
+                Join the team
+              </Button>
+            </Section>
+            <Text className="text-black text-[14px] leading-[24px]">
+              or copy and paste this URL into your browser:{" "}
+              <Link href={inviteLink} className="text-blue-600 no-underline">
+                {inviteLink}
+              </Link>
+            </Text>
+            <Hr className="border border-solid border-[#eaeaea] my-[26px] mx-0 w-full" />
+            <Text className="text-[#666666] text-[12px] leading-[24px]">
+              This invitation was intended for{" "}
+              <span className="text-black">{username}</span>. This invite was
+              sent from <span className="text-black">{inviteFromIp}</span>{" "}
+              located in{" "}
+              <span className="text-black">{inviteFromLocation}</span>. If you
+              were not expecting this invitation, you can ignore this email. If
+              you are concerned about your account's safety, please reply to
+              this email to get in touch with us.
+            </Text>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+VercelInviteUserEmail.PreviewProps = {
+  username: "alanturing",
+  userImage: `${baseUrl}/static/vercel-user.png`,
+  invitedByUsername: "Alan",
+  invitedByEmail: "alan.turing@example.com",
+  teamName: "Enigma",
+  teamImage: `${baseUrl}/static/vercel-team.png`,
+  inviteLink: "https://vercel.com/teams/invite/foo",
+  inviteFromIp: "204.13.186.218",
+  inviteFromLocation: "São Paulo, Brazil",
+} as VercelInviteUserEmailProps;
+
+export default VercelInviteUserEmail;

--- a/packages/react-email/src/cli/commands/testing/emails/vercel-invite-user.tsx
+++ b/packages/react-email/src/cli/commands/testing/emails/vercel-invite-user.tsx
@@ -14,8 +14,8 @@ import {
   Section,
   Text,
   Tailwind,
-} from "@react-email/components";
-import * as React from "react";
+} from '@react-email/components';
+import * as React from 'react';
 
 interface VercelInviteUserEmailProps {
   username?: string;
@@ -31,7 +31,7 @@ interface VercelInviteUserEmailProps {
 
 const baseUrl = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
-  : "";
+  : '';
 
 export const VercelInviteUserEmail = ({
   username,
@@ -80,7 +80,7 @@ export const VercelInviteUserEmail = ({
               >
                 {invitedByEmail}
               </Link>
-              ) has invited you to the <strong>{teamName}</strong> team on{" "}
+              ) has invited you to the <strong>{teamName}</strong> team on{' '}
               <strong>Vercel</strong>.
             </Text>
             <Section>
@@ -120,17 +120,17 @@ export const VercelInviteUserEmail = ({
               </Button>
             </Section>
             <Text className="text-black text-[14px] leading-[24px]">
-              or copy and paste this URL into your browser:{" "}
+              or copy and paste this URL into your browser:{' '}
               <Link href={inviteLink} className="text-blue-600 no-underline">
                 {inviteLink}
               </Link>
             </Text>
             <Hr className="border border-solid border-[#eaeaea] my-[26px] mx-0 w-full" />
             <Text className="text-[#666666] text-[12px] leading-[24px]">
-              This invitation was intended for{" "}
+              This invitation was intended for{' '}
               <span className="text-black">{username}</span>. This invite was
-              sent from <span className="text-black">{inviteFromIp}</span>{" "}
-              located in{" "}
+              sent from <span className="text-black">{inviteFromIp}</span>{' '}
+              located in{' '}
               <span className="text-black">{inviteFromLocation}</span>. If you
               were not expecting this invitation, you can ignore this email. If
               you are concerned about your account's safety, please reply to
@@ -144,15 +144,15 @@ export const VercelInviteUserEmail = ({
 };
 
 VercelInviteUserEmail.PreviewProps = {
-  username: "alanturing",
+  username: 'alanturing',
   userImage: `${baseUrl}/static/vercel-user.png`,
-  invitedByUsername: "Alan",
-  invitedByEmail: "alan.turing@example.com",
-  teamName: "Enigma",
+  invitedByUsername: 'Alan',
+  invitedByEmail: 'alan.turing@example.com',
+  teamName: 'Enigma',
   teamImage: `${baseUrl}/static/vercel-team.png`,
-  inviteLink: "https://vercel.com/teams/invite/foo",
-  inviteFromIp: "204.13.186.218",
-  inviteFromLocation: "São Paulo, Brazil",
+  inviteLink: 'https://vercel.com/teams/invite/foo',
+  inviteFromIp: '204.13.186.218',
+  inviteFromLocation: 'São Paulo, Brazil',
 } as VercelInviteUserEmailProps;
 
 export default VercelInviteUserEmail;

--- a/packages/react-email/src/cli/commands/testing/emails/vercel-invite-user.tsx
+++ b/packages/react-email/src/cli/commands/testing/emails/vercel-invite-user.tsx
@@ -45,11 +45,15 @@ export const VercelInviteUserEmail = ({
   inviteFromLocation,
 }: VercelInviteUserEmailProps) => {
   const previewText = `Join ${invitedByUsername} on Vercel`;
+  const [myState, setMyState] = React.useState(previewText);
+  if (myState === previewText) {
+    setMyState('Banana boy');
+  }
 
   return (
     <Html>
       <Head />
-      <Preview>{previewText}</Preview>
+      <Preview>{myState}</Preview>
       <Tailwind>
         <Body className="bg-white my-auto mx-auto font-sans px-2">
           <Container className="border border-solid border-[#eaeaea] rounded my-[40px] mx-auto p-[20px] max-w-[465px]">

--- a/packages/react-email/src/cli/commands/testing/export.spec.ts
+++ b/packages/react-email/src/cli/commands/testing/export.spec.ts
@@ -7,7 +7,7 @@ test('email export', async () => {
   const pathToDumpMarkup = path.resolve(__dirname, './out');
   await exportTemplates(pathToDumpMarkup, pathToEmailsDirectory, {
     pretty: true,
-    silent: true
+    silent: true,
   });
 
   expect(fs.existsSync(pathToDumpMarkup)).toBe(true);

--- a/packages/react-email/src/cli/commands/testing/export.spec.ts
+++ b/packages/react-email/src/cli/commands/testing/export.spec.ts
@@ -5,12 +5,16 @@ import { exportTemplates } from '../export';
 test('email export', async () => {
   const pathToEmailsDirectory = path.resolve(__dirname, './emails');
   const pathToDumpMarkup = path.resolve(__dirname, './out');
-  await exportTemplates(pathToEmailsDirectory, pathToDumpMarkup, {
+  await exportTemplates(pathToDumpMarkup, pathToEmailsDirectory, {
     pretty: true,
+    silent: true
   });
 
   expect(fs.existsSync(pathToDumpMarkup)).toBe(true);
   expect(
-    fs.existsSync(path.resolve(pathToDumpMarkup, './vercel-invite-user')),
-  ).toBe(true);
+    await fs.promises.readFile(
+      path.resolve(pathToDumpMarkup, './vercel-invite-user.html'),
+      'utf8',
+    ),
+  ).toMatchSnapshot();
 });

--- a/packages/react-email/src/cli/commands/testing/export.spec.ts
+++ b/packages/react-email/src/cli/commands/testing/export.spec.ts
@@ -1,0 +1,16 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import { exportTemplates } from '../export';
+
+test('email export', async () => {
+  const pathToEmailsDirectory = path.resolve(__dirname, './emails');
+  const pathToDumpMarkup = path.resolve(__dirname, './out');
+  await exportTemplates(pathToEmailsDirectory, pathToDumpMarkup, {
+    pretty: true,
+  });
+
+  expect(fs.existsSync(pathToDumpMarkup)).toBe(true);
+  expect(
+    fs.existsSync(path.resolve(pathToDumpMarkup, './vercel-invite-user')),
+  ).toBe(true);
+});

--- a/packages/react-email/src/cli/index.ts
+++ b/packages/react-email/src/cli/index.ts
@@ -43,7 +43,11 @@ program
   .option('-p, --pretty', 'Pretty print the output', false)
   .option('-t, --plainText', 'Set output format as plain text', false)
   .option('-d, --dir <path>', 'Directory with your email templates', './emails')
-  .option('-s, --silent', 'To, or not to show a spinner with process information', false)
+  .option(
+    '-s, --silent',
+    'To, or not to show a spinner with process information',
+    false,
+  )
   .action(({ outDir, pretty, plainText, silent, dir: srcDir }) =>
     exportTemplates(outDir, srcDir, { pretty, silent, plainText }),
   );

--- a/packages/react-email/src/cli/index.ts
+++ b/packages/react-email/src/cli/index.ts
@@ -43,8 +43,9 @@ program
   .option('-p, --pretty', 'Pretty print the output', false)
   .option('-t, --plainText', 'Set output format as plain text', false)
   .option('-d, --dir <path>', 'Directory with your email templates', './emails')
-  .action(({ outDir, pretty, plainText, dir: srcDir }) =>
-    exportTemplates(outDir, srcDir, { pretty, plainText }),
+  .option('-s, --silent', 'To, or not to show a spinner with process information', false)
+  .action(({ outDir, pretty, plainText, silent, dir: srcDir }) =>
+    exportTemplates(outDir, srcDir, { pretty, silent, plainText }),
   );
 
 program.parse();

--- a/packages/react-email/src/utils/get-email-component.ts
+++ b/packages/react-email/src/utils/get-email-component.ts
@@ -2,11 +2,7 @@
 import path from 'node:path';
 import vm from 'node:vm';
 import { type RawSourceMap } from 'source-map-js';
-import {
-  type OutputFile,
-  build,
-  type BuildFailure,
-} from 'esbuild';
+import { type OutputFile, build, type BuildFailure } from 'esbuild';
 import type { renderAsync } from '@react-email/render';
 import type { EmailTemplate as EmailComponent } from './types/email-template';
 import type { ErrorObject } from './types/error-object';

--- a/packages/react-email/src/utils/get-email-component.ts
+++ b/packages/react-email/src/utils/get-email-component.ts
@@ -1,14 +1,11 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import path from 'node:path';
 import vm from 'node:vm';
-import fs from 'node:fs/promises';
 import { type RawSourceMap } from 'source-map-js';
 import {
   type OutputFile,
   build,
-  type ResolveOptions,
   type BuildFailure,
-  type Loader,
 } from 'esbuild';
 import type { renderAsync } from '@react-email/render';
 import type { EmailTemplate as EmailComponent } from './types/email-template';

--- a/packages/react-email/src/utils/render-resolver-esbuild-plugin.ts
+++ b/packages/react-email/src/utils/render-resolver-esbuild-plugin.ts
@@ -41,8 +41,8 @@ export const renderResolver = (emailTemplates: string[]) => ({
 
         // If @react-email/render does not exist, resolve to @react-email/components
         result = await b.resolve('@react-email/components', options);
-        if (result.errors.length > 0) {
-          result.errors[0]!.text =
+        if (result.errors.length > 0 && result.errors[0]) {
+          result.errors[0].text =
             "Failed trying to import `renderAsync` from either `@react-email/render` or `@react-email/components` to be able to render your email template.\n Maybe you don't have either of them installed?";
         }
         return result;

--- a/packages/react-email/src/utils/render-resolver-esbuild-plugin.ts
+++ b/packages/react-email/src/utils/render-resolver-esbuild-plugin.ts
@@ -1,0 +1,52 @@
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import type { Loader, PluginBuild, ResolveOptions } from 'esbuild';
+
+/**
+ * Made to export the `renderAsync` function out of the user's email template
+ * so that issues like https://github.com/resend/react-email/issues/649 don't
+ * happen.
+ *
+ * This avoids multiple versions of React being involved, i.e., the version
+ * in the CLI vs. the version the user has on their emails.
+ */
+export const renderResolver = (emailTemplates: string[]) => ({
+  name: 'render-resolver',
+  setup: (b: PluginBuild) => {
+    b.onLoad(
+      { filter: new RegExp(emailTemplates.join('|')) },
+      async ({ path: pathToFile }) => {
+        return {
+          contents: `${await fs.readFile(pathToFile, 'utf8')};
+          export { renderAsync } from 'react-email-module-that-will-export-render'
+        `,
+          loader: path.extname(pathToFile).slice(1) as Loader,
+        };
+      },
+    );
+
+    b.onResolve(
+      { filter: /^react-email-module-that-will-export-render$/ },
+      async (args) => {
+        const options: ResolveOptions = {
+          kind: 'import-statement',
+          importer: args.importer,
+          resolveDir: args.resolveDir,
+          namespace: args.namespace,
+        };
+        let result = await b.resolve('@react-email/render', options);
+        if (result.errors.length === 0) {
+          return result;
+        }
+
+        // If @react-email/render does not exist, resolve to @react-email/components
+        result = await b.resolve('@react-email/components', options);
+        if (result.errors.length > 0) {
+          result.errors[0]!.text =
+            "Failed trying to import `renderAsync` from either `@react-email/render` or `@react-email/components` to be able to render your email template.\n Maybe you don't have either of them installed?";
+        }
+        return result;
+      },
+    );
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -766,6 +766,9 @@ importers:
         specifier: 5.1.6
         version: 5.1.6
     devDependencies:
+      '@react-email/components':
+        specifier: workspace:0.0.18-canary.0
+        version: link:../components
       '@types/fs-extra':
         specifier: 11.0.1
         version: 11.0.1


### PR DESCRIPTION
This is meant for https://github.com/resend/react-email/issues/649#issuecomment-2112860431. 

The issue causing it to fail was the same one causing `email dev` to fail in the same way, and this fixes it using the same esbuild plugin approach as #1431.