### PR TITLE
fix(react-email): Decorators causing dependency tree babel parsing to fail

### DIFF
--- a/.changeset/curly-fireants-allow.md
+++ b/.changeset/curly-fireants-allow.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Fixes decorators causing dependency tree babel parsing to fail

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/get-imported-modules.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/get-imported-modules.ts
@@ -7,7 +7,7 @@ export const getImportedModules = (contents: string) => {
     sourceType: 'unambiguous',
     strictMode: false,
     errorRecovery: true,
-    plugins: ['jsx', 'typescript'],
+    plugins: ['jsx', 'typescript', 'decorators'],
   });
 
   traverse(parsedContents, {


### PR DESCRIPTION
This PR is meant to address #1570.

For background, we generate a dependency tree by parsing email templates and
files to get their imports with the purpose of knowing what email templates to
hot reload when any file changes in the user's project. This has the side
effect of us either using some faulty regex to detect imports, or using a
full-blown parser — Babel today — so that we can properly determine what the
import sources are.

The issue that was happening then, was that we did not configure our Babel
instance so that it would support `decorators`. This PR does just that, as in
that it adds the `decorators` plugin to the `parse` function we call
internally.
