### PR TITLE
refactor: Simplify types and remove unused babel config files

### DIFF
--- a/examples/aws-ses/.babelrc
+++ b/examples/aws-ses/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/examples/mailersend/.babelrc
+++ b/examples/mailersend/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/examples/nodemailer/.babelrc
+++ b/examples/nodemailer/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/examples/plunk/.babelrc
+++ b/examples/plunk/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/examples/postmark/.babelrc
+++ b/examples/postmark/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/examples/scaleway/node/.babelrc
+++ b/examples/scaleway/node/.babelrc
@@ -1,8 +1,0 @@
-{
-  "presets": [[
-    "@babel/preset-react",
-    {
-      "runtime": "automatic"
-    }]
-  ]
-}

--- a/examples/sendgrid/.babelrc
+++ b/examples/sendgrid/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/body/.babelrc
+++ b/packages/body/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/body/package.json
+++ b/packages/body/package.json
@@ -34,8 +34,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/core": "7.23.9",
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/body/src/body.tsx
+++ b/packages/body/src/body.tsx
@@ -1,11 +1,8 @@
 import * as React from "react";
 
-type BodyElement = React.ElementRef<"body">;
-type RootProps = React.ComponentPropsWithoutRef<"body">;
+export type BodyProps = Readonly<React.HtmlHTMLAttributes<HTMLBodyElement>>;
 
-export type BodyProps = RootProps;
-
-export const Body = React.forwardRef<BodyElement, Readonly<BodyProps>>(
+export const Body = React.forwardRef<HTMLBodyElement, BodyProps>(
   ({ children, style, ...props }, ref) => {
     return (
       <body {...props} ref={ref} style={style}>

--- a/packages/button/.babelrc
+++ b/packages/button/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -46,7 +46,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import { parsePadding, pxToPt } from "./utils";
+import { parsePadding } from "./utils/parse-padding";
+import { pxToPt } from "./utils/px-to-pt";
 
-type ButtonElement = React.ElementRef<"a">;
-export type ButtonProps = React.ComponentPropsWithoutRef<"a">;
+export type ButtonProps = Readonly<React.ComponentPropsWithoutRef<"a">>;
 
 function computeFontWidthAndSpaceCount(expectedWidth: number) {
   let smallestSpaceCount = 0;
@@ -14,7 +14,7 @@ function computeFontWidthAndSpaceCount(expectedWidth: number) {
   return [expectedWidth / smallestSpaceCount / 2, smallestSpaceCount];
 }
 
-export const Button = React.forwardRef<ButtonElement, Readonly<ButtonProps>>(
+export const Button = React.forwardRef<HTMLAnchorElement, ButtonProps>(
   ({ children, style, target = "_blank", ...props }, ref) => {
     const { pt, pr, pb, pl } = parsePadding({
       padding: style?.padding,

--- a/packages/button/src/utils/index.ts
+++ b/packages/button/src/utils/index.ts
@@ -1,2 +1,0 @@
-export * from "./px-to-pt";
-export * from "./parse-padding";

--- a/packages/button/src/utils/utils.spec.ts
+++ b/packages/button/src/utils/utils.spec.ts
@@ -1,4 +1,5 @@
-import { convertToPx, parsePadding, pxToPt } from ".";
+import { convertToPx, parsePadding } from "./parse-padding";
+import { pxToPt } from "./px-to-pt";
 
 describe("convertToPx", () => {
   it('converts "10px" to 10', () => {

--- a/packages/code-block/.babelrc
+++ b/packages/code-block/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/code-block/package.json
+++ b/packages/code-block/package.json
@@ -44,7 +44,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "@types/prismjs": "1.26.4",
     "eslint-config-custom": "workspace:*",

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -68,46 +68,41 @@ const CodeBlockLine = ({
 /**
  * A component to show code using prismjs.
  */
-export const CodeBlock = React.forwardRef<
-  React.ElementRef<"pre">,
-  CodeBlockProps
->((props, ref) => {
-  const languageGrammar = Prism.languages[props.language];
-  if (typeof languageGrammar === "undefined")
-    throw new Error(
-      `CodeBlock: There is no language defined on Prism called ${props.language}`,
+export const CodeBlock = React.forwardRef<HTMLPreElement, CodeBlockProps>(
+  (props, ref) => {
+    const languageGrammar = Prism.languages[props.language];
+    if (typeof languageGrammar === "undefined") {
+      throw new Error(
+        `CodeBlock: There is no language defined on Prism called ${props.language}`,
+      );
+    }
+
+    const lines = props.code.split(/\r\n|\r|\n/gm);
+    const tokensPerLine = lines.map((line) =>
+      Prism.tokenize(line, languageGrammar),
     );
 
-  const lines = props.code.split(/\r\n|\r|\n/gm);
-  const tokensPerLine = lines.map((line) =>
-    Prism.tokenize(line, languageGrammar),
-  );
+    return (
+      <pre
+        ref={ref}
+        style={{ ...props.theme.base, width: "100%", ...props.style }}
+      >
+        <code>
+          {tokensPerLine.map((tokensForLine, lineIndex) => (
+            <p key={lineIndex} style={{ margin: 0, minHeight: "1em" }}>
+              {Boolean(props.lineNumbers) && (
+                <span style={{ paddingRight: 30 }}>{lineIndex + 1}</span>
+              )}
 
-  return (
-    <pre
-      ref={ref}
-      style={{ ...props.theme.base, width: "100%", ...props.style }}
-    >
-      <code>
-        {tokensPerLine.map((tokensForLine, lineIndex) => (
-          <p key={lineIndex} style={{ margin: 0, minHeight: "1em" }}>
-            {props.lineNumbers ? (
-              <span
-                style={{
-                  paddingRight: 30,
-                }}
-              >
-                {lineIndex + 1}
-              </span>
-            ) : null}
-            {tokensForLine.map((token, i) => (
-              <CodeBlockLine key={i} theme={props.theme} token={token} />
-            ))}
-          </p>
-        ))}
-      </code>
-    </pre>
-  );
-});
+              {tokensForLine.map((token, i) => (
+                <CodeBlockLine key={i} theme={props.theme} token={token} />
+              ))}
+            </p>
+          ))}
+        </code>
+      </pre>
+    );
+  },
+);
 
 CodeBlock.displayName = "CodeBlock";

--- a/packages/code-inline/.babelrc
+++ b/packages/code-inline/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/code-inline/package.json
+++ b/packages/code-inline/package.json
@@ -38,7 +38,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/code-inline/src/code-inline.tsx
+++ b/packages/code-inline/src/code-inline.tsx
@@ -1,22 +1,19 @@
-import React from "react";
+import * as React from "react";
 
 type RootProps = React.ComponentPropsWithoutRef<"code"> &
   React.ComponentPropsWithoutRef<"span">;
 
-type SpanElement = React.ElementRef<"span">;
-export type CodeInlineProps = RootProps;
+export type CodeInlineProps = Readonly<RootProps>;
 
 /**
  * If you are sending emails for users that have the Orange.fr email client,
  * beware that this component will only work when you have a head containing meta tags.
  */
-export const CodeInline = React.forwardRef<
-  SpanElement,
-  Readonly<CodeInlineProps>
->(({ children, ...props }, ref) => {
-  return (
-    <>
-      {/* 
+export const CodeInline = React.forwardRef<HTMLSpanElement, CodeInlineProps>(
+  ({ children, ...props }, ref) => {
+    return (
+      <>
+        {/* 
     This style tag is targeted at fixing an issue for the Orange.fr email client
     See:
     - https://www.caniemail.com/features/html-code/
@@ -25,7 +22,7 @@ export const CodeInline = React.forwardRef<
     On that email client, the head and html elements are removed, making the meta tag a sibling of them
     allowing us to use a selector on them. Also <style> tags are supported on it.
     */}
-      <style>{`
+        <style>{`
         meta ~ .cino {
           display: none !important;
           opacity: 0 !important;
@@ -36,25 +33,26 @@ export const CodeInline = React.forwardRef<
         }
       `}</style>
 
-      {/* Does not render on Orange.fr */}
-      <code
-        {...props}
-        className={`${props.className ? props.className : ""} cino`}
-      >
-        {children}
-      </code>
+        {/* Does not render on Orange.fr */}
+        <code
+          {...props}
+          className={`${props.className ? props.className : ""} cino`}
+        >
+          {children}
+        </code>
 
-      {/* Renders only on Orange.fr */}
-      <span
-        {...props}
-        className={`${props.className ? props.className : ""} cio`}
-        ref={ref}
-        style={{ display: "none", ...props.style }}
-      >
-        {children}
-      </span>
-    </>
-  );
-});
+        {/* Renders only on Orange.fr */}
+        <span
+          {...props}
+          className={`${props.className ? props.className : ""} cio`}
+          ref={ref}
+          style={{ display: "none", ...props.style }}
+        >
+          {children}
+        </span>
+      </>
+    );
+  },
+);
 
 CodeInline.displayName = "CodeInline";

--- a/packages/column/.babelrc
+++ b/packages/column/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/column/package.json
+++ b/packages/column/package.json
@@ -46,7 +46,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/column/src/column.tsx
+++ b/packages/column/src/column.tsx
@@ -1,11 +1,8 @@
 import * as React from "react";
 
-type RootProps = React.ComponentPropsWithoutRef<"td">;
-type TdElement = React.ElementRef<"td">;
+export type ColumnProps = Readonly<React.ComponentPropsWithoutRef<"td">>;
 
-export type ColumnProps = RootProps;
-
-export const Column = React.forwardRef<TdElement, Readonly<ColumnProps>>(
+export const Column = React.forwardRef<HTMLTableCellElement, ColumnProps>(
   ({ children, style, ...props }, ref) => {
     return (
       <td {...props} data-id="__react-email-column" ref={ref} style={style}>

--- a/packages/components/.babelrc
+++ b/packages/components/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -66,7 +66,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",
     "typescript": "5.1.6"

--- a/packages/container/.babelrc
+++ b/packages/container/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -46,7 +46,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/container/src/container.tsx
+++ b/packages/container/src/container.tsx
@@ -1,33 +1,29 @@
 import * as React from "react";
 
-type RootProps = React.ComponentPropsWithoutRef<"table">;
-type TableElement = React.ElementRef<"table">;
+export type ContainerProps = Readonly<React.ComponentPropsWithoutRef<"table">>;
 
-export type ContainerProps = RootProps;
-
-export const Container = React.forwardRef<
-  TableElement,
-  Readonly<ContainerProps>
->(({ children, style, ...props }, ref) => {
-  return (
-    <table
-      align="center"
-      width="100%"
-      {...props}
-      border={0}
-      cellPadding="0"
-      cellSpacing="0"
-      ref={ref}
-      role="presentation"
-      style={{ maxWidth: "37.5em", ...style }}
-    >
-      <tbody>
-        <tr style={{ width: "100%" }}>
-          <td>{children}</td>
-        </tr>
-      </tbody>
-    </table>
-  );
-});
+export const Container = React.forwardRef<HTMLTableElement, ContainerProps>(
+  ({ children, style, ...props }, ref) => {
+    return (
+      <table
+        align="center"
+        width="100%"
+        {...props}
+        border={0}
+        cellPadding="0"
+        cellSpacing="0"
+        ref={ref}
+        role="presentation"
+        style={{ maxWidth: "37.5em", ...style }}
+      >
+        <tbody>
+          <tr style={{ width: "100%" }}>
+            <td>{children}</td>
+          </tr>
+        </tbody>
+      </table>
+    );
+  },
+);
 
 Container.displayName = "Container";

--- a/packages/create-email/.babelrc
+++ b/packages/create-email/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/create-email/package.json
+++ b/packages/create-email/package.json
@@ -27,7 +27,6 @@
     "create-email": "src/index.js"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "eslint-config-custom": "workspace:*",
     "prettier": "3.0.0",
     "tsconfig": "workspace:*"

--- a/packages/font/.babelrc
+++ b/packages/font/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -34,7 +34,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/font/src/font.tsx
+++ b/packages/font/src/font.tsx
@@ -74,5 +74,3 @@ export const Font: React.FC<Readonly<FontProps>> = ({
   `;
   return <style dangerouslySetInnerHTML={{ __html: style }} />;
 };
-
-Font.displayName = "Font";

--- a/packages/head/.babelrc
+++ b/packages/head/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -46,7 +46,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/head/src/head.tsx
+++ b/packages/head/src/head.tsx
@@ -1,11 +1,8 @@
 import * as React from "react";
 
-type RootProps = React.ComponentPropsWithoutRef<"head">;
-type HeadElement = React.ElementRef<"head">;
+export type HeadProps = Readonly<React.ComponentPropsWithoutRef<"head">>;
 
-export type HeadProps = RootProps;
-
-export const Head = React.forwardRef<HeadElement, Readonly<HeadProps>>(
+export const Head = React.forwardRef<HTMLHeadElement, HeadProps>(
   ({ children, ...props }, ref) => (
     <head {...props} ref={ref}>
       <meta content="text/html; charset=UTF-8" httpEquiv="Content-Type" />

--- a/packages/heading/.babelrc
+++ b/packages/heading/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/heading/package.json
+++ b/packages/heading/package.json
@@ -42,14 +42,10 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "dependencies": {
-    "@radix-ui/react-slot": "1.1.0"
-  },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/heading/src/heading.tsx
+++ b/packages/heading/src/heading.tsx
@@ -6,25 +6,24 @@ import { withMargin } from "./utils/spaces";
 export type HeadingAs = As<"h1", "h2", "h3", "h4", "h5", "h6">;
 export type HeadingProps = HeadingAs & Margin;
 
-export const Heading: React.FC<Readonly<HeadingProps>> = ({
-  as: Tag = "h1",
-  children,
-  style,
-  m,
-  mx,
-  my,
-  mt,
-  mr,
-  mb,
-  ml,
-  ...props
-}) => {
-  return (
-    <Tag
-      {...props}
-      style={{ ...withMargin({ m, mx, my, mt, mr, mb, ml }), ...style }}
-    >
-      {children}
-    </Tag>
-  );
-};
+export const Heading = React.forwardRef<
+  HTMLHeadingElement,
+  Readonly<HeadingProps>
+>(
+  (
+    { as: Tag = "h1", children, style, m, mx, my, mt, mr, mb, ml, ...props },
+    ref,
+  ) => {
+    return (
+      <Tag
+        {...props}
+        ref={ref}
+        style={{ ...withMargin({ m, mx, my, mt, mr, mb, ml }), ...style }}
+      >
+        {children}
+      </Tag>
+    );
+  },
+);
+
+Heading.displayName = "Heading";

--- a/packages/heading/src/heading.tsx
+++ b/packages/heading/src/heading.tsx
@@ -1,7 +1,7 @@
-import { Slot } from "@radix-ui/react-slot";
 import * as React from "react";
-import type { As, Margin } from "./utils";
-import { withMargin } from "./utils";
+import type { As } from "./utils/as";
+import type { Margin } from "./utils/spaces";
+import { withMargin } from "./utils/spaces";
 
 export type HeadingAs = As<"h1", "h2", "h3", "h4", "h5", "h6">;
 export type HeadingProps = HeadingAs & Margin;
@@ -20,11 +20,11 @@ export const Heading: React.FC<Readonly<HeadingProps>> = ({
   ...props
 }) => {
   return (
-    <Slot
+    <Tag
       {...props}
       style={{ ...withMargin({ m, mx, my, mt, mr, mb, ml }), ...style }}
     >
-      <Tag>{children}</Tag>
-    </Slot>
+      {children}
+    </Tag>
   );
 };

--- a/packages/heading/src/utils/index.ts
+++ b/packages/heading/src/utils/index.ts
@@ -1,2 +1,0 @@
-export * from "./as";
-export * from "./spaces";

--- a/packages/heading/src/utils/utils.spec.ts
+++ b/packages/heading/src/utils/utils.spec.ts
@@ -1,5 +1,5 @@
-import type { Margin } from ".";
-import { withMargin, withSpace } from ".";
+import type { Margin } from "./spaces";
+import { withMargin, withSpace } from "./spaces";
 
 describe("withMargin", () => {
   it("should return an empty object for empty input", () => {

--- a/packages/hr/.babelrc
+++ b/packages/hr/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/hr/package.json
+++ b/packages/hr/package.json
@@ -46,7 +46,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/hr/src/hr.tsx
+++ b/packages/hr/src/hr.tsx
@@ -1,10 +1,8 @@
 import * as React from "react";
 
-type RootProps = React.ComponentPropsWithoutRef<"hr">;
+export type HrProps = Readonly<React.ComponentPropsWithoutRef<"hr">>;
 
-export type HrProps = RootProps;
-
-export const Hr = React.forwardRef<React.ElementRef<"hr">, Readonly<HrProps>>(
+export const Hr = React.forwardRef<HTMLHRElement, HrProps>(
   ({ style, ...props }, ref) => (
     <hr
       {...props}

--- a/packages/html/.babelrc
+++ b/packages/html/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -46,7 +46,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/html/src/html.tsx
+++ b/packages/html/src/html.tsx
@@ -1,16 +1,13 @@
 import * as React from "react";
 
-type RootProps = React.ComponentPropsWithoutRef<"html">;
+export type HtmlProps = Readonly<React.ComponentPropsWithoutRef<"html">>;
 
-export type HtmlProps = RootProps;
-
-export const Html = React.forwardRef<
-  React.ElementRef<"html">,
-  Readonly<HtmlProps>
->(({ children, lang = "en", dir = "ltr", ...props }, ref) => (
-  <html {...props} dir={dir} lang={lang} ref={ref}>
-    {children}
-  </html>
-));
+export const Html = React.forwardRef<HTMLHtmlElement, HtmlProps>(
+  ({ children, lang = "en", dir = "ltr", ...props }, ref) => (
+    <html {...props} dir={dir} lang={lang} ref={ref}>
+      {children}
+    </html>
+  ),
+);
 
 Html.displayName = "Html";

--- a/packages/img/.babelrc
+++ b/packages/img/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -46,7 +46,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/img/src/img.tsx
+++ b/packages/img/src/img.tsx
@@ -1,28 +1,25 @@
 import * as React from "react";
 
-type RootProps = React.ComponentPropsWithoutRef<"img">;
+export type ImgProps = Readonly<React.ComponentPropsWithoutRef<"img">>;
 
-export type ImgProps = RootProps;
-
-export const Img = React.forwardRef<
-  React.ElementRef<"img">,
-  Readonly<ImgProps>
->(({ alt, src, width, height, style, ...props }, ref) => (
-  <img
-    {...props}
-    alt={alt}
-    height={height}
-    ref={ref}
-    src={src}
-    style={{
-      display: "block",
-      outline: "none",
-      border: "none",
-      textDecoration: "none",
-      ...style,
-    }}
-    width={width}
-  />
-));
+export const Img = React.forwardRef<HTMLImageElement, ImgProps>(
+  ({ alt, src, width, height, style, ...props }, ref) => (
+    <img
+      {...props}
+      alt={alt}
+      height={height}
+      ref={ref}
+      src={src}
+      style={{
+        display: "block",
+        outline: "none",
+        border: "none",
+        textDecoration: "none",
+        ...style,
+      }}
+      width={width}
+    />
+  ),
+);
 
 Img.displayName = "Img";

--- a/packages/link/.babelrc
+++ b/packages/link/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -46,7 +46,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/link/src/link.tsx
+++ b/packages/link/src/link.tsx
@@ -1,25 +1,22 @@
 import * as React from "react";
 
-type RootProps = React.ComponentPropsWithoutRef<"a">;
+export type LinkProps = Readonly<React.ComponentPropsWithoutRef<"a">>;
 
-export type LinkProps = RootProps;
-
-export const Link = React.forwardRef<
-  React.ElementRef<"a">,
-  Readonly<LinkProps>
->(({ target = "_blank", style, ...props }, ref) => (
-  <a
-    {...props}
-    ref={ref}
-    style={{
-      color: "#067df7",
-      textDecoration: "none",
-      ...style,
-    }}
-    target={target}
-  >
-    {props.children}
-  </a>
-));
+export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ target = "_blank", style, ...props }, ref) => (
+    <a
+      {...props}
+      ref={ref}
+      style={{
+        color: "#067df7",
+        textDecoration: "none",
+        ...style,
+      }}
+      target={target}
+    >
+      {props.children}
+    </a>
+  ),
+);
 
 Link.displayName = "Link";

--- a/packages/markdown/.babelrc
+++ b/packages/markdown/.babelrc
@@ -1,4 +1,0 @@
-{
-    "presets": ["@babel/preset-react"]
-  }
-  

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -50,7 +50,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/markdown/src/markdown.tsx
+++ b/packages/markdown/src/markdown.tsx
@@ -2,16 +2,13 @@ import type { StylesType } from "md-to-react-email";
 import { parseMarkdownToJSX } from "md-to-react-email";
 import * as React from "react";
 
-export interface MarkdownProps {
+export type MarkdownProps = Readonly<{
   children: string;
   markdownCustomStyles?: StylesType;
   markdownContainerStyles?: React.CSSProperties;
-}
+}>;
 
-export const Markdown = React.forwardRef<
-  React.ElementRef<"div">,
-  Readonly<MarkdownProps>
->(
+export const Markdown = React.forwardRef<HTMLDivElement, MarkdownProps>(
   (
     { children, markdownContainerStyles, markdownCustomStyles, ...props },
     ref,

--- a/packages/preview/.babelrc
+++ b/packages/preview/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -46,7 +46,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/preview/src/preview.tsx
+++ b/packages/preview/src/preview.tsx
@@ -1,44 +1,46 @@
 import * as React from "react";
 
-type RootProps = React.ComponentPropsWithoutRef<"div">;
-
-export interface PreviewProps extends RootProps {
-  children: string | string[];
-}
+export type PreviewProps = Readonly<
+  React.ComponentPropsWithoutRef<"div"> & {
+    children: string | string[];
+  }
+>;
 
 const PREVIEW_MAX_LENGTH = 150;
 
-export const Preview = React.forwardRef<
-  React.ElementRef<"div">,
-  Readonly<PreviewProps>
->(({ children = "", ...props }, ref) => {
-  let text = Array.isArray(children) ? children.join("") : children;
-  text = text.substr(0, PREVIEW_MAX_LENGTH);
-  return (
-    <div
-      style={{
-        display: "none",
-        overflow: "hidden",
-        lineHeight: "1px",
-        opacity: 0,
-        maxHeight: 0,
-        maxWidth: 0,
-      }}
-      {...props}
-      ref={ref}
-    >
-      {text}
-      {renderWhiteSpace(text)}
-    </div>
-  );
-});
+export const Preview = React.forwardRef<HTMLDivElement, PreviewProps>(
+  ({ children = "", ...props }, ref) => {
+    const text = (
+      Array.isArray(children) ? children.join("") : children
+    ).substring(0, PREVIEW_MAX_LENGTH);
+
+    return (
+      <div
+        style={{
+          display: "none",
+          overflow: "hidden",
+          lineHeight: "1px",
+          opacity: 0,
+          maxHeight: 0,
+          maxWidth: 0,
+        }}
+        {...props}
+        ref={ref}
+      >
+        {text}
+        {renderWhiteSpace(text)}
+      </div>
+    );
+  },
+);
 
 Preview.displayName = "Preview";
 
+const whiteSpaceCodes = "\xa0\u200C\u200B\u200D\u200E\u200F\uFEFF";
 export const renderWhiteSpace = (text: string) => {
   if (text.length >= PREVIEW_MAX_LENGTH) {
     return null;
   }
-  const whiteSpaceCodes = "\xa0\u200C\u200B\u200D\u200E\u200F\uFEFF";
+
   return <div>{whiteSpaceCodes.repeat(PREVIEW_MAX_LENGTH - text.length)}</div>;
 };

--- a/packages/render/.babelrc
+++ b/packages/render/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -94,7 +94,6 @@
     "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@edge-runtime/vm": "3.1.8",
     "@types/html-to-text": "9.0.4",
     "@types/js-beautify": "1.14.3",

--- a/packages/row/.babelrc
+++ b/packages/row/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/row/package.json
+++ b/packages/row/package.json
@@ -46,7 +46,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/row/src/row.tsx
+++ b/packages/row/src/row.tsx
@@ -1,32 +1,31 @@
 import * as React from "react";
 
-type RootProps = React.ComponentPropsWithoutRef<"table">;
+export type RowProps = Readonly<
+  React.ComponentPropsWithoutRef<"table"> & {
+    children: React.ReactNode;
+  }
+>;
 
-export interface RowProps extends RootProps {
-  children: React.ReactNode;
-}
-
-export const Row = React.forwardRef<
-  React.ElementRef<"table">,
-  Readonly<RowProps>
->(({ children, style, ...props }, ref) => {
-  return (
-    <table
-      align="center"
-      width="100%"
-      {...props}
-      border={0}
-      cellPadding="0"
-      cellSpacing="0"
-      ref={ref}
-      role="presentation"
-      style={style}
-    >
-      <tbody style={{ width: "100%" }}>
-        <tr style={{ width: "100%" }}>{children}</tr>
-      </tbody>
-    </table>
-  );
-});
+export const Row = React.forwardRef<HTMLTableElement, RowProps>(
+  ({ children, style, ...props }, ref) => {
+    return (
+      <table
+        align="center"
+        width="100%"
+        {...props}
+        border={0}
+        cellPadding="0"
+        cellSpacing="0"
+        ref={ref}
+        role="presentation"
+        style={style}
+      >
+        <tbody style={{ width: "100%" }}>
+          <tr style={{ width: "100%" }}>{children}</tr>
+        </tbody>
+      </table>
+    );
+  },
+);
 
 Row.displayName = "Row";

--- a/packages/section/.babelrc
+++ b/packages/section/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/section/package.json
+++ b/packages/section/package.json
@@ -46,7 +46,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/section/src/section.tsx
+++ b/packages/section/src/section.tsx
@@ -1,32 +1,29 @@
 import * as React from "react";
 
-type RootProps = React.ComponentPropsWithoutRef<"table">;
+export type SectionProps = Readonly<React.ComponentPropsWithoutRef<"table">>;
 
-export type SectionProps = RootProps;
-
-export const Section = React.forwardRef<
-  React.ElementRef<"table">,
-  Readonly<SectionProps>
->(({ children, style, ...props }, ref) => {
-  return (
-    <table
-      align="center"
-      width="100%"
-      {...props}
-      border={0}
-      cellPadding="0"
-      cellSpacing="0"
-      ref={ref}
-      role="presentation"
-      style={style}
-    >
-      <tbody>
-        <tr>
-          <td>{children}</td>
-        </tr>
-      </tbody>
-    </table>
-  );
-});
+export const Section = React.forwardRef<HTMLTableElement, SectionProps>(
+  ({ children, style, ...props }, ref) => {
+    return (
+      <table
+        align="center"
+        width="100%"
+        {...props}
+        border={0}
+        cellPadding="0"
+        cellSpacing="0"
+        ref={ref}
+        role="presentation"
+        style={style}
+      >
+        <tbody>
+          <tr>
+            <td>{children}</td>
+          </tr>
+        </tbody>
+      </table>
+    );
+  },
+);
 
 Section.displayName = "Section";

--- a/packages/tailwind/.babelrc
+++ b/packages/tailwind/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -47,9 +47,7 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/core": "7.23.9",
     "@responsive-email/react-email": "0.0.2",
-    "@babel/preset-react": "7.23.3",
     "@react-email/button": "workspace:^",
     "@react-email/head": "workspace:*",
     "@react-email/heading": "workspace:*",

--- a/packages/text/.babelrc
+++ b/packages/text/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -46,7 +46,6 @@
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@react-email/render": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",

--- a/packages/text/src/text.tsx
+++ b/packages/text/src/text.tsx
@@ -1,23 +1,20 @@
 import * as React from "react";
 
-type RootProps = React.ComponentPropsWithoutRef<"p">;
+export type TextProps = Readonly<React.ComponentPropsWithoutRef<"p">>;
 
-export type TextProps = RootProps;
-
-export const Text = React.forwardRef<
-  React.ElementRef<"p">,
-  Readonly<TextProps>
->(({ style, ...props }, ref) => (
-  <p
-    {...props}
-    ref={ref}
-    style={{
-      fontSize: "14px",
-      lineHeight: "24px",
-      margin: "16px 0",
-      ...style,
-    }}
-  />
-));
+export const Text = React.forwardRef<HTMLParagraphElement, TextProps>(
+  ({ style, ...props }, ref) => (
+    <p
+      {...props}
+      ref={ref}
+      style={{
+        fontSize: "14px",
+        lineHeight: "24px",
+        margin: "16px 0",
+        ...style,
+      }}
+    />
+  ),
+);
 
 Text.displayName = "Text";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,12 +192,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/core':
-        specifier: 7.23.9
-        version: 7.23.9
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -217,9 +211,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -242,9 +233,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -267,9 +255,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -295,9 +280,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -377,9 +359,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       eslint-config-custom:
         specifier: workspace:*
         version: link:../eslint-config-custom
@@ -396,9 +375,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -427,9 +403,6 @@ importers:
         specifier: 6.1.2
         version: 6.1.2
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       eslint-config-custom:
         specifier: workspace:*
         version: link:../eslint-config-custom
@@ -483,9 +456,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -505,9 +475,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -523,16 +490,10 @@ importers:
 
   packages/heading:
     dependencies:
-      '@radix-ui/react-slot':
-        specifier: 1.1.0
-        version: 1.1.0(react@19.0.0-rc.0)(types-react@19.0.0-rc.1)
       react:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -552,9 +513,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -574,9 +532,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -596,9 +551,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -618,9 +570,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -643,9 +592,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -665,9 +611,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -833,7 +776,7 @@ importers:
         version: 8.50.0
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.3.101(@swc/helpers@0.5.11))(postcss@8.4.40)(typescript@5.1.6)
+        version: 7.2.0(@swc/core@1.3.101)(postcss@8.4.40)(typescript@5.1.6)
       tsx:
         specifier: 4.9.0
         version: 4.9.0
@@ -859,9 +802,6 @@ importers:
         specifier: 0.3.4
         version: 0.3.4
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@edge-runtime/vm':
         specifier: 3.1.8
         version: 3.1.8
@@ -896,9 +836,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -918,9 +855,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -940,12 +874,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/core':
-        specifier: 7.23.9
-        version: 7.23.9
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.9)
       '@react-email/button':
         specifier: workspace:^
         version: link:../button
@@ -1016,9 +944,6 @@ importers:
         specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 19.0.0-rc.0
     devDependencies:
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.24.5)
       '@react-email/render':
         specifier: workspace:*
         version: link:../render
@@ -1056,10 +981,6 @@ packages:
     resolution: {integrity: sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.23.9':
-    resolution: {integrity: sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/core@7.24.5':
     resolution: {integrity: sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==}
     engines: {node: '>=6.9.0'}
@@ -1071,16 +992,8 @@ packages:
       '@babel/core': ^7.11.0
       eslint: ^7.5.0 || ^8.0.0
 
-  '@babel/generator@7.24.4':
-    resolution: {integrity: sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/generator@7.24.5':
     resolution: {integrity: sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-annotate-as-pure@7.22.5':
-    resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.23.6':
@@ -1103,32 +1016,14 @@ packages:
     resolution: {integrity: sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-transforms@7.23.3':
-    resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
   '@babel/helper-module-transforms@7.24.5':
     resolution: {integrity: sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-plugin-utils@7.24.0':
-    resolution: {integrity: sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-simple-access@7.22.5':
-    resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-simple-access@7.24.5':
     resolution: {integrity: sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-split-export-declaration@7.22.6':
-    resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-split-export-declaration@7.24.5':
@@ -1151,10 +1046,6 @@ packages:
     resolution: {integrity: sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.24.4':
-    resolution: {integrity: sha512-FewdlZbSiwaVGlgT1DPANDuCHaDMiOo+D/IDYRFYjHOuv66xMSJ7fQwwODwRNAPkADIO/z1EoF/l2BCWlWABDw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helpers@7.24.5':
     resolution: {integrity: sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==}
     engines: {node: '>=6.9.0'}
@@ -1168,52 +1059,12 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/plugin-syntax-jsx@7.24.1':
-    resolution: {integrity: sha512-2eCtxZXf+kbkMIsXS4poTvT4Yu5rXiRa+9xGVT56raghjmBTKMpFNc9R4IDiB4emao9eO22Ox7CxuJG7BgExqA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-display-name@7.24.1':
-    resolution: {integrity: sha512-mvoQg2f9p2qlpDQRBC7M3c3XTr0k7cp/0+kFKKO/7Gtu0LSw16eKB+Fabe2bDT/UpsyasTBBkAnbdsLrkD5XMw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-development@7.22.5':
-    resolution: {integrity: sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx@7.23.4':
-    resolution: {integrity: sha512-5xOpoPguCZCRbo/JeHlloSkTA8Bld1J/E1/kLfD1nsuiW1m8tduTA1ERCgIZokDflX/IBzKcqR3l7VlRgiIfHA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-pure-annotations@7.24.1':
-    resolution: {integrity: sha512-+pWEAaDJvSm9aFvJNpLiM2+ktl2Sn2U5DdyiWdZBxmLc6+xGt88dvFqsHiAiDS+8WqUwbDfkKz9jRxK3M0k+kA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/preset-react@7.23.3':
-    resolution: {integrity: sha512-tbkHOS9axH6Ysf2OUEqoSZ6T3Fa2SrNH6WTWSPBboxKzdxNc9qOICeLXkNG0ZEwbQ1HY8liwOce4aN/Ceyuq6w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/runtime@7.24.4':
     resolution: {integrity: sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.24.0':
     resolution: {integrity: sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.24.1':
-    resolution: {integrity: sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.24.5':
@@ -6612,26 +6463,6 @@ snapshots:
 
   '@babel/compat-data@7.24.4': {}
 
-  '@babel/core@7.23.9':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.24.2
-      '@babel/generator': 7.24.4
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.9)
-      '@babel/helpers': 7.24.4
-      '@babel/parser': 7.24.5
-      '@babel/template': 7.24.0
-      '@babel/traverse': 7.24.1
-      '@babel/types': 7.24.0
-      convert-source-map: 2.0.0
-      debug: 4.3.4
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/core@7.24.5':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -6660,23 +6491,12 @@ snapshots:
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
-  '@babel/generator@7.24.4':
-    dependencies:
-      '@babel/types': 7.24.0
-      '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
-      jsesc: 2.5.2
-
   '@babel/generator@7.24.5':
     dependencies:
       '@babel/types': 7.24.5
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
-
-  '@babel/helper-annotate-as-pure@7.22.5':
-    dependencies:
-      '@babel/types': 7.24.0
 
   '@babel/helper-compilation-targets@7.23.6':
     dependencies:
@@ -6701,15 +6521,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.24.0
 
-  '@babel/helper-module-transforms@7.23.3(@babel/core@7.23.9)':
-    dependencies:
-      '@babel/core': 7.23.9
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-module-imports': 7.24.3
-      '@babel/helper-simple-access': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.20
-
   '@babel/helper-module-transforms@7.24.5(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
@@ -6719,19 +6530,9 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.24.5
       '@babel/helper-validator-identifier': 7.24.5
 
-  '@babel/helper-plugin-utils@7.24.0': {}
-
-  '@babel/helper-simple-access@7.22.5':
-    dependencies:
-      '@babel/types': 7.24.0
-
   '@babel/helper-simple-access@7.24.5':
     dependencies:
       '@babel/types': 7.24.5
-
-  '@babel/helper-split-export-declaration@7.22.6':
-    dependencies:
-      '@babel/types': 7.24.0
 
   '@babel/helper-split-export-declaration@7.24.5':
     dependencies:
@@ -6744,14 +6545,6 @@ snapshots:
   '@babel/helper-validator-identifier@7.24.5': {}
 
   '@babel/helper-validator-option@7.23.5': {}
-
-  '@babel/helpers@7.24.4':
-    dependencies:
-      '@babel/template': 7.24.0
-      '@babel/traverse': 7.24.1
-      '@babel/types': 7.24.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helpers@7.24.5':
     dependencies:
@@ -6772,86 +6565,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.24.5
 
-  '@babel/plugin-syntax-jsx@7.24.1(@babel/core@7.23.9)':
-    dependencies:
-      '@babel/core': 7.23.9
-      '@babel/helper-plugin-utils': 7.24.0
-
-  '@babel/plugin-syntax-jsx@7.24.1(@babel/core@7.24.5)':
-    dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.0
-
-  '@babel/plugin-transform-react-display-name@7.24.1(@babel/core@7.23.9)':
-    dependencies:
-      '@babel/core': 7.23.9
-      '@babel/helper-plugin-utils': 7.24.0
-
-  '@babel/plugin-transform-react-display-name@7.24.1(@babel/core@7.24.5)':
-    dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.0
-
-  '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.23.9)':
-    dependencies:
-      '@babel/core': 7.23.9
-      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.23.9)
-
-  '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.24.5)':
-    dependencies:
-      '@babel/core': 7.24.5
-      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.5)
-
-  '@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.23.9)':
-    dependencies:
-      '@babel/core': 7.23.9
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-module-imports': 7.24.3
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.23.9)
-      '@babel/types': 7.24.0
-
-  '@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.5)':
-    dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-module-imports': 7.24.3
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.24.5)
-      '@babel/types': 7.24.0
-
-  '@babel/plugin-transform-react-pure-annotations@7.24.1(@babel/core@7.23.9)':
-    dependencies:
-      '@babel/core': 7.23.9
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-plugin-utils': 7.24.0
-
-  '@babel/plugin-transform-react-pure-annotations@7.24.1(@babel/core@7.24.5)':
-    dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-plugin-utils': 7.24.0
-
-  '@babel/preset-react@7.23.3(@babel/core@7.23.9)':
-    dependencies:
-      '@babel/core': 7.23.9
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-validator-option': 7.23.5
-      '@babel/plugin-transform-react-display-name': 7.24.1(@babel/core@7.23.9)
-      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.23.9)
-      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.23.9)
-      '@babel/plugin-transform-react-pure-annotations': 7.24.1(@babel/core@7.23.9)
-
-  '@babel/preset-react@7.23.3(@babel/core@7.24.5)':
-    dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-validator-option': 7.23.5
-      '@babel/plugin-transform-react-display-name': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.5)
-      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.24.5)
-      '@babel/plugin-transform-react-pure-annotations': 7.24.1(@babel/core@7.24.5)
-
   '@babel/runtime@7.24.4':
     dependencies:
       regenerator-runtime: 0.14.1
@@ -6861,21 +6574,6 @@ snapshots:
       '@babel/code-frame': 7.24.2
       '@babel/parser': 7.24.5
       '@babel/types': 7.24.0
-
-  '@babel/traverse@7.24.1':
-    dependencies:
-      '@babel/code-frame': 7.24.2
-      '@babel/generator': 7.24.4
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.24.5
-      '@babel/types': 7.24.0
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/traverse@7.24.5':
     dependencies:
@@ -11233,7 +10931,7 @@ snapshots:
 
   prism-react-renderer@2.1.0(react@18.3.1):
     dependencies:
-      '@types/prismjs': 1.26.4
+      '@types/prismjs': 1.26.3
       clsx: 1.2.1
       react: 18.3.1
 
@@ -12108,30 +11806,6 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tsup@7.2.0(@swc/core@1.3.101(@swc/helpers@0.5.11))(postcss@8.4.40)(typescript@5.1.6):
-    dependencies:
-      bundle-require: 4.0.2(esbuild@0.18.20)
-      cac: 6.7.14
-      chokidar: 3.6.0
-      debug: 4.3.4
-      esbuild: 0.18.20
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.40)
-      resolve-from: 5.0.0
-      rollup: 3.29.4
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tree-kill: 1.2.2
-    optionalDependencies:
-      '@swc/core': 1.3.101(@swc/helpers@0.5.11)
-      postcss: 8.4.40
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-
   tsup@7.2.0(@swc/core@1.3.101)(postcss@8.4.40)(typescript@5.1.6):
     dependencies:
       bundle-require: 4.0.2(esbuild@0.18.20)
@@ -12160,7 +11834,7 @@ snapshots:
     dependencies:
       bundle-require: 4.0.2(esbuild@0.18.20)
       cac: 6.7.14
-      chokidar: 3.6.0
+      chokidar: 3.5.3
       debug: 4.3.4
       esbuild: 0.18.20
       execa: 5.1.1


### PR DESCRIPTION
- simplified types by stopping to use the deprecated `ElementRef` in favor of HTML element types 
- removed unused babel files and devDependencies, we use `vite` or `tsup` to build stuff 