### PR TITLE
Fix: Background image quoted URLs converted to HTML entities during email export

### DIFF
--- a/packages/font/src/font.spec.tsx
+++ b/packages/font/src/font.spec.tsx
@@ -4,7 +4,7 @@ import { Font } from "./index";
 describe("<Font> component", () => {
   it("renders with default props", async () => {
     const html = await render(
-      <Font fallbackFontFamily="Helvetica" fontFamily="Arial" />,
+      <Font fallbackFontFamily="Helvetica" fontFamily="Arial" />
     );
 
     expect(html).toContain("font-style: normal;");
@@ -23,18 +23,18 @@ describe("<Font> component", () => {
         fallbackFontFamily="Helvetica"
         fontFamily="Example"
         webFont={webFont}
-      />,
+      />
     );
 
     expect(html).toContain("font-family: 'Example';");
     expect(html).toContain(
-      `src: url(${webFont.url}) format('${webFont.format}');`,
+      `src: url(${webFont.url}) format('${webFont.format}');`
     );
   });
 
   it("renders with multiple fallback fonts", async () => {
     const html = await render(
-      <Font fallbackFontFamily={["Helvetica", "Verdana"]} fontFamily="Arial" />,
+      <Font fallbackFontFamily={["Helvetica", "Verdana"]} fontFamily="Arial" />
     );
 
     expect(html).toContain("font-family: 'Arial', Helvetica, Verdana;");
@@ -42,7 +42,7 @@ describe("<Font> component", () => {
 
   it("renders correctly", async () => {
     const actualOutput = await render(
-      <Font fallbackFontFamily="Verdana" fontFamily="Roboto" />,
+      <Font fallbackFontFamily="Verdana" fontFamily="Roboto" />
     );
     expect(actualOutput).toMatchSnapshot();
   });
@@ -52,18 +52,19 @@ describe("<Font> component", () => {
       url: '"http://example.com/font.woff"',
       format: "woff",
     } as const;
-  
+
     const html = await render(
       <Font
         fallbackFontFamily={["Helvetica Neue", "Arial"]}
         fontFamily="My 'Custom' Font"
         webFont={webFont}
-      />,
+      />
     );
-  
+
     expect(html).toContain("font-family: 'My \\'Custom\\' Font';");
     expect(html).toContain("Helvetica Neue, Arial");
-    expect(html).toContain('src: url("http://example.com/font.woff") format(\'woff\');');
+    expect(html).toContain(
+      'src: url(\\"http://example.com/font.woff\\") format(\'woff\');'
+    );
   });
-  
 });

--- a/packages/font/src/font.spec.tsx
+++ b/packages/font/src/font.spec.tsx
@@ -46,4 +46,24 @@ describe("<Font> component", () => {
     );
     expect(actualOutput).toMatchSnapshot();
   });
+
+  it("renders with quoted URLs and font names", async () => {
+    const webFont = {
+      url: '"http://example.com/font.woff"',
+      format: "woff",
+    } as const;
+  
+    const html = await render(
+      <Font
+        fallbackFontFamily={["Helvetica Neue", "Arial"]}
+        fontFamily="My 'Custom' Font"
+        webFont={webFont}
+      />,
+    );
+  
+    expect(html).toContain("font-family: 'My \\'Custom\\' Font';");
+    expect(html).toContain("Helvetica Neue, Arial");
+    expect(html).toContain('src: url("http://example.com/font.woff") format(\'woff\');');
+  });
+  
 });

--- a/packages/font/src/font.spec.tsx
+++ b/packages/font/src/font.spec.tsx
@@ -4,7 +4,7 @@ import { Font } from "./index";
 describe("<Font> component", () => {
   it("renders with default props", async () => {
     const html = await render(
-      <Font fallbackFontFamily="Helvetica" fontFamily="Arial" />
+      <Font fallbackFontFamily="Helvetica" fontFamily="Arial" />,
     );
 
     expect(html).toContain("font-style: normal;");
@@ -23,18 +23,18 @@ describe("<Font> component", () => {
         fallbackFontFamily="Helvetica"
         fontFamily="Example"
         webFont={webFont}
-      />
+      />,
     );
 
     expect(html).toContain("font-family: 'Example';");
     expect(html).toContain(
-      `src: url(${webFont.url}) format('${webFont.format}');`
+      `src: url(${webFont.url}) format('${webFont.format}');`,
     );
   });
 
   it("renders with multiple fallback fonts", async () => {
     const html = await render(
-      <Font fallbackFontFamily={["Helvetica", "Verdana"]} fontFamily="Arial" />
+      <Font fallbackFontFamily={["Helvetica", "Verdana"]} fontFamily="Arial" />,
     );
 
     expect(html).toContain("font-family: 'Arial', Helvetica, Verdana;");
@@ -42,7 +42,7 @@ describe("<Font> component", () => {
 
   it("renders correctly", async () => {
     const actualOutput = await render(
-      <Font fallbackFontFamily="Verdana" fontFamily="Roboto" />
+      <Font fallbackFontFamily="Verdana" fontFamily="Roboto" />,
     );
     expect(actualOutput).toMatchSnapshot();
   });
@@ -58,13 +58,13 @@ describe("<Font> component", () => {
         fallbackFontFamily={["Helvetica Neue", "Arial"]}
         fontFamily="My 'Custom' Font"
         webFont={webFont}
-      />
+      />,
     );
 
     expect(html).toContain("font-family: 'My \\'Custom\\' Font';");
     expect(html).toContain("Helvetica Neue, Arial");
     expect(html).toContain(
-      'src: url(\\"http://example.com/font.woff\\") format(\'woff\');'
+      "src: url(\\\"http://example.com/font.woff\\\") format('woff');",
     );
   });
 });

--- a/packages/font/src/font.tsx
+++ b/packages/font/src/font.tsx
@@ -66,10 +66,10 @@ export const Font: React.FC<Readonly<FontProps>> = ({
 
     * {
       font-family: '${fontFamily.replace(/'/g, "\\'")}', ${
-        Array.isArray(fallbackFontFamily)
-          ? fallbackFontFamily.map(font => font.replace(/'/g, "\\'")).join(", ")
-          : fallbackFontFamily.replace(/'/g, "\\'")
-      };
+    Array.isArray(fallbackFontFamily)
+      ? fallbackFontFamily.map((font) => font.replace(/'/g, "\\'")).join(", ")
+      : fallbackFontFamily.replace(/'/g, "\\'")
+  };
     }
   `;
   return <style dangerouslySetInnerHTML={{ __html: style }} />;

--- a/packages/font/src/font.tsx
+++ b/packages/font/src/font.tsx
@@ -48,27 +48,27 @@ export const Font: React.FC<Readonly<FontProps>> = ({
   fontWeight = 400,
 }) => {
   const src = webFont
-    ? `src: url(${webFont.url}) format('${webFont.format}');`
+    ? `src: url(${webFont.url.replace(/"/g, '\\"')}) format('${webFont.format}');`
     : "";
 
   const style = `
     @font-face {
-      font-family: '${fontFamily}';
+      font-family: '${fontFamily.replace(/'/g, "\\'")}';
       font-style: ${fontStyle};
       font-weight: ${fontWeight};
       mso-font-alt: '${
         Array.isArray(fallbackFontFamily)
-          ? fallbackFontFamily[0]
-          : fallbackFontFamily
+          ? fallbackFontFamily[0].replace(/'/g, "\\'")
+          : fallbackFontFamily.replace(/'/g, "\\'")
       }';
       ${src}
     }
 
     * {
-      font-family: '${fontFamily}', ${
+      font-family: '${fontFamily.replace(/'/g, "\\'")}', ${
         Array.isArray(fallbackFontFamily)
-          ? fallbackFontFamily.join(", ")
-          : fallbackFontFamily
+          ? fallbackFontFamily.map(font => font.replace(/'/g, "\\'")).join(", ")
+          : fallbackFontFamily.replace(/'/g, "\\'")
       };
     }
   `;

--- a/packages/font/src/font.tsx
+++ b/packages/font/src/font.tsx
@@ -48,7 +48,9 @@ export const Font: React.FC<Readonly<FontProps>> = ({
   fontWeight = 400,
 }) => {
   const src = webFont
-    ? `src: url(${webFont.url.replace(/"/g, '\\"')}) format('${webFont.format}');`
+    ? `src: url(${webFont.url.replace(/"/g, '\\"')}) format('${
+        webFont.format
+      }');`
     : "";
 
   const style = `
@@ -66,10 +68,12 @@ export const Font: React.FC<Readonly<FontProps>> = ({
 
     * {
       font-family: '${fontFamily.replace(/'/g, "\\'")}', ${
-    Array.isArray(fallbackFontFamily)
-      ? fallbackFontFamily.map((font) => font.replace(/'/g, "\\'")).join(", ")
-      : fallbackFontFamily.replace(/'/g, "\\'")
-  };
+        Array.isArray(fallbackFontFamily)
+          ? fallbackFontFamily
+              .map((font) => font.replace(/'/g, "\\'"))
+              .join(", ")
+          : fallbackFontFamily.replace(/'/g, "\\'")
+      };
     }
   `;
   return <style dangerouslySetInnerHTML={{ __html: style }} />;


### PR DESCRIPTION
### Problem:
- Background image quoted URLs are converted to HTML entities during email export, breaking functionality in older email clients.


closes: #442

## Issue ticket number and link:
- **Ticket Number:** [ 442 ]
- **Link:** [ https://github.com/resend/react-email/issues/442 ]

### Acceptance Criteria
- [x]  Update the `Font` component to properly escape quotes in URLs and font names
- [x] Add a new test case to verify the correct handling of quoted URLs and font names
- [x] Ensure all existing tests pass
