### PR TITLE
feat(html-comment): Add components for handling html comments and outlook conditional comments

### DIFF
--- a/packages/comment/.eslintrc.js
+++ b/packages/comment/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ["custom/react-internal"],
+};

--- a/packages/comment/license.md
+++ b/packages/comment/license.md
@@ -1,0 +1,7 @@
+Copyright 2024 Plus Five Five, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/comment/package.json
+++ b/packages/comment/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@react-email/comment",
+  "version": "0.0.1",
+  "description": "HTML comment components",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "license": "MIT",
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --external react",
+    "clean": "rm -rf dist",
+    "dev": "tsup src/index.ts --format esm,cjs --dts --external react --watch",
+    "lint": "eslint .",
+    "test:watch": "vitest",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+  },
+  "devDependencies": {
+    "@react-email/render": "workspace:*",
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*",
+    "typescript": "5.1.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/comment/src/comment.spec.tsx
+++ b/packages/comment/src/comment.spec.tsx
@@ -1,0 +1,11 @@
+import { render } from "@react-email/render";
+import { Comment } from "./index";
+
+describe("<Comment> component", () => {
+  it("renders correctly", async () => {
+    const actualOutput = await render(<Comment>Lorem ipsum</Comment>);
+    expect(actualOutput).toMatchInlineSnapshot(
+      '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><!--Lorem ipsum-->"',
+    );
+  });
+});

--- a/packages/comment/src/comment.tsx
+++ b/packages/comment/src/comment.tsx
@@ -1,0 +1,10 @@
+import * as React from "react";
+import { childrenPropsDecider, CommentPlaceholder } from "./shared/utils";
+
+export type CommentProps = Required<React.PropsWithChildren>;
+
+export const Comment: React.FC<CommentProps> = ({ children }) => (
+  <CommentPlaceholder {...childrenPropsDecider(children)} />
+);
+
+Comment.displayName = "Comment";

--- a/packages/comment/src/index.ts
+++ b/packages/comment/src/index.ts
@@ -1,0 +1,9 @@
+export * from "./comment";
+
+export * from "./mso";
+
+export * from "./non-mso";
+
+export * from "./mso-ghost";
+
+export * from "./non-mso-ghost";

--- a/packages/comment/src/mso-ghost.tsx
+++ b/packages/comment/src/mso-ghost.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import {
+  conditionPropsDecider,
+  MsoPlaceholderCloser,
+  MsoPlaceholderOpener,
+} from "./shared/utils";
+import type { MsoConditionalVersion, MsoVersion } from "./shared/mso";
+
+type Version = MsoVersion | MsoConditionalVersion;
+
+export type MsoGhostProps = Required<React.PropsWithChildren> & {
+  version?: Version | Version[];
+  ghostWrapper: (children: React.ReactNode) => React.ReactElement;
+};
+
+export const MsoGhost: React.FC<MsoGhostProps> = ({
+  children,
+  version,
+  ghostWrapper,
+}) => {
+  const conditionProps = conditionPropsDecider(version);
+
+  return (
+    <>
+      <MsoPlaceholderOpener {...conditionProps} />
+      {ghostWrapper(
+        <>
+          <MsoPlaceholderCloser />
+          {children}
+          <MsoPlaceholderOpener {...conditionProps} />
+        </>,
+      )}
+      <MsoPlaceholderCloser />
+    </>
+  );
+};
+
+MsoGhost.displayName = "MsoGhost";

--- a/packages/comment/src/mso.spec.tsx
+++ b/packages/comment/src/mso.spec.tsx
@@ -1,0 +1,25 @@
+import { render } from "@react-email/render";
+import { Mso } from "./index";
+
+describe("<Mso> component", () => {
+  it("renders correctly", async () => {
+    const actualOutput = await render(<Mso>Lorem ipsum</Mso>);
+    expect(actualOutput).toMatchInlineSnapshot(
+      '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><!--[if mso]>Lorem ipsum<![endif]-->"',
+    );
+  });
+
+  it("renders correctly with complex children", async () => {
+    const actualOutput = await render(
+      <Mso>
+        <div style={{ textDecoration: "underline" }}>
+          <b>Lorem</b>
+          <i>ipsum</i>
+        </div>
+      </Mso>,
+    );
+    expect(actualOutput).toMatchInlineSnapshot(
+      '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><!--[if mso]><div style="text-decoration:underline"><b>Lorem</b><i>ipsum</i></div><![endif]-->"',
+    );
+  });
+});

--- a/packages/comment/src/mso.tsx
+++ b/packages/comment/src/mso.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+import {
+  childrenPropsDecider,
+  conditionPropsDecider,
+  MsoPlaceholder,
+} from "./shared/utils";
+import type { MsoConditionalVersion, MsoVersion } from "./shared/mso";
+
+type Version = MsoVersion | MsoConditionalVersion;
+
+export type MsoProps = Required<React.PropsWithChildren> & {
+  version?: Version | Version[];
+};
+
+export const Mso: React.FC<MsoProps> = ({ children, version }) => (
+  <MsoPlaceholder
+    {...conditionPropsDecider(version)}
+    {...childrenPropsDecider(children)}
+  />
+);
+
+Mso.displayName = "Mso";

--- a/packages/comment/src/non-mso-ghost.tsx
+++ b/packages/comment/src/non-mso-ghost.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import {
+  conditionPropsDecider,
+  NonMsoCloserPlaceholder,
+  NonMsoOpenerPlaceholder,
+} from "./shared/utils";
+import type { MsoVersion } from "./shared/mso";
+
+export type NonMsoGhostProps = Required<React.PropsWithChildren> & {
+  version?: MsoVersion | MsoVersion[];
+  ghostWrapper: (children: React.ReactNode) => React.ReactElement;
+};
+
+export const NonMsoGhost: React.FC<NonMsoGhostProps> = ({
+  children,
+  version,
+  ghostWrapper,
+}) => {
+  const conditionProps = conditionPropsDecider(version);
+
+  return (
+    <>
+      <NonMsoOpenerPlaceholder {...conditionProps} />
+      {ghostWrapper(
+        <>
+          <NonMsoCloserPlaceholder />
+          {children}
+          <NonMsoOpenerPlaceholder {...conditionProps} />
+        </>,
+      )}
+      <NonMsoCloserPlaceholder />
+    </>
+  );
+};
+
+NonMsoGhost.displayName = "NonMsoGhost";

--- a/packages/comment/src/non-mso.tsx
+++ b/packages/comment/src/non-mso.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import {
+  conditionPropsDecider,
+  NonMsoCloserPlaceholder,
+  NonMsoOpenerPlaceholder,
+} from "./shared/utils";
+import type { MsoVersion } from "./shared/mso";
+
+export type NonMsoProps = Required<React.PropsWithChildren> & {
+  version?: MsoVersion | MsoVersion[];
+};
+
+export const NonMso: React.FC<NonMsoProps> = ({ children, version }) => (
+  <>
+    <NonMsoOpenerPlaceholder {...conditionPropsDecider(version)} />
+    {children}
+    <NonMsoCloserPlaceholder />
+  </>
+);
+
+NonMso.displayName = "NonMso";

--- a/packages/comment/src/shared/mso.ts
+++ b/packages/comment/src/shared/mso.ts
@@ -1,0 +1,7 @@
+export type MsoVersion = "9" | "10" | "11" | "12" | "14" | "15" | "16";
+
+type MsoCondition = "gt" | "lt" | "gte" | "lte";
+
+export type MsoConditionalVersion =
+  | MsoVersion
+  | `${MsoCondition} ${MsoVersion}`;

--- a/packages/comment/src/shared/utils/index.ts
+++ b/packages/comment/src/shared/utils/index.ts
@@ -1,0 +1,166 @@
+type Opener = (condition: string | undefined) => string;
+
+interface CommentTemplateData {
+  opener?: Opener;
+  closer?: string;
+  name: Capitalize<string>;
+}
+
+const MSO_CONDITION_ARGUMENT_KEY = "a";
+
+const VERSION_SEPARATOR = ",";
+
+type ChildrenProps = React.PropsWithChildren<
+  Pick<React.DOMAttributes<unknown>, "dangerouslySetInnerHTML">
+>;
+
+type ConditionProps = Partial<
+  Record<typeof MSO_CONDITION_ARGUMENT_KEY, string>
+>;
+
+type ComponentPlaceholder = React.FC<ChildrenProps & ConditionProps>;
+
+const generateCommentUtilities = <T extends CommentTemplateData[]>(
+  ...args: T
+) => {
+  const alphabet = "abcdefghijklmnopqrstuvwxyz";
+
+  const placeholders = {} as Record<
+    {
+      [index in keyof T]:
+        | `${T[index]["name"]}Placeholder`
+        | (T[index]["closer"] extends string
+            ? T[index]["opener"] extends Opener
+              ? `${T[index]["name"]}Placeholder${"Opener" | "Closer"}`
+              : never
+            : never);
+    }[number],
+    ComponentPlaceholder
+  >;
+
+  const commentReplacerMap = new Map<
+    string,
+    (comment: string, condition: string | undefined) => string
+  >();
+
+  let alphabetIndex = 0;
+
+  args.forEach(({ name, opener, closer }) => {
+    const letter = alphabet[alphabetIndex++];
+
+    placeholders[`${name as T[number]["name"]}Placeholder`] =
+      `${letter}-` as unknown as ComponentPlaceholder;
+
+    if (opener && closer) {
+      const openCommentLetter = alphabet[alphabetIndex++];
+
+      const closeCommentLetter = alphabet[alphabetIndex++];
+
+      placeholders[`${name}PlaceholderOpener` as keyof typeof placeholders] =
+        `${openCommentLetter}-` as unknown as ComponentPlaceholder;
+
+      placeholders[`${name}PlaceholderCloser` as keyof typeof placeholders] =
+        `${closeCommentLetter}-` as unknown as ComponentPlaceholder;
+
+      commentReplacerMap.set(
+        letter,
+        (comment, condition) =>
+          `<!--${opener(condition)}${comment}${closer}-->`,
+      );
+
+      commentReplacerMap.set(
+        openCommentLetter,
+        (_, condition) => `<!--${opener(condition)}`,
+      );
+
+      commentReplacerMap.set(closeCommentLetter, () => `${closer}-->`);
+    } else if (opener) {
+      commentReplacerMap.set(
+        letter,
+        (comment, condition) => `<!--${opener(condition)}${comment}-->`,
+      );
+    } else if (closer) {
+      commentReplacerMap.set(letter, () => `<!--${closer}-->`);
+    } else {
+      commentReplacerMap.set(letter, (comment) => `<!--${comment}-->`);
+    }
+  });
+
+  const placeholderRegex = new RegExp(
+    `<([${alphabet[0]}-${
+      alphabet[alphabetIndex - 1]
+    }])-(?: ${MSO_CONDITION_ARGUMENT_KEY}="(.*?)")?>(.*?)<\\/\\1->`,
+    "g",
+  );
+
+  return {
+    placeholders,
+    replaceCommentPlaceholders: (html: string) =>
+      html.replace(
+        placeholderRegex,
+        (_, tag: string, condition: string | undefined, comment: string) =>
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          commentReplacerMap.get(tag)!(comment, condition),
+      ),
+  };
+};
+
+const { placeholders, replaceCommentPlaceholders } = generateCommentUtilities(
+  {
+    name: "NonMsoOpener",
+    opener: (version) =>
+      version
+        ? `[if ${version
+            .split(VERSION_SEPARATOR)
+            .map((item) => `!mso ${item}`)
+            .join(" | ")}]><!`
+        : "[if !mso]><!",
+  },
+  { name: "NonMsoCloser", closer: "<![endif]" },
+  {
+    name: "Mso",
+    opener: (data) =>
+      data
+        ? `[if ${data
+            .split(VERSION_SEPARATOR)
+            .map((item) => {
+              const t = item.split(" ");
+
+              return t.length === 1 ? `mso ${t[0]}` : `${t[0]} mso ${t[1]}`;
+            })
+            .join(" | ")}]>`
+        : "[if mso]>",
+    closer: "<![endif]",
+  },
+  {
+    name: "Comment",
+  },
+);
+
+export { replaceCommentPlaceholders };
+
+export const {
+  CommentPlaceholder,
+  MsoPlaceholder,
+  NonMsoCloserPlaceholder,
+  NonMsoOpenerPlaceholder,
+  MsoPlaceholderCloser,
+  MsoPlaceholderOpener,
+} = placeholders;
+
+export const childrenPropsDecider = (
+  children: React.ReactNode,
+): ChildrenProps =>
+  typeof children === "string"
+    ? { dangerouslySetInnerHTML: { __html: children } }
+    : { children };
+
+export const conditionPropsDecider = (
+  data: string | string[] | undefined,
+): ConditionProps =>
+  data
+    ? {
+        [MSO_CONDITION_ARGUMENT_KEY]:
+          typeof data !== "object" ? data : data.join(VERSION_SEPARATOR),
+      }
+    : {};

--- a/packages/comment/tsconfig.json
+++ b/packages/comment/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "tsconfig/react-library.json",
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,6 +381,25 @@ importers:
         specifier: 5.1.6
         version: 5.1.6
 
+  packages/comment:
+    dependencies:
+      react:
+        specifier: ^18.0 || ^19.0 || ^19.0.0-rc
+        version: 18.3.1
+    devDependencies:
+      '@react-email/render':
+        specifier: workspace:*
+        version: link:../render
+      eslint-config-custom:
+        specifier: workspace:*
+        version: link:../eslint-config-custom
+      tsconfig:
+        specifier: workspace:*
+        version: link:../tsconfig
+      typescript:
+        specifier: 5.1.6
+        version: 5.1.6
+
   packages/components:
     dependencies:
       '@react-email/body':
@@ -9046,7 +9065,7 @@ snapshots:
 
   '@types/webpack@5.28.5(@swc/core@1.3.101(@swc/helpers@0.5.12))(esbuild@0.19.11)':
     dependencies:
-      '@types/node': 20.16.1
+      '@types/node': 18.18.0
       tapable: 2.2.1
       webpack: 5.91.0(@swc/core@1.3.101(@swc/helpers@0.5.12))(esbuild@0.19.11)
     transitivePeerDependencies:
@@ -9644,7 +9663,7 @@ snapshots:
       caniuse-lite: 1.0.30001605
       fraction.js: 4.3.7
       normalize-range: 0.1.2
-      picocolors: 1.0.1
+      picocolors: 1.0.0
       postcss: 8.4.39
       postcss-value-parser: 4.2.0
 


### PR DESCRIPTION
#1584

It use comment placeholders for each variant of possible usage: regular html comment, mso and non-mso comments with version and conditions support, ghost wrappers for mso and non-mso. Render method should be wrapped by `replaceCommentPlaceholders` to replace all placeholders by comments

# Example

```tsx
  <div>
    <Comment>comment</Comment>
    <Mso>
      <div>mso content</div>
    </Mso>
    <NonMso>
      <div>non-mso content</div>
    </NonMso>
    <MsoGhost
      ghostWrapper={(children) => (
        <table>
          <tr>
            <td>{children}</td>
          </tr>
        </table>
      )}
    >
      <div>content</div>
    </MsoGhost>
    <NonMsoGhost
      ghostWrapper={(children) => (
        <table>
          <tr>
            <td>{children}</td>
          </tr>
        </table>
      )}
    >
      <div>content</div>
    </NonMsoGhost>
  </div>
```

# Output

```html
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><div><!--comment--><!--[if mso]><div>mso content</div><![endif]--><!--[if !mso]><!--><div>non-mso content</div><!--<![endif]--><!--[if mso]><table><tr><td><![endif]--><div>content</div><!--[if mso]></td></tr></table><![endif]--><!--[if !mso]><!--><table><tr><td><!--<![endif]--><div>content</div><!--[if !mso]><!--></td></tr></table><!--<![endif]--></div>
```

# Problems
`replaceCommentPlaceholders` should be used in `render` method, but it another lib and I'm not sure how i can use it with this structure