### PR TITLE
chore(code-block, components, create-email): Bump for stable release

### DIFF
--- a/packages/code-block/package.json
+++ b/packages/code-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/code-block",
-  "version": "0.0.5-canary.2",
+  "version": "0.0.5",
   "description": "Display code with a selected theme and regex highlighting using Prism.js",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-email/components",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "A collection of all components React Email.",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/create-email/package.json
+++ b/packages/create-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-email",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "The easiest way to get started with React Email",
   "main": "src/index.js",
   "type": "module",

--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -8,7 +8,7 @@
     "export": "email export"
   },
   "dependencies": {
-    "@react-email/components": "0.0.20",
+    "@react-email/components": "0.0.21",
     "react-email": "2.1.5",
     "react": "^18.2.0"
   },


### PR DESCRIPTION
- **code-block 0.0.5-canary.2 -> 0.0.5**
- **components 0.0.20 -> 0.0.21**
- **create-email 0.0.28 -> 0.0.29**
- **create-email template components 0.0.20 -> 0.0.21**
