### PR TITLE
fix(tailwind): Relatively complex media queries not being parsed properly

### DIFF
--- a/packages/tailwind/src/__snapshots__/tailwind.spec.tsx.snap
+++ b/packages/tailwind/src/__snapshots__/tailwind.spec.tsx.snap
@@ -10,4 +10,6 @@ Make sure that you have either a <head> element at some point inside of the <Tai
 If you do already have a <head> element at some depth, please file a bug https://github.com/resend/react-email/issues/new?assignees=&labels=Type%3A+Bug&projects=&template=1.bug_report.yml."
 `;
 
+exports[`Responsive styles > should work with relatively complex media query utilities 1`] = `"<head><meta content=\\"text/html; charset=UTF-8\\" http-equiv=\\"Content-Type\\"/><meta name=\\"x-apple-disable-message-reformatting\\"/><style>@media not all and(min-width:640px){.max-sm_text-red-600{color:rgb(220,38,38)!important}}</style></head><p class=\\"max-sm_text-red-600\\" style=\\"color:rgb(29,78,216)\\">I am some text</p>"`;
+
 exports[`Tailwind component > should work with Heading component 1`] = `"Hello<h1>My testing heading</h1>friends"`;

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -252,7 +252,7 @@ describe("Responsive styles", () => {
     );
   });
 
-  it.only("should work with relatively complex media query utilities", () => {
+  it("should work with relatively complex media query utilities", () => {
     const Email = () => {
       return (
         <Tailwind>

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -252,6 +252,19 @@ describe("Responsive styles", () => {
     );
   });
 
+  it.only("should work with relatively complex media query utilities", () => {
+    const Email = () => {
+      return (
+        <Tailwind>
+          <Head />
+          <p className="text-blue-700 max-sm:text-red-600">I am some text</p>
+        </Tailwind>
+      );
+    };
+
+    expect(render(<Email />)).toMatchSnapshot();
+  });
+
   it("should throw an error when used without a <head/>", () => {
     function noHead() {
       render(

--- a/packages/tailwind/src/utils/css/media-queries/separate-media-queries-from-css.spec.ts
+++ b/packages/tailwind/src/utils/css/media-queries/separate-media-queries-from-css.spec.ts
@@ -1,0 +1,42 @@
+import { separateMediaQueriesFromCSS } from "./separate-media-queries-from-css";
+
+test("separateMediaQueriesFromCSS()", () => {
+  const [cssWithoutMediaQueries, mediaQueries] = separateMediaQueriesFromCSS(`
+.text-blue-700 {
+  --tw-text-opacity: 1;
+  color: rgb(29 78 216 / var(--tw-text-opacity));
+}
+@media not all and (min-width: 640px) {
+  .max-sm\\:text-red-600 {
+    --tw-text-opacity: 1;
+    color: rgb(220 38 38 / var(--tw-text-opacity));
+  }
+}
+@media (min-width: 640px) {
+  .sm\\:text-blue-400 {
+    --tw-text-opacity: 1;
+    color: rgb(96 165 250 / var(--tw-text-opacity));
+  }
+}
+  `);
+
+  expect(cssWithoutMediaQueries.trim()).toBe(`.text-blue-700 {
+  --tw-text-opacity: 1;
+  color: rgb(29 78 216 / var(--tw-text-opacity));
+}`);
+
+  expect(mediaQueries).toEqual([
+    `@media not all and (min-width: 640px) {
+  .max-sm\\:text-red-600 {
+    --tw-text-opacity: 1;
+    color: rgb(220 38 38 / var(--tw-text-opacity));
+  }
+}`,
+    `@media (min-width: 640px) {
+  .sm\\:text-blue-400 {
+    --tw-text-opacity: 1;
+    color: rgb(96 165 250 / var(--tw-text-opacity));
+  }
+}`
+  ]);
+});

--- a/packages/tailwind/src/utils/css/media-queries/separate-media-queries-from-css.spec.ts
+++ b/packages/tailwind/src/utils/css/media-queries/separate-media-queries-from-css.spec.ts
@@ -37,6 +37,6 @@ test("separateMediaQueriesFromCSS()", () => {
     --tw-text-opacity: 1;
     color: rgb(96 165 250 / var(--tw-text-opacity));
   }
-}`
+}`,
   ]);
 });

--- a/packages/tailwind/src/utils/css/media-queries/separate-media-queries-from-css.ts
+++ b/packages/tailwind/src/utils/css/media-queries/separate-media-queries-from-css.ts
@@ -5,7 +5,7 @@ export function separateMediaQueriesFromCSS(
   const mediaQueries: string[] = [];
 
   for (const match of css.matchAll(
-    /@media\s*\(.*\)\s*{\s*\..*\s*{[\s\S]*?}\s*}/gm,
+    /@media\s*[^{]*\{(?:[^{}]*\{[^{}]*\})*[^{}]*\}/gm
   )) {
     const [mediaQuery] = match;
     cssWithoutMediaQueries = cssWithoutMediaQueries.replace(mediaQuery, "");

--- a/packages/tailwind/src/utils/css/media-queries/separate-media-queries-from-css.ts
+++ b/packages/tailwind/src/utils/css/media-queries/separate-media-queries-from-css.ts
@@ -5,7 +5,7 @@ export function separateMediaQueriesFromCSS(
   const mediaQueries: string[] = [];
 
   for (const match of css.matchAll(
-    /@media\s*[^{]*\{(?:[^{}]*\{[^{}]*\})*[^{}]*\}/gm
+    /@media\s*[^{]*\{(?:[^{}]*\{[^{}]*\})*[^{}]*\}/gm,
   )) {
     const [mediaQuery] = match;
     cssWithoutMediaQueries = cssWithoutMediaQueries.replace(mediaQuery, "");


### PR DESCRIPTION
This is meant for #1450. There, they pointed out that utilities like
`max-sm:text-red-600` were not working. The reason being that it used a bit
more complex media queries than our regex accounted for:

https://github.com/resend/react-email/blob/2fc5b0df0731bafeb86ca5b5939c7af7a2d5647c/packages/tailwind/src/utils/css/media-queries/separate-media-queries-from-css.ts#L7-L11

The new regex both allows for nesting, and it doesn't necessarily check to see
if the media query is valid, like we did with the selector and the checking of
to see if there is an actual condition inside. This new regex is much more
optimal and more focused into actually separating the media queries.

