### PR TITLE
chore(components, create-email, react-email, render): Bump for stable release

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/components",
-  "version": "0.0.20-canary.0",
+  "version": "0.0.20",
   "description": "A collection of all components React Email.",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,7 +56,7 @@
     "@react-email/link": "0.0.8",
     "@react-email/markdown": "0.0.10",
     "@react-email/preview": "0.0.9",
-    "@react-email/render": "workspace:0.0.16-canary.0",
+    "@react-email/render": "workspace:0.0.16",
     "@react-email/row": "0.0.8",
     "@react-email/section": "0.0.12",
     "@react-email/tailwind": "0.0.18",

--- a/packages/create-email/package.json
+++ b/packages/create-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-email",
-  "version": "0.0.28-canary.0",
+  "version": "0.0.28",
   "description": "The easiest way to get started with React Email",
   "main": "src/index.js",
   "type": "module",

--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -8,8 +8,8 @@
     "export": "email export"
   },
   "dependencies": {
-    "@react-email/components": "0.0.20-canary.0",
-    "react-email": "2.1.5-canary.0",
+    "@react-email/components": "0.0.20",
+    "react-email": "2.1.5",
     "react": "^18.2.0"
   },
   "devDependencies": {

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-email",
-  "version": "2.1.5-canary.0",
+  "version": "2.1.5",
   "description": "A live preview of your emails right in your browser.",
   "bin": {
     "email": "./cli/index.js"

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/render",
-  "version": "0.0.16-canary.0",
+  "version": "0.0.16",
   "description": "Transform React components into HTML email templates",
   "sideEffects": false,
   "main": "./dist/browser/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,7 +346,7 @@ importers:
         specifier: 0.0.9
         version: 0.0.9(react@18.2.0)
       '@react-email/render':
-        specifier: workspace:0.0.16-canary.0
+        specifier: workspace:0.0.16
         version: link:../render
       '@react-email/row':
         specifier: 0.0.8
@@ -2126,7 +2126,7 @@ packages:
     resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
     peerDependencies:
       '@types/react': '*'
-      react: 19.0.0-rc.0 || 19.0.0-beta-4508873393-20240430
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2154,8 +2154,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: 19.0.0-rc.0 || 19.0.0-beta-4508873393-20240430
-      react-dom: 19.0.0-rc.0 || 19.0.0-beta-4508873393-20240430
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true


### PR DESCRIPTION
- **react-email 2.1.5-canary.0 -> 2.1.5**
- **render 0.0.16-canary.0 -> 0.0.16**
- **render in components 0.0.16-canary.0 -> 0.0.16**
- **components 0.0.20-canary.0 -> 0.0.20**
- **bump template dependencies**
- **create-email 0.0.28-canary.0 -> 0.0.28**
- **update lock**
