### PR TITLE
fix(react-email): Live refresh not working with files outside of emails directory

### DIFF
--- a/packages/preview/src/preview.tsx
+++ b/packages/preview/src/preview.tsx
@@ -16,7 +16,6 @@ export const Preview = React.forwardRef<
   text = text.substr(0, PREVIEW_MAX_LENGTH);
   return (
     <div
-      ref={ref}
       style={{
         display: "none",
         overflow: "hidden",

--- a/packages/preview/src/preview.tsx
+++ b/packages/preview/src/preview.tsx
@@ -16,6 +16,7 @@ export const Preview = React.forwardRef<
   text = text.substr(0, PREVIEW_MAX_LENGTH);
   return (
     <div
+      ref={ref}
       style={{
         display: "none",
         overflow: "hidden",

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
@@ -109,7 +109,7 @@ export const createDependencyGraph = async (directory: string) => {
           try {
             // will throw if the the file is not existant
             isDirectory = statSync(pathToDependencyFromDirectory).isDirectory();
-          } catch (_) { }
+          } catch (_) {}
           if (isDirectory) {
             const pathToSubDirectory = pathToDependencyFromDirectory;
             const pathWithExtension = checkFileExtensionsUntilItExists(

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
@@ -193,15 +193,6 @@ export const createDependencyGraph = async (directory: string) => {
           dependencyModule.dependentPaths.filter(
             (dependentPath) => dependentPath !== moduleFilePath,
           );
-        if (
-          dependencyModule.dependentPaths.length === 0 &&
-          // This means that this module is higher up than the original directory we are looking at,
-          // therefore we must remove this module as its sole purpose was to have this module as a
-          // dependent and it is not needed anymore.
-          path.relative(directory, dependencyModule.path).startsWith('..')
-        ) {
-          removeModuleFromGraph(dependencyModule.path);
-        }
       }
     }
 

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
@@ -244,9 +244,6 @@ export const createDependencyGraph = async (directory: string) => {
 
   return [
     graph,
-    /**
-     * @param pathToModified - An absolute path to the module involved in this change
-     */
     async (
       event: 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir',
       pathToModified: string,

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
@@ -193,6 +193,15 @@ export const createDependencyGraph = async (directory: string) => {
           dependencyModule.dependentPaths.filter(
             (dependentPath) => dependentPath !== moduleFilePath,
           );
+        if (
+          dependencyModule.dependentPaths.length === 0 &&
+          // This means that this module is higher up than the original directory we are looking at,
+          // therefore we must remove this module as its sole purpose was to have this module as a
+          // dependent and it is not needed anymore.
+          path.relative(directory, dependencyModule.path).startsWith('..')
+        ) {
+          removeModuleFromGraph(dependencyModule.path);
+        }
       }
     }
 
@@ -301,7 +310,7 @@ export const createDependencyGraph = async (directory: string) => {
         }
 
         return dependentPaths;
-      }
+      },
     },
   ] as const;
 };

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/setup-hot-reloading.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/setup-hot-reloading.ts
@@ -51,7 +51,7 @@ export const setupHotreloading = async (
     Object.keys(dependencyGraph).filter((p) =>
       path.relative(absolutePathToEmailsDirectory, p).startsWith('..'),
     );
-  const filesOutsideEmailsDirectory = getFilesOutsideEmailsDirectory();
+  let filesOutsideEmailsDirectory = getFilesOutsideEmailsDirectory();
   // adds in to be watched separately all of the files that are outside of
   // the user's emails directory
   for (const p of filesOutsideEmailsDirectory) {
@@ -90,6 +90,7 @@ export const setupHotreloading = async (
         watcher.add(p);
       }
     }
+    filesOutsideEmailsDirectory = newFilesOutsideEmailsDirectory;
 
     changes.push({
       event,


### PR DESCRIPTION
This is intended to fix the issue mentioned in https://github.com/resend/react-email/issues/1433#issuecomment-2177515290.

The issue there was that the live refresh was not notifying the preview server
when the user modified an email template dependency that was outside their
specified emails directory. What was causing this, was that our `chokidar` file watcher
was not including any files outside the users' emails directory.

To fix this, I first attempted finding the highest up file among all in the dependency graph
and adding that into the watcher. This was not the best option because it would end up
watching a bunch of files, except for the ones that we really need to.

The second attempt was to individually add in all the files into the watcher that
are specifically outside the user's emails directory, and then, once the user
updated their imports including a new file, it would add that into the ones being
watched as well. This works perfectly from what I have tested.

