### PR TITLE
fix(react-email): Windows issue with the render resolving esbuild plugin

### DIFF
--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -46,6 +46,7 @@
     "commander": "11.1.0",
     "debounce": "2.0.0",
     "esbuild": "0.19.11",
+    "escape-string-regexp": "5.0.0",
     "eslint-config-prettier": "9.0.0",
     "eslint-config-turbo": "1.10.12",
     "framer-motion": "10.17.4",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -46,7 +46,6 @@
     "commander": "11.1.0",
     "debounce": "2.0.0",
     "esbuild": "0.19.11",
-    "escape-string-regexp": "5.0.0",
     "eslint-config-prettier": "9.0.0",
     "eslint-config-turbo": "1.10.12",
     "framer-motion": "10.17.4",

--- a/packages/react-email/src/utils/render-resolver-esbuild-plugin.ts
+++ b/packages/react-email/src/utils/render-resolver-esbuild-plugin.ts
@@ -1,7 +1,12 @@
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
-import escapeStringForRegex from 'escape-string-regexp';
 import type { Loader, PluginBuild, ResolveOptions } from 'esbuild';
+
+function escapeStringForRegex(string: string) {
+  return string
+    .replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
+    .replace(/-/g, '\\x2d');
+}
 
 /**
  * Made to export the `renderAsync` function out of the user's email template

--- a/packages/react-email/src/utils/render-resolver-esbuild-plugin.ts
+++ b/packages/react-email/src/utils/render-resolver-esbuild-plugin.ts
@@ -16,7 +16,13 @@ export const renderResolver = (emailTemplates: string[]) => ({
   setup: (b: PluginBuild) => {
     b.onLoad(
       // We need to escape all of the "\" characters to avoid issues on Windows
-      { filter: new RegExp(escapeStringForRegex(emailTemplates.join('|'))) },
+      {
+        filter: new RegExp(
+          emailTemplates
+            .map((emailPath) => escapeStringForRegex(emailPath))
+            .join('|'),
+        ),
+      },
       async ({ path: pathToFile }) => {
         return {
           contents: `${await fs.readFile(pathToFile, 'utf8')};

--- a/packages/react-email/src/utils/render-resolver-esbuild-plugin.ts
+++ b/packages/react-email/src/utils/render-resolver-esbuild-plugin.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
+import escapeStringForRegex from 'escape-string-regexp';
 import type { Loader, PluginBuild, ResolveOptions } from 'esbuild';
 
 /**
@@ -14,7 +15,8 @@ export const renderResolver = (emailTemplates: string[]) => ({
   name: 'render-resolver',
   setup: (b: PluginBuild) => {
     b.onLoad(
-      { filter: new RegExp(emailTemplates.join('|')) },
+      // We need to escape all of the "\" characters to avoid issues on Windows
+      { filter: new RegExp(escapeStringForRegex(emailTemplates.join('|'))) },
       async ({ path: pathToFile }) => {
         return {
           contents: `${await fs.readFile(pathToFile, 'utf8')};

--- a/packages/react-email/src/utils/render-resolver-esbuild-plugin.ts
+++ b/packages/react-email/src/utils/render-resolver-esbuild-plugin.ts
@@ -3,9 +3,7 @@ import { promises as fs } from 'node:fs';
 import type { Loader, PluginBuild, ResolveOptions } from 'esbuild';
 
 function escapeStringForRegex(string: string) {
-  return string
-    .replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
-    .replace(/-/g, '\\x2d');
+  return string.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d');
 }
 
 /**

--- a/packages/react-email/src/utils/render-resolver-esbuild-plugin.ts
+++ b/packages/react-email/src/utils/render-resolver-esbuild-plugin.ts
@@ -15,7 +15,6 @@ export const renderResolver = (emailTemplates: string[]) => ({
   name: 'render-resolver',
   setup: (b: PluginBuild) => {
     b.onLoad(
-      // We need to escape all of the "\" characters to avoid issues on Windows
       {
         filter: new RegExp(
           emailTemplates

--- a/packages/render/src/render-async.ts
+++ b/packages/render/src/render-async.ts
@@ -84,7 +84,7 @@ export const renderAsync = async (
   const doctype =
     '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">';
 
-  const document = `${doctype}${html.replace(/<!DOCTYPE.*?>/, '')}`;
+  const document = `${doctype}${html.replace(/<!DOCTYPE.*?>/, "")}`;
 
   if (options?.pretty) {
     return pretty(document);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -696,9 +696,6 @@ importers:
       esbuild:
         specifier: 0.19.11
         version: 0.19.11
-      escape-string-regexp:
-        specifier: 5.0.0
-        version: 5.0.0
       eslint-config-prettier:
         specifier: 9.0.0
         version: 9.0.0(eslint@8.50.0)
@@ -792,7 +789,7 @@ importers:
         version: 0.8.15
       '@vercel/style-guide':
         specifier: 5.1.0
-        version: 5.1.0(eslint@8.50.0)(prettier@3.0.3)(typescript@5.1.6)
+        version: 5.1.0(eslint@8.50.0)(typescript@5.1.6)
       eslint:
         specifier: 8.50.0
         version: 8.50.0
@@ -804,7 +801,7 @@ importers:
         version: 4.9.0
       vitest:
         specifier: 1.1.3
-        version: 1.1.3(@types/node@18.0.0)(happy-dom@12.2.2)
+        version: 1.1.3(@types/node@18.0.0)
 
   packages/render:
     dependencies:
@@ -3925,6 +3922,52 @@ packages:
       - supports-color
     dev: true
 
+  /@vercel/style-guide@5.1.0(eslint@8.50.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-L9lWYePIycm7vIOjDLj+mmMdmmPkW3/brHjgq+nJdvMOrL7Hdk/19w8X583HYSk0vWsq494o5Qkh6x5+uW7ljg==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@next/eslint-plugin-next': '>=12.3.0 <15'
+      eslint: '>=8.48.0 <9'
+      prettier: '>=3.0.0 <4'
+      typescript: '>=4.8.0 <6'
+    peerDependenciesMeta:
+      '@next/eslint-plugin-next':
+        optional: true
+      eslint:
+        optional: true
+      prettier:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/eslint-parser': 7.24.1(@babel/core@7.24.5)(eslint@8.50.0)
+      '@rushstack/eslint-patch': 1.10.1
+      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.50.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.50.0)(typescript@5.1.6)
+      eslint: 8.50.0
+      eslint-config-prettier: 9.0.0(eslint@8.50.0)
+      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.29.1)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0)(eslint-plugin-import@2.29.1)(eslint@8.50.0)
+      eslint-plugin-eslint-comments: 3.2.0(eslint@8.50.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.50.0)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0)(eslint@8.50.0)(typescript@5.1.6)
+      eslint-plugin-jsx-a11y: 6.8.0(eslint@8.50.0)
+      eslint-plugin-playwright: 0.16.0(eslint-plugin-jest@27.9.0)(eslint@8.50.0)
+      eslint-plugin-react: 7.34.1(eslint@8.50.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.50.0)
+      eslint-plugin-testing-library: 6.2.0(eslint@8.50.0)(typescript@5.1.6)
+      eslint-plugin-tsdoc: 0.2.17
+      eslint-plugin-unicorn: 48.0.1(eslint@8.50.0)
+      prettier-plugin-packagejson: 2.4.14
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - eslint-import-resolver-node
+      - eslint-import-resolver-webpack
+      - jest
+      - supports-color
+    dev: true
+
   /@vitest/expect@0.34.6:
     resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
     dependencies:
@@ -5619,11 +5662,6 @@ packages:
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
-
-  /escape-string-regexp@5.0.0:
-    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
-    engines: {node: '>=12'}
-    dev: false
 
   /eslint-config-prettier@9.0.0(eslint@8.50.0):
     resolution: {integrity: sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==}
@@ -8022,6 +8060,18 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  /prettier-plugin-packagejson@2.4.14:
+    resolution: {integrity: sha512-sli+gV5tW7uxvzDZQscaBtSfbyAW2ToL6n/HGt51PipwX9vI7M54vefG0mKSfklVkT29TNGO6Mo6g8c6Z79gmw==}
+    peerDependencies:
+      prettier: '>= 1.16.0'
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+    dependencies:
+      sort-package-json: 2.10.0
+      synckit: 0.9.0
+    dev: true
+
   /prettier-plugin-packagejson@2.4.14(prettier@3.0.3):
     resolution: {integrity: sha512-sli+gV5tW7uxvzDZQscaBtSfbyAW2ToL6n/HGt51PipwX9vI7M54vefG0mKSfklVkT29TNGO6Mo6g8c6Z79gmw==}
     peerDependencies:
@@ -10129,7 +10179,7 @@ packages:
       - terser
     dev: true
 
-  /vitest@1.1.3(@types/node@18.0.0)(happy-dom@12.2.2):
+  /vitest@1.1.3(@types/node@18.0.0):
     resolution: {integrity: sha512-2l8om1NOkiA90/Y207PsEvJLYygddsOyr81wLQ20Ra8IlLKbyQncWsGZjnbkyG2KwwuTXLQjEPOJuxGMG8qJBQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -10165,7 +10215,6 @@ packages:
       chai: 4.4.1
       debug: 4.3.4
       execa: 8.0.1
-      happy-dom: 12.2.2
       local-pkg: 0.5.0
       magic-string: 0.30.9
       pathe: 1.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -696,6 +696,9 @@ importers:
       esbuild:
         specifier: 0.19.11
         version: 0.19.11
+      escape-string-regexp:
+        specifier: 5.0.0
+        version: 5.0.0
       eslint-config-prettier:
         specifier: 9.0.0
         version: 9.0.0(eslint@8.50.0)
@@ -5616,6 +5619,11 @@ packages:
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  /escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+    dev: false
 
   /eslint-config-prettier@9.0.0(eslint@8.50.0):
     resolution: {integrity: sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==}


### PR DESCRIPTION
The day we released the `2.1.3` version of `react-email` someone from Discord
tried upgrading and noticed an error, similar to the following:

![image](https://github.com/resend/react-email/assets/88866334/fdb5e8b7-8eeb-48c2-a2c3-4050fe7960eb)

At first, I didn't think it was an actual issue on our side, but maybe some
intermittent problem on their side, probably caused by something they did wrong.
But after someone else reported the same issue, I started looking a bit deeper.

From the error, it is visible that this is something to do with `esbuild`,
specifically, it's saying that the regex of a path is invalid. The place where
we pass a regex onto `esbuild` is exactly here:

https://github.com/resend/react-email/blob/17cbc5347769826092443541822efdf05c470642/packages/react-email/src/utils/render-resolver-esbuild-plugin.ts#L13-L20

This function is a `esbuild` plugin meant to add an extra export to email
template files that would be equivalent to `export { renderAsync } from
'@react-email/render'`. It tries to only do that on the email templates, though,
so it needs to do a filter through all the files `esbuild` processes to decide
whether the certain file is an email template. 

The issue was, precisely, with the regex. On Windows, the paths were coming in
with two `\` which were both unescaped and thus would cause issues when
`esbuild` was parsing this regex. This PR fixes that by escaping each path
to each email template and then using these instead.

