### PR TITLE
fix(tailwind): Unecessary style generation

### DIFF
--- a/.changeset/tame-windows-look.md
+++ b/.changeset/tame-windows-look.md
@@ -1,0 +1,5 @@
+---
+"@react-email/tailwind": patch
+---
+
+Fixes generation of unecessary styles (ex: including `container` as text somehwere in your template)

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -83,6 +83,12 @@ describe("Tailwind component", () => {
     );
   });
 
+  test("it should not generate styles from text", () => {
+    expect(render(<Tailwind>container bg-red-500 bg-blue-300</Tailwind>)).toBe(
+      "container bg-red-500 bg-blue-300",
+    );
+  });
+
   it("should work with components that return children", () => {
     const Wrapper = (props: { children: React.ReactNode }) => {
       return <Tailwind>{props.children}</Tailwind>;

--- a/packages/tailwind/src/utils/__snapshots__/quick-safe-render-to-string.spec.tsx.snap
+++ b/packages/tailwind/src/utils/__snapshots__/quick-safe-render-to-string.spec.tsx.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`quick safe render to string 1`] = `"<div className=\\"bg-red-500 text-gray-200\\"><h1><div className=\\"user-name flex text-2xl\\"></div></h1><span className=\\"dark:bg-green-500 hover:bg-green-800 transition-colors\\"></span></div><span className=\\"dark:bg-green-500 hover:bg-green-800 transition-colors\\"></span>"`;

--- a/packages/tailwind/src/utils/quick-safe-render-to-string.spec.tsx
+++ b/packages/tailwind/src/utils/quick-safe-render-to-string.spec.tsx
@@ -30,7 +30,5 @@ test("quick safe render to string", () => {
     </>
   );
 
-  expect(quickSafeRenderToString(jsx)).toMatchInlineSnapshot(
-    `"<div className=\\"bg-red-500 text-gray-200\\" style=\\"{\\"marginInline\\":\\"auto\\",\\"width\\":\\"100%\\",\\"maxWidth\\":\\"768px\\"}\\">Content in here that is interesting<h1><div className=\\"user-name flex text-2xl\\">Gabriel</div></h1><span className=\\"dark:bg-green-500 hover:bg-green-800 transition-colors\\">More content that comes from another jsx that should be render properly</span></div><span className=\\"dark:bg-green-500 hover:bg-green-800 transition-colors\\">More content that comes from another jsx that should be render properly</span>"`,
-  );
+  expect(quickSafeRenderToString(jsx)).toMatchSnapshot();
 });

--- a/packages/tailwind/src/utils/quick-safe-render-to-string.ts
+++ b/packages/tailwind/src/utils/quick-safe-render-to-string.ts
@@ -17,7 +17,7 @@ const propToAttributeString = (propValue: string | object) => {
  */
 export const quickSafeRenderToString = (element: React.ReactNode): string => {
   if (typeof element === "string" || typeof element === "number") {
-    return String(element);
+    return "";
   }
 
   if (Array.isArray(element)) {
@@ -35,7 +35,7 @@ export const quickSafeRenderToString = (element: React.ReactNode): string => {
       const functionComponent =
         typeof type === "object"
           ? // @ts-expect-error - we know this is a component
-            (type.render as React.FC<Props>)
+          (type.render as React.FC<Props>)
           : (type as React.FC<Props>);
       // If the element is a component (function component), render it
       const componentRenderingResults = functionComponent(props);
@@ -43,15 +43,12 @@ export const quickSafeRenderToString = (element: React.ReactNode): string => {
     }
 
     // Regular HTML-like element
-    let elementAttributes = Object.keys(props || {})
-      .filter((propName) => propName !== "children")
-      .map(
-        (prop) =>
-          `${prop}="${propToAttributeString(
-            props?.[prop] as string | object,
-          )}"`,
-      )
-      .join(" ");
+    let elementAttributes =
+      props && 'className' in props
+        ? `className="${propToAttributeString(
+          props.className as string | object,
+        )}"`
+        : "";
     elementAttributes =
       elementAttributes.trim().length > 0 ? ` ${elementAttributes}` : "";
     const children = props && "children" in props ? props.children : "";

--- a/packages/tailwind/src/utils/quick-safe-render-to-string.ts
+++ b/packages/tailwind/src/utils/quick-safe-render-to-string.ts
@@ -35,7 +35,7 @@ export const quickSafeRenderToString = (element: React.ReactNode): string => {
       const functionComponent =
         typeof type === "object"
           ? // @ts-expect-error - we know this is a component
-          (type.render as React.FC<Props>)
+            (type.render as React.FC<Props>)
           : (type as React.FC<Props>);
       // If the element is a component (function component), render it
       const componentRenderingResults = functionComponent(props);
@@ -44,10 +44,10 @@ export const quickSafeRenderToString = (element: React.ReactNode): string => {
 
     // Regular HTML-like element
     let elementAttributes =
-      props && 'className' in props
+      props && "className" in props
         ? `className="${propToAttributeString(
-          props.className as string | object,
-        )}"`
+            props.className as string | object,
+          )}"`
         : "";
     elementAttributes =
       elementAttributes.trim().length > 0 ? ` ${elementAttributes}` : "";


### PR DESCRIPTION
While working on our new patterns, I noticed that when the email template had
`container` as text anywhere inside of it, Tailwind would add in the media
queries for the `container`. This can be problematic, as it can make things a
bit slower, but because it can add styles that are not desired by the user.

At first, I wrongly thought this was a [Tailwind
issue](https://github.com/tailwindlabs/tailwindcss/issues/14070#issuecomment-2253567340),
as it happens with anything Tailwind related, but this is just how it works
being language-agnostic.

Now for some background, we currently have a `quickSafeRenderToString` function
that renders the entirity of the React tree from the component down, with the
sole purpose of handing it to Tailwind so that it can generate the respective
CSS. This function tries to mimic some sort of basic rendering, but it
currently renders children and many other things that we don't really need.


With that removed, unecessary pieces of content won't be used to generate the
styles at all, this way avoiding the generation of styles that shouldn't be
generated.
