### PR TITLE
fix(tailwind): `float-left` utility being converted to `cssFloat: "left"`

### DIFF
--- a/.changeset/selfish-garlics-clap.md
+++ b/.changeset/selfish-garlics-clap.md
@@ -1,0 +1,5 @@
+---
+"@react-email/tailwind": patch
+---
+
+Fix `css-float` being used for utilities such as `float-left`

--- a/packages/tailwind/src/utils/compatibility/css-to-jsx-style.spec.ts
+++ b/packages/tailwind/src/utils/compatibility/css-to-jsx-style.spec.ts
@@ -76,10 +76,6 @@ test("transforms rules with browser prefixes", () => {
   });
 });
 
-test("transforms float rule property to cssFloat", () => {
-  expect(cssToJsxStyle("float: left")).toEqual({ cssFloat: "left" });
-});
-
 test("transforms rules with urls", () => {
   expect(
     cssToJsxStyle(

--- a/packages/tailwind/src/utils/compatibility/css-to-jsx-style.ts
+++ b/packages/tailwind/src/utils/compatibility/css-to-jsx-style.ts
@@ -8,10 +8,6 @@ const convertPropertyName = (prop: string) => {
 
   modifiedProp = modifiedProp.toLowerCase();
 
-  if (modifiedProp === "float") {
-    return "cssFloat";
-  }
-
   if (modifiedProp.startsWith("--")) {
     return modifiedProp;
   }


### PR DESCRIPTION
- **fix(tailwind): Remove use of css-float instead of float**
- **add changeset**
- **remove unecessary test**
