### PR TITLE
fix(react-email): Respect user NODE_ENV

### DIFF
--- a/.changeset/early-mugs-divide.md
+++ b/.changeset/early-mugs-divide.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Respect user's NODE_ENV when previewing templates

--- a/packages/react-email/src/cli/utils/preview/start-dev-server.ts
+++ b/packages/react-email/src/cli/utils/preview/start-dev-server.ts
@@ -119,8 +119,8 @@ export const startDevServer = async (
   // these environment variables are used on the next app
   // this is the most reliable way of communicating these paths through
   process.env = {
-    ...process.env,
     NODE_ENV: 'development',
+    ...process.env,
     ...getEnvVariablesForPreviewApp(
       // If we don't do normalization here, stuff like https://github.com/resend/react-email/issues/1354 happens.
       path.normalize(emailsDirRelativePath),

--- a/packages/react-email/src/cli/utils/preview/start-dev-server.ts
+++ b/packages/react-email/src/cli/utils/preview/start-dev-server.ts
@@ -120,7 +120,9 @@ export const startDevServer = async (
   // this is the most reliable way of communicating these paths through
   process.env = {
     NODE_ENV: 'development',
-    ...process.env,
+    ...(process.env as Omit<NodeJS.ProcessEnv, 'NODE_ENV'> & {
+      NODE_ENV?: NodeJS.ProcessEnv['NODE_ENV'];
+    }),
     ...getEnvVariablesForPreviewApp(
       // If we don't do normalization here, stuff like https://github.com/resend/react-email/issues/1354 happens.
       path.normalize(emailsDirRelativePath),


### PR DESCRIPTION
https://github.com/resend/react-email/commit/7eb68af95681600545ce992b03ff58f2ace9fb24#diff-c5c5ee3ee563e33630e1ad83f07d66cb99b9be9a662fa8f4f9d7a6d43e98b7d0

This commit caused `NODE_ENV` to no longer be respected and always become `development`

This change will respect `NODE_ENV` and default to `development` if nothing is passed in.