### PR TITLE
Text color in tooltips

### DIFF
--- a/packages/react-email/src/components/tooltip-content.tsx
+++ b/packages/react-email/src/components/tooltip-content.tsx
@@ -18,7 +18,7 @@ export const TooltipContent = React.forwardRef<
     <TooltipPrimitive.Content
       {...props}
       className={cn(
-        'bg-black border border-slate-6 z-20 px-3 py-2 rounded-md text-xs',
+        'bg-black text-white border border-slate-6 z-20 px-3 py-2 rounded-md text-xs',
         `${inter.variable} font-sans`,
       )}
       ref={forwardedRef}


### PR DESCRIPTION

**Changes Made**

Set the tooltip content text color to white, ensuring consistency and visibility across all browsers.

**Fixes**
This pull request addresses issue https://github.com/resend/react-email/issues/1326.