### PR TITLE
fix(react-email): Export failing when templates have different suffixes

### DIFF
--- a/packages/react-email/src/actions/get-emails-directory-metadata.ts
+++ b/packages/react-email/src/actions/get-emails-directory-metadata.ts
@@ -60,6 +60,7 @@ const mergeDirectoriesWithSubDirectories = (
 
 export const getEmailsDirectoryMetadata = async (
   absolutePathToEmailsDirectory: string,
+  keepFileExtensions = false,
 ): Promise<EmailsDirectory | undefined> => {
   if (!fs.existsSync(absolutePathToEmailsDirectory)) return;
 
@@ -71,7 +72,11 @@ export const getEmailsDirectoryMetadata = async (
     .filter((dirent) =>
       isFileAnEmail(path.join(absolutePathToEmailsDirectory, dirent.name)),
     )
-    .map((dirent) => dirent.name.replace(path.extname(dirent.name), ''));
+    .map((dirent) =>
+      keepFileExtensions
+        ? dirent.name
+        : dirent.name.replace(path.extname(dirent.name), ''),
+    );
 
   const subDirectories = await Promise.all(
     dirents

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -54,6 +54,7 @@ export const exportTemplates = async (
 
   const emailsDirectoryMetadata = await getEmailsDirectoryMetadata(
     path.resolve(process.cwd(), emailsDirectoryPath),
+    true
   );
 
   if (typeof emailsDirectoryMetadata === 'undefined') {

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -54,7 +54,7 @@ export const exportTemplates = async (
 
   const emailsDirectoryMetadata = await getEmailsDirectoryMetadata(
     path.resolve(process.cwd(), emailsDirectoryPath),
-    true
+    true,
   );
 
   if (typeof emailsDirectoryMetadata === 'undefined') {


### PR DESCRIPTION
Meant for #1386. 

The issue was that we were reading all of the email template filenames from the
directory while also removing the suffixing file extension. This ended up
making `esbuild` treat all of them as the same file for some reason. This PR
just plain adds an option to not remove the file extensions, and then passes it
as true when finding the email templates to export.
