### PR TITLE
chore(components, create-email, react-email, render): Bump for canary release

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "turbo run build",
+    "build": "turbo run build --force",
     "dev": "turbo run dev --parallel --concurrency 25",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,md}\"",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "turbo run build --force",
+    "build": "turbo run build",
     "dev": "turbo run dev --parallel --concurrency 25",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,md}\"",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,7 +56,7 @@
     "@react-email/link": "0.0.8",
     "@react-email/markdown": "0.0.10",
     "@react-email/preview": "0.0.9",
-    "@react-email/render": "0.0.15",
+    "@react-email/render": "0.0.16-canary.0",
     "@react-email/row": "0.0.8",
     "@react-email/section": "0.0.12",
     "@react-email/tailwind": "0.0.18",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/components",
-  "version": "0.0.19",
+  "version": "0.0.20-canary.0",
   "description": "A collection of all components React Email.",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,7 +56,7 @@
     "@react-email/link": "0.0.8",
     "@react-email/markdown": "0.0.10",
     "@react-email/preview": "0.0.9",
-    "@react-email/render": "workspace:0.0.16-canary.0",
+    "@react-email/render": "0.0.16-canary.0",
     "@react-email/row": "0.0.8",
     "@react-email/section": "0.0.12",
     "@react-email/tailwind": "0.0.18",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,7 +56,7 @@
     "@react-email/link": "0.0.8",
     "@react-email/markdown": "0.0.10",
     "@react-email/preview": "0.0.9",
-    "@react-email/render": "0.0.16-canary.0",
+    "@react-email/render": "workspace:0.0.16-canary.0",
     "@react-email/row": "0.0.8",
     "@react-email/section": "0.0.12",
     "@react-email/tailwind": "0.0.18",

--- a/packages/create-email/package.json
+++ b/packages/create-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-email",
-  "version": "0.0.27",
+  "version": "0.0.28-canary.0",
   "description": "The easiest way to get started with React Email",
   "main": "src/index.js",
   "type": "module",

--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -8,7 +8,7 @@
     "export": "email export"
   },
   "dependencies": {
-    "@react-email/components": "0.0.19",
+    "@react-email/components": "0.0.20-canary.0",
     "react-email": "2.1.4",
     "react": "^18.2.0"
   },

--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@react-email/components": "0.0.20-canary.0",
-    "react-email": "2.1.4",
+    "react-email": "2.1.5-canary.0",
     "react": "^18.2.0"
   },
   "devDependencies": {

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-email",
-  "version": "2.1.4",
+  "version": "2.1.5-canary.0",
   "description": "A live preview of your emails right in your browser.",
   "bin": {
     "email": "./cli/index.js"

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/render",
-  "version": "0.0.15",
+  "version": "0.0.16-canary.0",
   "description": "Transform React components into HTML email templates",
   "sideEffects": false,
   "main": "./dist/browser/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,8 +346,8 @@ importers:
         specifier: 0.0.9
         version: 0.0.9(react@18.2.0)
       '@react-email/render':
-        specifier: 0.0.15
-        version: 0.0.15
+        specifier: workspace:0.0.16-canary.0
+        version: link:../render
       '@react-email/row':
         specifier: 0.0.8
         version: 0.0.8(react@18.2.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,7 +346,7 @@ importers:
         specifier: 0.0.9
         version: 0.0.9(react@18.2.0)
       '@react-email/render':
-        specifier: 0.0.16-canary.0
+        specifier: workspace:0.0.16-canary.0
         version: link:../render
       '@react-email/row':
         specifier: 0.0.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,7 +346,7 @@ importers:
         specifier: 0.0.9
         version: 0.0.9(react@18.2.0)
       '@react-email/render':
-        specifier: workspace:0.0.16-canary.0
+        specifier: 0.0.16-canary.0
         version: link:../render
       '@react-email/row':
         specifier: 0.0.8


### PR DESCRIPTION
- **bump react-email 2.1.4 -> 2.1.5-canary.0**
- **bump render 0.0.15 -> 0.0.16-canary.0**
- **bump components dependency on render to 0.0.16-canary.0**
- **bump components 0.0.19 -> 0.0.20-canary.0**
- **bump create-email template dependency on components to 0.0.20-canary.0**
- **bump create-email template dependency on react-email to 2.1.5-canary.0**
- **update lockfile**
