### PR TITLE
fix(docs): add imports for react-email in integrations step 1

### DIFF
--- a/apps/docs/integrations/aws-ses.mdx
+++ b/apps/docs/integrations/aws-ses.mdx
@@ -12,15 +12,15 @@ Get the [@react-email/render](https://www.npmjs.com/package/@react-email/render)
 <CodeGroup>
 
 ```sh npm
-npm install @react-email/render @aws-sdk/client-ses
+npm install @react-email/render @aws-sdk/client-ses @react-email/components
 ```
 
 ```sh yarn
-yarn add @react-email/render @aws-sdk/client-ses
+yarn add @react-email/render @aws-sdk/client-ses @react-email/components
 ```
 
 ```sh pnpm
-pnpm add @react-email/render @aws-sdk/client-ses
+pnpm add @react-email/render @aws-sdk/client-ses @react-email/components
 ```
 
 </CodeGroup>

--- a/apps/docs/integrations/aws-ses.mdx
+++ b/apps/docs/integrations/aws-ses.mdx
@@ -7,20 +7,20 @@ description: 'Learn how to send an email using React Email and the AWS SES Node.
 
 ## 1. Install dependencies
 
-Get the [@react-email/render](https://www.npmjs.com/package/@react-email/render) package and the [AWS SES Node.js SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-ses/).
+Get the [@react-email/components](https://www.npmjs.com/package/@react-email/components) package and the [AWS SES Node.js SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-ses/).
 
 <CodeGroup>
 
 ```sh npm
-npm install @react-email/render @aws-sdk/client-ses @react-email/components
+npm install @aws-sdk/client-ses @react-email/components
 ```
 
 ```sh yarn
-yarn add @react-email/render @aws-sdk/client-ses @react-email/components
+yarn add @aws-sdk/client-ses @react-email/components
 ```
 
 ```sh pnpm
-pnpm add @react-email/render @aws-sdk/client-ses @react-email/components
+pnpm add @aws-sdk/client-ses @react-email/components
 ```
 
 </CodeGroup>
@@ -51,7 +51,7 @@ Import the email template you just built, convert into a HTML string, and use th
 <CodeGroup>
 
 ```js React
-import { render } from '@react-email/render';
+import { render } from '@react-email/components';
 import { SES } from '@aws-sdk/client-ses';
 import { Email } from './email';
 
@@ -82,7 +82,7 @@ await ses.sendEmail(params);
 ```
 
 ```js NodeJS
-import { render } from '@react-email/render';
+import { render } from '@react-email/components';
 import { SES } from '@aws-sdk/client-ses';
 import { Email } from './email';
 

--- a/apps/docs/integrations/mailersend.mdx
+++ b/apps/docs/integrations/mailersend.mdx
@@ -12,15 +12,15 @@ Get the [@react-email/render](https://www.npmjs.com/package/@react-email/render)
 <CodeGroup>
 
 ```sh npm
-npm install @react-email/render mailersend
+npm install @react-email/render mailersend @react-email/components
 ```
 
 ```sh yarn
-yarn add @react-email/render mailersend
+yarn add @react-email/render mailersend @react-email/components
 ```
 
 ```sh pnpm
-pnpm add @react-email/render mailersend
+pnpm add @react-email/render mailersend @react-email/components
 ```
 
 </CodeGroup>

--- a/apps/docs/integrations/mailersend.mdx
+++ b/apps/docs/integrations/mailersend.mdx
@@ -7,20 +7,20 @@ description: 'Learn how to send an email using React Email and the MailerSend No
 
 ## 1. Install dependencies
 
-Get the [@react-email/render](https://www.npmjs.com/package/@react-email/render) package and the [MailerSend Node.js SDK](https://www.npmjs.com/package/mailersend).
+Get the [@react-email/components](https://www.npmjs.com/package/@react-email/components) package and the [MailerSend Node.js SDK](https://www.npmjs.com/package/mailersend).
 
 <CodeGroup>
 
 ```sh npm
-npm install @react-email/render mailersend @react-email/components
+npm install mailersend @react-email/components
 ```
 
 ```sh yarn
-yarn add @react-email/render mailersend @react-email/components
+yarn add mailersend @react-email/components
 ```
 
 ```sh pnpm
-pnpm add @react-email/render mailersend @react-email/components
+pnpm add mailersend @react-email/components
 ```
 
 </CodeGroup>
@@ -50,7 +50,7 @@ Import the email template you just built, convert into a HTML string, and use th
 
 
 ```jsx index.jsx
-import { render } from '@react-email/render';
+import { render } from '@react-email/components';
 import { MailerSend, EmailParams, Sender, Recipient } from "mailersend";
 import { Email } from './email';
 

--- a/apps/docs/integrations/nodemailer.mdx
+++ b/apps/docs/integrations/nodemailer.mdx
@@ -7,20 +7,20 @@ description: 'Learn how to send an email using React Email and Nodemailer.'
 
 ## 1. Install dependencies
 
-Get the [@react-email/render](https://www.npmjs.com/package/@react-email/render) and [nodemailer](https://www.npmjs.com/package/nodemailer) packages.
+Get the [@react-email/components](https://www.npmjs.com/package/@react-email/components) and [nodemailer](https://www.npmjs.com/package/nodemailer) packages.
 
 <CodeGroup>
 
 ```sh npm
-npm install @react-email/render nodemailer @react-email/components
+npm install nodemailer @react-email/components
 ```
 
 ```sh yarn
-yarn add @react-email/render nodemailer @react-email/components
+yarn add nodemailer @react-email/components
 ```
 
 ```sh pnpm
-pnpm add @react-email/render nodemailer @react-email/components
+pnpm add nodemailer @react-email/components
 ```
 
 </CodeGroup>
@@ -51,7 +51,7 @@ Import the email template you just built, convert into a HTML string, and use th
 <CodeGroup>
 
 ```js React
-import { render } from '@react-email/render';
+import { render } from '@react-email/components';
 import nodemailer from 'nodemailer';
 import { Email } from './email';
 
@@ -78,7 +78,7 @@ await transporter.sendMail(options);
 ```
 
 ```js NodeJS
-import { render } from '@react-email/render';
+import { render } from '@react-email/components';
 import nodemailer from 'nodemailer';
 import { Email } from './email';
 

--- a/apps/docs/integrations/nodemailer.mdx
+++ b/apps/docs/integrations/nodemailer.mdx
@@ -12,15 +12,15 @@ Get the [@react-email/render](https://www.npmjs.com/package/@react-email/render)
 <CodeGroup>
 
 ```sh npm
-npm install @react-email/render nodemailer
+npm install @react-email/render nodemailer @react-email/components
 ```
 
 ```sh yarn
-yarn add @react-email/render nodemailer
+yarn add @react-email/render nodemailer @react-email/components
 ```
 
 ```sh pnpm
-pnpm add @react-email/render nodemailer
+pnpm add @react-email/render nodemailer @react-email/components
 ```
 
 </CodeGroup>

--- a/apps/docs/integrations/plunk.mdx
+++ b/apps/docs/integrations/plunk.mdx
@@ -7,20 +7,20 @@ description: 'Learn how to send an email using React Email and the Plunk Node.js
 
 ## 1. Install dependencies
 
-Get the [Plunk Node.js SDK](https://www.npmjs.com/package/@plunk/node).
+Get the [@react-email/components](https://www.npmjs.com/package/@react-email/components) package and the [Plunk Node.js SDK](https://www.npmjs.com/package/@plunk/node).
 
 <CodeGroup>
 
   ```sh npm
-  npm install @react-email/render @plunk/node @react-email/components
+  npm install @plunk/node @react-email/components
   ```
 
   ```sh yarn
-  yarn add @react-email/render @plunk/node @react-email/components
+  yarn add @plunk/node @react-email/components
   ```
 
   ```sh pnpm
-  pnpm add @react-email/render @plunk/node @react-email/components
+  pnpm add @plunk/node @react-email/components
   ```
 
 </CodeGroup>
@@ -54,7 +54,7 @@ Import the email template you just built, convert into a HTML string, and use th
 
   ```js React
   import Plunk from '@plunk/node';
-  import { render } from '@react-email/render';
+  import { render } from '@react-email/components';
   import { Email } from './email';
 
   const plunk = new Plunk(process.env.PLUNK_API_KEY);
@@ -70,7 +70,7 @@ Import the email template you just built, convert into a HTML string, and use th
 
   ```js NodeJS
   import Plunk from '@plunk/node';
-  import { render } from '@react-email/render';
+  import { render } from '@react-email/components';
   import { Email } from './email';
 
   const plunk = new Plunk(process.env.PLUNK_API_KEY);

--- a/apps/docs/integrations/plunk.mdx
+++ b/apps/docs/integrations/plunk.mdx
@@ -12,15 +12,15 @@ Get the [Plunk Node.js SDK](https://www.npmjs.com/package/@plunk/node).
 <CodeGroup>
 
   ```sh npm
-  npm install @plunk/node
+  npm install @react-email/render @plunk/node @react-email/components
   ```
 
   ```sh yarn
-  yarn add @plunk/node
+  yarn add @react-email/render @plunk/node @react-email/components
   ```
 
   ```sh pnpm
-  pnpm add @plunk/node
+  pnpm add @react-email/render @plunk/node @react-email/components
   ```
 
 </CodeGroup>

--- a/apps/docs/integrations/postmark.mdx
+++ b/apps/docs/integrations/postmark.mdx
@@ -12,15 +12,15 @@ Get the [@react-email/render](https://www.npmjs.com/package/@react-email/render)
 <CodeGroup>
 
 ```sh npm
-npm install @react-email/render postmark
+npm install @react-email/render postmark @react-email/components
 ```
 
 ```sh yarn
-yarn add @react-email/render postmark
+yarn add @react-email/render postmark @react-email/components
 ```
 
 ```sh pnpm
-pnpm add @react-email/render postmark
+pnpm add @react-email/render postmark @react-email/components
 ```
 
 </CodeGroup>

--- a/apps/docs/integrations/postmark.mdx
+++ b/apps/docs/integrations/postmark.mdx
@@ -7,20 +7,20 @@ description: 'Learn how to send an email using React Email and the Postmark Node
 
 ## 1. Install dependencies
 
-Get the [@react-email/render](https://www.npmjs.com/package/@react-email/render) package and the [Postmark Node.js SDK](https://www.npmjs.com/package/postmark).
+Get the [@react-email/components](https://www.npmjs.com/package/@react-email/components) package and the [Postmark Node.js SDK](https://www.npmjs.com/package/postmark).
 
 <CodeGroup>
 
 ```sh npm
-npm install @react-email/render postmark @react-email/components
+npm install postmark @react-email/components
 ```
 
 ```sh yarn
-yarn add @react-email/render postmark @react-email/components
+yarn add postmark @react-email/components
 ```
 
 ```sh pnpm
-pnpm add @react-email/render postmark @react-email/components
+pnpm add postmark @react-email/components
 ```
 
 </CodeGroup>
@@ -51,7 +51,7 @@ Import the email template you just built, convert into a HTML string, and use th
 <CodeGroup>
 
 ```js React
-import { render } from '@react-email/render';
+import { render } from '@react-email/components';
 import postmark from 'postmark';
 import { Email } from './email';
 
@@ -70,7 +70,7 @@ client.sendEmail(options);
 ```
 
 ```js NodeJS
-import { render } from '@react-email/render';
+import { render } from '@react-email/components';
 import postmark from 'postmark';
 import { Email } from './email';
 

--- a/apps/docs/integrations/resend.mdx
+++ b/apps/docs/integrations/resend.mdx
@@ -14,15 +14,15 @@ Get the [Resend Node.js SDK](https://www.npmjs.com/package/resend).
 <CodeGroup>
 
 ```sh npm
-npm install resend
+npm install resend @react-email/components
 ```
 
 ```sh yarn
-yarn add resend
+yarn add resend @react-email/components
 ```
 
 ```sh pnpm
-pnpm add resend
+pnpm add resend @react-email/components
 ```
 
 </CodeGroup>

--- a/apps/docs/integrations/resend.mdx
+++ b/apps/docs/integrations/resend.mdx
@@ -9,7 +9,7 @@ description: 'Learn how to send an email using React Email and the Resend Node.j
 
 ## 1. Install dependencies
 
-Get the [Resend Node.js SDK](https://www.npmjs.com/package/resend).
+Get the [@react-email/components](https://www.npmjs.com/package/@react-email/components) package and the [Resend Node.js SDK](https://www.npmjs.com/package/resend).
 
 <CodeGroup>
 

--- a/apps/docs/integrations/scaleway.mdx
+++ b/apps/docs/integrations/scaleway.mdx
@@ -12,15 +12,15 @@ Get the [@react-email/render](https://www.npmjs.com/package/@react-email/render)
 <CodeGroup>
 
 ```sh npm
-npm install @react-email/render @scaleway/sdk
+npm install @react-email/render @scaleway/sdk @react-email/components
 ```
 
 ```sh yarn
-yarn add @react-email/render @scaleway/sdk
+yarn add @react-email/render @scaleway/sdk @react-email/components
 ```
 
 ```sh pnpm
-pnpm add @react-email/render @scaleway/sdk
+pnpm add @react-email/render @scaleway/sdk @react-email/components
 ```
 
 </CodeGroup>

--- a/apps/docs/integrations/scaleway.mdx
+++ b/apps/docs/integrations/scaleway.mdx
@@ -7,20 +7,20 @@ description: 'Learn how to send an email using React Email and the Scaleway Node
 
 ## 1. Install dependencies
 
-Get the [@react-email/render](https://www.npmjs.com/package/@react-email/render) package and the [Scaleway Node.js SDK](https://www.npmjs.com/package/@scaleway/sdk).
+Get the [@react-email/components](https://www.npmjs.com/package/@react-email/components) package and the [Scaleway Node.js SDK](https://www.npmjs.com/package/@scaleway/sdk).
 
 <CodeGroup>
 
 ```sh npm
-npm install @react-email/render @scaleway/sdk @react-email/components
+npm install @scaleway/sdk @react-email/components
 ```
 
 ```sh yarn
-yarn add @react-email/render @scaleway/sdk @react-email/components
+yarn add @scaleway/sdk @react-email/components
 ```
 
 ```sh pnpm
-pnpm add @react-email/render @scaleway/sdk @react-email/components
+pnpm add @scaleway/sdk @react-email/components
 ```
 
 </CodeGroup>
@@ -51,7 +51,7 @@ Import the email template you just built, convert into a HTML string, and use th
 <CodeGroup>
 
 ```js React
-import { render } from '@react-email/render';
+import { render } from '@react-email/components';
 import { TransactionalEmail, createClient } from "@scaleway/sdk";
 import { Email } from './email';
 

--- a/apps/docs/integrations/sendgrid.mdx
+++ b/apps/docs/integrations/sendgrid.mdx
@@ -12,15 +12,15 @@ Get the [@react-email/render](https://www.npmjs.com/package/@react-email/render)
 <CodeGroup>
 
 ```sh npm
-npm install @react-email/render @sendgrid/mail
+npm install @react-email/render @sendgrid/mail @react-email/components
 ```
 
 ```sh yarn
-yarn add @react-email/render @sendgrid/mail
+yarn add @react-email/render @sendgrid/mail @react-email/components
 ```
 
 ```sh pnpm
-pnpm add @react-email/render @sendgrid/mail
+pnpm add @react-email/render @sendgrid/mail @react-email/components
 ```
 
 </CodeGroup>

--- a/apps/docs/integrations/sendgrid.mdx
+++ b/apps/docs/integrations/sendgrid.mdx
@@ -7,20 +7,20 @@ description: 'Learn how to send an email using React Email and the SendGrid Node
 
 ## 1. Install dependencies
 
-Get the [@react-email/render](https://www.npmjs.com/package/@react-email/render) package and the [SendGrid Node.js SDK](https://www.npmjs.com/package/@sendgrid/mail).
+Get the [@react-email/components](https://www.npmjs.com/package/@react-email/components) package and the [SendGrid Node.js SDK](https://www.npmjs.com/package/@sendgrid/mail).
 
 <CodeGroup>
 
 ```sh npm
-npm install @react-email/render @sendgrid/mail @react-email/components
+npm install @sendgrid/mail @react-email/components
 ```
 
 ```sh yarn
-yarn add @react-email/render @sendgrid/mail @react-email/components
+yarn add @sendgrid/mail @react-email/components
 ```
 
 ```sh pnpm
-pnpm add @react-email/render @sendgrid/mail @react-email/components
+pnpm add @sendgrid/mail @react-email/components
 ```
 
 </CodeGroup>
@@ -51,7 +51,7 @@ Import the email template you just built, convert into a HTML string, and use th
 <CodeGroup>
 
 ```js React
-import { render } from '@react-email/render';
+import { render } from '@react-email/components';
 import sendgrid from '@sendgrid/mail';
 import { Email } from './email';
 
@@ -70,7 +70,7 @@ sendgrid.send(options);
 ```
 
 ```js NodeJS
-import { render } from '@react-email/render';
+import { render } from '@react-email/components';
 import sendgrid from '@sendgrid/mail';
 import { Email } from './email';
 


### PR DESCRIPTION
## Background
Previously, every integrations in the documentation, step 1, recommended to install a list of dependencies to have a particular integration work seamlessly. But that step missed the following dependency ```@react-email/render``` in each integration, which can lead to a misunderstanding when an error will show up

## How this PR should fix it ?
This PR adds the relevant imports to make the integrations work as intended. It's a fix for #1501 