### PR TITLE
fix(react-email): Text color in tooltips and patch change added

### DIFF
--- a/.changeset/orange-plums-double.md
+++ b/.changeset/orange-plums-double.md
@@ -1,0 +1,5 @@
+---
+"create-email": minor
+---
+
+Set the tooltip content text color to white, ensuring consistency and visibility across all browsers.

--- a/packages/react-email/src/components/tooltip-content.tsx
+++ b/packages/react-email/src/components/tooltip-content.tsx
@@ -15,7 +15,6 @@ export const TooltipContent = React.forwardRef<
   Readonly<TooltipProps>
 >(({ sideOffset = 6, children, ...props }, forwardedRef) => (
   <TooltipPrimitive.Portal>
-    {/* for tesging purpose */}
     <TooltipPrimitive.Content
       {...props}
       className={cn(

--- a/packages/react-email/src/components/tooltip-content.tsx
+++ b/packages/react-email/src/components/tooltip-content.tsx
@@ -15,6 +15,7 @@ export const TooltipContent = React.forwardRef<
   Readonly<TooltipProps>
 >(({ sideOffset = 6, children, ...props }, forwardedRef) => (
   <TooltipPrimitive.Portal>
+    {/* for tesging purpose */}
     <TooltipPrimitive.Content
       {...props}
       className={cn(


### PR DESCRIPTION
**Changes Made**

Set the tooltip content text color to white, ensuring consistency and visibility across all browsers.

Patch change added

**Fixes**
This pull request addresses issue https://github.com/resend/react-email/issues/1326.