### PR TITLE
fix(code-block): Improper padding on the line numbers

### DIFF
--- a/.changeset/silly-knives-kiss.md
+++ b/.changeset/silly-knives-kiss.md
@@ -1,0 +1,5 @@
+---
+"@react-email/code-block": patch
+---
+
+fix improper padding on the line numbers

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -95,13 +95,9 @@ export const CodeBlock = React.forwardRef<HTMLPreElement, CodeBlockProps>(
         <code>
           {tokensPerLine.map((tokensForLine, lineIndex) => (
             <p key={lineIndex} style={{ margin: 0, minHeight: "1em" }}>
-              {Boolean(props.lineNumbers) && (
-                <span
-                  style={{ paddingRight: 30, fontFamily: props.fontFamily }}
-                >
-                  {lineIndex + 1}
-                </span>
-              )}
+              {props.lineNumbers ? (
+                <span style={{ maxWidth: '1.875em', fontFamily: props.fontFamily  }}>{lineIndex + 1}</span>
+              ) : null}
 
               {tokensForLine.map((token, i) => (
                 <CodeBlockLine

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -96,7 +96,7 @@ export const CodeBlock = React.forwardRef<HTMLPreElement, CodeBlockProps>(
           {tokensPerLine.map((tokensForLine, lineIndex) => (
             <p key={lineIndex} style={{ margin: 0, minHeight: "1em" }}>
               {props.lineNumbers ? (
-                <span style={{ maxWidth: '1.875em', fontFamily: props.fontFamily  }}>{lineIndex + 1}</span>
+                <span style={{ maxWidth: "1.875em", fontFamily: props.fontFamily   }}>{lineIndex + 1}</span>
               ) : null}
 
               {tokensForLine.map((token, i) => (

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -96,7 +96,11 @@ export const CodeBlock = React.forwardRef<HTMLPreElement, CodeBlockProps>(
           {tokensPerLine.map((tokensForLine, lineIndex) => (
             <p key={lineIndex} style={{ margin: 0, minHeight: "1em" }}>
               {props.lineNumbers ? (
-                <span style={{ maxWidth: "1.875em", fontFamily: props.fontFamily   }}>{lineIndex + 1}</span>
+                <span
+                  style={{ maxWidth: "1.875em", fontFamily: props.fontFamily }}
+                >
+                  {lineIndex + 1}
+                </span>
               ) : null}
 
               {tokensForLine.map((token, i) => (


### PR DESCRIPTION
The issue that was happening was that the size of the line numbers's span was
changing based on the size of its content. As we were setting the distance
between the line number and the code block's content, that caused the actual
content of the code block to get unaligned when going from lines with fewer to
more digits.

![image](https://github.com/user-attachments/assets/56b32a48-4b91-4f36-b368-006c55ba3d31)
