### PR TITLE
fix(react-email): Add Node.js dependencies used by Prisma client

### DIFF
--- a/packages/react-email/src/utils/static-node-modules-for-vm.ts
+++ b/packages/react-email/src/utils/static-node-modules-for-vm.ts
@@ -26,6 +26,7 @@ import cluster from 'node:cluster';
 import childProcess from 'node:child_process';
 import buffer from 'node:buffer';
 import assert from 'node:assert';
+import asyncHooks from 'node:async_hooks';
 
 /**
  * A map of the name of the modules (including `node:` prefixed ones)
@@ -71,6 +72,7 @@ export const staticNodeModulesForVM = {
   'node:http': http,
   fs,
   'node:fs': fs,
+  'fs/promises': fs.promises,
   events,
   'node:events': events,
   domain,
@@ -89,4 +91,5 @@ export const staticNodeModulesForVM = {
   'node:buffer': buffer,
   assert,
   'node:assert': assert,
+  'async_hooks': asyncHooks,
 };

--- a/packages/react-email/src/utils/static-node-modules-for-vm.ts
+++ b/packages/react-email/src/utils/static-node-modules-for-vm.ts
@@ -73,6 +73,7 @@ export const staticNodeModulesForVM = {
   fs,
   'node:fs': fs,
   'fs/promises': fs.promises,
+  'node:fs/promises': fs.promises,
   events,
   'node:events': events,
   domain,
@@ -92,4 +93,5 @@ export const staticNodeModulesForVM = {
   assert,
   'node:assert': assert,
   'async_hooks': asyncHooks,
+  'node:async_hooks': asyncHooks,
 };


### PR DESCRIPTION
This PR adds the necessary native Node.js modules that the Prisma client uses internally. Without these, the react-email preview server errors out.

More details on the Discord server [here](https://discord.com/channels/1022242959736983613/1246089315142860934/1246089315142860934).
