### PR TITLE
chore(create-email, react-email): Bump for canary release

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -12,7 +12,7 @@
     "@react-email/components": "0.0.18-canary.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-email": "2.1.3-canary.1"
+    "react-email": "2.1.3-canary.2"
   },
   "devDependencies": {
     "next": "14.1.4",

--- a/packages/create-email/package.json
+++ b/packages/create-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-email",
-  "version": "0.0.26-canary.1",
+  "version": "0.0.26-canary.2",
   "description": "The easiest way to get started with React Email",
   "main": "src/index.js",
   "type": "module",

--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@react-email/components": "0.0.18-canary.0",
-    "react-email": "2.1.3-canary.1",
+    "react-email": "2.1.3-canary.2",
     "react": "^18.2.0"
   },
   "devDependencies": {

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-email",
-  "version": "2.1.3-canary.1",
+  "version": "2.1.3-canary.2",
   "description": "A live preview of your emails right in your browser.",
   "bin": {
     "email": "./cli/index.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       react-email:
-        specifier: 2.1.3-canary.1
+        specifier: 2.1.3-canary.2
         version: link:../../packages/react-email
     devDependencies:
       '@types/react':


### PR DESCRIPTION
- **react-email: 2.1.3-canary.1 -> 2.1.3-canary.2**
- **bump create-email template dependency on react-email to 2.1.3-canary.2**
- **create-email: 0.0.26-canary.1 -> 0.0.26-canary.2**
