### PR TITLE
chore(components, create-email, head, react-email, render, tailwind): Bump for stable release

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -9,10 +9,10 @@
     "export": "email export"
   },
   "dependencies": {
-    "@react-email/components": "0.0.18-canary.0",
+    "@react-email/components": "0.0.18",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-email": "2.1.3-canary.2"
+    "react-email": "2.1.3"
   },
   "devDependencies": {
     "next": "14.1.4",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,7 +56,7 @@
     "@react-email/link": "0.0.8",
     "@react-email/markdown": "0.0.10",
     "@react-email/preview": "0.0.9",
-    "@react-email/render": "0.0.14-canary.0",
+    "@react-email/render": "0.0.14",
     "@react-email/row": "0.0.8",
     "@react-email/section": "0.0.12",
     "@react-email/tailwind": "0.0.17-canary.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/components",
-  "version": "0.0.18-canary.0",
+  "version": "0.0.18",
   "description": "A collection of all components React Email.",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -59,7 +59,7 @@
     "@react-email/render": "0.0.14",
     "@react-email/row": "0.0.8",
     "@react-email/section": "0.0.12",
-    "@react-email/tailwind": "0.0.17-canary.0",
+    "@react-email/tailwind": "0.0.17",
     "@react-email/text": "0.0.8"
   },
   "peerDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,7 +48,7 @@
     "@react-email/column": "0.0.10",
     "@react-email/container": "0.0.12",
     "@react-email/font": "0.0.6",
-    "@react-email/head": "0.0.9-canary.0",
+    "@react-email/head": "0.0.9",
     "@react-email/heading": "0.0.12",
     "@react-email/hr": "0.0.8",
     "@react-email/html": "0.0.8",

--- a/packages/create-email/package.json
+++ b/packages/create-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-email",
-  "version": "0.0.26-canary.2",
+  "version": "0.0.26",
   "description": "The easiest way to get started with React Email",
   "main": "src/index.js",
   "type": "module",

--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -8,8 +8,8 @@
     "export": "email export"
   },
   "dependencies": {
-    "@react-email/components": "0.0.18-canary.0",
-    "react-email": "2.1.3-canary.2",
+    "@react-email/components": "0.0.18",
+    "react-email": "2.1.3",
     "react": "^18.2.0"
   },
   "devDependencies": {

--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/head",
-  "version": "0.0.9-canary.0",
+  "version": "0.0.9",
   "description": "Contains head components such as style and meta elements.",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -34,7 +34,6 @@
     "@radix-ui/react-slot": "1.0.2",
     "@radix-ui/react-toggle-group": "1.0.4",
     "@radix-ui/react-tooltip": "1.0.7",
-    "@react-email/render": "0.0.14-canary.0",
     "@swc/core": "1.3.101",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
@@ -72,6 +71,7 @@
   },
   "devDependencies": {
     "@react-email/components": "workspace:0.0.18-canary.0",
+    "@react-email/render": "0.0.14",
     "@types/fs-extra": "11.0.1",
     "@types/mime-types": "2.1.4",
     "@types/node": "18.0.0",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-email",
-  "version": "2.1.3-canary.2",
+  "version": "2.1.3",
   "description": "A live preview of your emails right in your browser.",
   "bin": {
     "email": "./cli/index.js"

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -70,7 +70,7 @@
     "typescript": "5.1.6"
   },
   "devDependencies": {
-    "@react-email/components": "workspace:0.0.18-canary.0",
+    "@react-email/components": "0.0.18",
     "@react-email/render": "0.0.14",
     "@types/fs-extra": "11.0.1",
     "@types/mime-types": "2.1.4",

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/render",
-  "version": "0.0.14-canary.0",
+  "version": "0.0.14",
   "description": "Transform React components into HTML email templates",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/tailwind",
-  "version": "0.0.17-canary.0",
+  "version": "0.0.17",
   "description": "A React component to wrap emails with Tailwind CSS",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
   apps/demo:
     dependencies:
       '@react-email/components':
-        specifier: 0.0.18-canary.0
+        specifier: 0.0.18
         version: link:../../packages/components
       react:
         specifier: ^18.2.0
@@ -65,7 +65,7 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       react-email:
-        specifier: 2.1.3-canary.2
+        specifier: 2.1.3
         version: link:../../packages/react-email
     devDependencies:
       '@types/react':
@@ -322,7 +322,7 @@ importers:
         specifier: 0.0.6
         version: link:../font
       '@react-email/head':
-        specifier: 0.0.9-canary.0
+        specifier: 0.0.9
         version: link:../head
       '@react-email/heading':
         specifier: 0.0.12
@@ -346,7 +346,7 @@ importers:
         specifier: 0.0.9
         version: link:../preview
       '@react-email/render':
-        specifier: 0.0.14-canary.0
+        specifier: 0.0.14
         version: link:../render
       '@react-email/row':
         specifier: 0.0.8
@@ -355,7 +355,7 @@ importers:
         specifier: 0.0.12
         version: link:../section
       '@react-email/tailwind':
-        specifier: 0.0.17-canary.0
+        specifier: 0.0.17
         version: link:../tailwind
       '@react-email/text':
         specifier: 0.0.8
@@ -660,9 +660,6 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: 1.0.7
         version: 1.0.7(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
-      '@react-email/render':
-        specifier: 0.0.14-canary.0
-        version: link:../render
       '@swc/core':
         specifier: 1.3.101
         version: 1.3.101
@@ -767,8 +764,11 @@ importers:
         version: 5.1.6
     devDependencies:
       '@react-email/components':
-        specifier: workspace:0.0.18-canary.0
+        specifier: 0.0.18
         version: link:../components
+      '@react-email/render':
+        specifier: 0.0.14
+        version: link:../render
       '@types/fs-extra':
         specifier: 11.0.1
         version: 11.0.1


### PR DESCRIPTION
- **tailwind 0.0.17-canary.0 -> 0.0.17**
- **react-email 2.1.3-canary.2 -> 2.1.3**
- **render 0.0.14-canary -> 0.0.14**
- **head 0.0.9-canary.0 -> 0.0.9**
- **react-email/render on react-email 0.0.14-canary.0 -> 0.0.14**
- **react-email/head on components 0.0.9-canary.0 -> 0.0.9**
- **react-email/render on components 0.0.14-canary.0 -> 0.0.14**
- **react-email/tailwind on components 0.0.17-canary.0 -> 0.0.17**
- **components 0.0.18-canary.0 -> 0.0.18**
- **bump the demo dependencies**
- **bump create-email template dependencies**
- **create-email 0.0.26-canary.2 -> 0.0.26**
