### PR TITLE
Fix(docs): add await to the integration examples in the documentation

### DIFF
--- a/apps/docs/integrations/aws-ses.mdx
+++ b/apps/docs/integrations/aws-ses.mdx
@@ -57,7 +57,7 @@ import { Email } from './email';
 
 const ses = new SES({ region: process.env.AWS_SES_REGION })
 
-const emailHtml = render(<Email url="https://example.com" />);
+const emailHtml = await render(<Email url="https://example.com" />);
 
 const params = {
   Source: 'you@example.com',
@@ -88,7 +88,7 @@ import { Email } from './email';
 
 const ses = new SES({ region: process.env.AWS_SES_REGION })
 
-const emailHtml = render(Email({ url:"https://example.com" }));
+const emailHtml = await render(Email({ url:"https://example.com" }));
 
 const params = {
   Source: 'you@example.com',

--- a/apps/docs/integrations/mailersend.mdx
+++ b/apps/docs/integrations/mailersend.mdx
@@ -58,7 +58,7 @@ const mailerSend = new MailerSend({
   apiKey: process.env.MAILERSEND_API_KEY || '',
 });
 
-const emailHtml = render(<Email url="https://example.com" />);
+const emailHtml = await render(<Email url="https://example.com" />);
 
 const sentFrom = new Sender("you@yourdomain.com", "Your name");
 const recipients = [

--- a/apps/docs/integrations/nodemailer.mdx
+++ b/apps/docs/integrations/nodemailer.mdx
@@ -65,7 +65,7 @@ const transporter = nodemailer.createTransport({
   },
 });
 
-const emailHtml = render(<Email url="https://example.com" />);
+const emailHtml = await render(<Email url="https://example.com" />);
 
 const options = {
   from: 'you@example.com',
@@ -92,7 +92,7 @@ const transporter = nodemailer.createTransport({
   },
 });
 
-const emailHtml = render(Email({ url: "https://example.com" }));
+const emailHtml = await render(Email({ url: "https://example.com" }));
 
 const options = {
   from: 'you@example.com',

--- a/apps/docs/integrations/plunk.mdx
+++ b/apps/docs/integrations/plunk.mdx
@@ -59,7 +59,7 @@ Import the email template you just built, convert into a HTML string, and use th
 
   const plunk = new Plunk(process.env.PLUNK_API_KEY);
 
-  const emailHtml = render(<Email url="https://example.com" />);
+  const emailHtml = await render(<Email url="https://example.com" />);
 
   plunk.emails.send({
     to: "hello@useplunk.com",
@@ -75,7 +75,7 @@ Import the email template you just built, convert into a HTML string, and use th
 
   const plunk = new Plunk(process.env.PLUNK_API_KEY);
 
-  const emailHtml = render(Email({ url: "https://example.com" }));
+  const emailHtml = await render(Email({ url: "https://example.com" }));
 
   plunk.emails.send({
     to: "hello@useplunk.com",

--- a/apps/docs/integrations/postmark.mdx
+++ b/apps/docs/integrations/postmark.mdx
@@ -57,7 +57,7 @@ import { Email } from './email';
 
 const client = new postmark.ServerClient(process.env.POSTMARK_API_KEY);
 
-const emailHtml = render(<Email url="https://example.com" />);
+const emailHtml = await render(<Email url="https://example.com" />);
 
 const options = {
   From: 'you@example.com',
@@ -76,7 +76,7 @@ import { Email } from './email';
 
 const client = new postmark.ServerClient(process.env.POSTMARK_API_KEY);
 
-const emailHtml = render(Email({ url: "https://example.com" }));
+const emailHtml = await render(Email({ url: "https://example.com" }));
 
 const options = {
   From: 'you@example.com',

--- a/apps/docs/integrations/scaleway.mdx
+++ b/apps/docs/integrations/scaleway.mdx
@@ -66,7 +66,7 @@ const client = createClient({
 const transactionalEmailClient = new TransactionalEmail.v1alpha1.API(client);
 
 
-const emailHtml = render(<Email url="https://example.com" />);
+const emailHtml = await render(<Email url="https://example.com" />);
 
 const sender = {
   email: "react-email@transactional.email.fr",

--- a/apps/docs/integrations/sendgrid.mdx
+++ b/apps/docs/integrations/sendgrid.mdx
@@ -57,7 +57,7 @@ import { Email } from './email';
 
 sendgrid.setApiKey(process.env.SENDGRID_API_KEY);
 
-const emailHtml = render(<Email url="https://example.com" />);
+const emailHtml = await render(<Email url="https://example.com" />);
 
 const options = {
   from: 'you@example.com',
@@ -76,7 +76,7 @@ import { Email } from './email';
 
 sendgrid.setApiKey(process.env.SENDGRID_API_KEY);
 
-const emailHtml = render(Email({ url: "https://example.com" }));
+const emailHtml = await render(Email({ url: "https://example.com" }));
 
 const options = {
   from: 'you@example.com',

--- a/packages/render/readme.md
+++ b/packages/render/readme.md
@@ -35,7 +35,7 @@ Convert React components into a HTML string.
 import { MyTemplate } from "../components/MyTemplate";
 import { render } from "@react-email/render";
 
-const html = render(<MyTemplate firstName="Jim" />);
+const html = await render(<MyTemplate firstName="Jim" />);
 ```
 
 ## License


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

Changed the docs integration examples to use the await since render now returns a `Promise<string>` and not a `string`. There are still some more changes that need to be made in the `examples/[INTEGRATION]` folder but for some reason my pnpm and the one on codespaces is unable to complete the pnpm install command