### PR TITLE
fix(react-email): Hot reloading

### DIFF
--- a/.changeset/thin-scissors-wave.md
+++ b/.changeset/thin-scissors-wave.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Fix hot reloading

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/create-dependency-graph.ts
@@ -1,4 +1,4 @@
-import path, { resolve } from 'node:path';
+import path from 'node:path';
 import { existsSync, promises as fs, statSync } from 'node:fs';
 import { getImportedModules } from './get-imported-modules';
 import { isDev } from '../start-dev-server';

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/setup-hot-reloading.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/setup-hot-reloading.ts
@@ -70,7 +70,7 @@ export const setupHotreloading = async (
       return;
     }
     const pathToChangeTarget = path.resolve(
-      process.cwd(),
+      absolutePathToEmailsDirectory,
       relativePathToChangeTarget,
     );
 


### PR DESCRIPTION
Closes #1623.

The issue was that we changed some settings that we passed onto chokidar causing it to
give paths to changed files relative to the user's directory instead of relative to the CWD of the process.
This caused that a further path manipulation failed and in turn caused the hot reloading to completely break.

We may want to think about a way to test this to avoid this kind of issue happening again without being
caught by our CI.