### PR TITLE
docs: Move `react-email` to dev dependencies in install guides

### DIFF
--- a/apps/docs/getting-started/manual-setup.mdx
+++ b/apps/docs/getting-started/manual-setup.mdx
@@ -27,15 +27,18 @@ Install the React Email package locally and a few components.
 <CodeGroup>
 
 ```sh npm
-npm install react-email @react-email/components -E
+npm install react-email -D -E
+npm install @react-email/components -E
 ```
 
 ```sh yarn
-yarn add react-email @react-email/components -E
+yarn add react-email -D -E
+yarn add @react-email/components -E
 ```
 
 ```sh pnpm
-pnpm add react-email @react-email/components -E
+pnpm add react-email -D -E
+pnpm add @react-email/components -E
 ```
 
 </CodeGroup>

--- a/apps/docs/getting-started/monorepo-setup/npm.mdx
+++ b/apps/docs/getting-started/monorepo-setup/npm.mdx
@@ -24,7 +24,8 @@ Include a new `package.json` and do not forget to add this to the `workspaces` o
 Install React Email in the `transactional` workspace.
 
 ```sh packages/transactional
-npm install react-email @react-email/components -E
+npm install react-email -D -E
+npm install @react-email/components -E
 ```
 
 ## 3. Add scripts

--- a/apps/docs/getting-started/monorepo-setup/pnpm.mdx
+++ b/apps/docs/getting-started/monorepo-setup/pnpm.mdx
@@ -23,7 +23,8 @@ in there setup a new `package.json` and do not forget to add this to your `pnpm-
 Install React Email in the `transactional` workspace.
 
 ```sh packages/transactional
-pnpm add react-email @react-email/components -E
+pnpm add react-email -D -E
+pnpm add @react-email/components -E
 ```
 
 ## 3. Add scripts

--- a/apps/docs/getting-started/monorepo-setup/yarn.mdx
+++ b/apps/docs/getting-started/monorepo-setup/yarn.mdx
@@ -39,7 +39,8 @@ nodeLinker: node-modules
 Install React Email in the `transactional` workspace.
 
 ```sh packages/transactional
-yarn add react-email @react-email/components -E
+yarn add react-email -D -E
+yarn add @react-email/components -E
 ```
 
 ## 4. Add scripts


### PR DESCRIPTION
`react-email` can be installed as a dev dependency, instead of a dependency that we need to ship at runtime, thus saving bundle space. Adjust the documentation for all package managers to reflect this.

This has been mentioned initially in this issue thread: https://github.com/resend/react-email/issues/1101

## Side by side comparison

<img width="1512" alt="image" src="https://github.com/resend/react-email/assets/58329512/8fbfaa49-54a9-4510-a36d-6941a33831ee">

<img width="1512" alt="image" src="https://github.com/resend/react-email/assets/58329512/0110b856-77c0-483f-b33f-75f60451e8e2">



