### PR TITLE
fix(code-block): line-height, wrapping, width and splitting issues

### DIFF
--- a/packages/code-block/package.json
+++ b/packages/code-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/code-block",
-  "version": "0.0.5-canary.1",
+  "version": "0.0.5-canary.2",
   "description": "Display code with a selected theme and regex highlighting using Prism.js",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/code-block/package.json
+++ b/packages/code-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/code-block",
-  "version": "0.0.5-canary.0",
+  "version": "0.0.5-canary.1",
   "description": "Display code with a selected theme and regex highlighting using Prism.js",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/code-block/package.json
+++ b/packages/code-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/code-block",
-  "version": "0.0.4",
+  "version": "0.0.5-canary.0",
   "description": "Display code with a selected theme and regex highlighting using Prism.js",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -88,9 +88,9 @@ export const CodeBlock = React.forwardRef<
       ref={ref}
       style={{
         ...props.theme.base,
-        ...props.style,
         maxWidth: "600px",
         width: "100%",
+        ...props.style,
       }}
     >
       <code>

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -95,7 +95,7 @@ export const CodeBlock = React.forwardRef<
     >
       <code>
         {tokensPerLine.map((tokensForLine, lineIndex) => (
-          <p key={lineIndex} style={{ margin: 0, height: '1em' }}>
+          <p key={lineIndex} style={{ margin: 0, minHeight: '1em' }}>
             {props.lineNumbers ? (
               <span
                 style={{

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -78,7 +78,7 @@ export const CodeBlock = React.forwardRef<
       `CodeBlock: There is no language defined on Prism called ${props.language}`,
     );
 
-  const lines = props.code.split(/\r\n|\r|\n/gm) ?? [];
+  const lines = props.code.split(/\r\n|\r|\n/gm);
   const tokensPerLine = lines.map((line) =>
     Prism.tokenize(line, languageGrammar),
   );

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -88,7 +88,6 @@ export const CodeBlock = React.forwardRef<
       ref={ref}
       style={{
         ...props.theme.base,
-        maxWidth: "600px",
         width: "100%",
         ...props.style,
       }}

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -95,7 +95,7 @@ export const CodeBlock = React.forwardRef<
     >
       <code>
         {tokensPerLine.map((tokensForLine, lineIndex) => (
-          <p key={lineIndex} style={{ margin: 0 }}>
+          <p key={lineIndex} style={{ margin: 0, height: '1em' }}>
             {props.lineNumbers ? (
               <span
                 style={{

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -84,7 +84,15 @@ export const CodeBlock = React.forwardRef<
   );
 
   return (
-    <pre ref={ref} style={{ ...props.theme.base, ...props.style }}>
+    <pre
+      ref={ref}
+      style={{
+        ...props.theme.base,
+        ...props.style,
+        maxWidth: "600px",
+        width: "100%",
+      }}
+    >
       <code>
         {tokensPerLine.map((tokensForLine, lineIndex) => (
           <p key={lineIndex} style={{ margin: 0 }}>

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -78,7 +78,7 @@ export const CodeBlock = React.forwardRef<
       `CodeBlock: There is no language defined on Prism called ${props.language}`,
     );
 
-  const lines = props.code.match(/[^\r\n]+/g) ?? [];
+  const lines = props.code.split(/\r\n|\r|\n/gm) ?? [];
   const tokensPerLine = lines.map((line) =>
     Prism.tokenize(line, languageGrammar),
   );

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -95,7 +95,7 @@ export const CodeBlock = React.forwardRef<
     >
       <code>
         {tokensPerLine.map((tokensForLine, lineIndex) => (
-          <p key={lineIndex} style={{ margin: 0, minHeight: '1em' }}>
+          <p key={lineIndex} style={{ margin: 0, minHeight: "1em" }}>
             {props.lineNumbers ? (
               <span
                 style={{

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -87,7 +87,7 @@ export const CodeBlock = React.forwardRef<
     <pre ref={ref} style={{ ...props.theme.base, ...props.style }}>
       <code>
         {tokensPerLine.map((tokensForLine, lineIndex) => (
-          <p key={lineIndex}>
+          <p key={lineIndex} style={{ margin: 0 }}>
             {props.lineNumbers ? (
               <span
                 style={{

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@react-email/body": "0.0.8",
     "@react-email/button": "0.0.15",
-    "@react-email/code-block": "0.0.4",
+    "@react-email/code-block": "workspace:*",
     "@react-email/code-inline": "0.0.2",
     "@react-email/column": "0.0.10",
     "@react-email/container": "0.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,8 +307,8 @@ importers:
         specifier: 0.0.15
         version: 0.0.15(react@18.2.0)
       '@react-email/code-block':
-        specifier: 0.0.4
-        version: 0.0.4(react@18.2.0)
+        specifier: workspace:*
+        version: link:../code-block
       '@react-email/code-inline':
         specifier: 0.0.2
         version: 0.0.2(react@18.2.0)


### PR DESCRIPTION
The rough edges this PR tries to correct are:

- Lines were being split in a way that empty lines were ignored
- There was an extra margin in between each code block line
- Lines, when being forced to wrap, would sometimes collapse on others
  ![image](https://github.com/resend/react-email/assets/88866334/5e7422da-e0cc-43b7-aafe-d8f1800def87)
- The width of the code block was always the size of the screen

This does improve the code block quite a bit from before, and it should now
behave much more properly. Most of the issues were also coming from mobile,
because of its small screen size.

Also, with the purposes of testing, this PR also bumps the code block package
to a canary and I published it yesterday. It is
`@react-email/code-block@0.0.5-canary.0`.

