### PR TITLE
chore(all): Move React dependencies to just plain dependencies

### DIFF
--- a/.changeset/cuddly-meals-sniff.md
+++ b/.changeset/cuddly-meals-sniff.md
@@ -1,0 +1,26 @@
+---
+"@react-email/code-inline": patch
+"react-email": patch
+"@react-email/code-block": patch
+"@react-email/components": patch
+"@react-email/container": patch
+"@react-email/markdown": patch
+"@react-email/tailwind": patch
+"@react-email/heading": patch
+"@react-email/preview": patch
+"@react-email/section": patch
+"@react-email/button": patch
+"@react-email/column": patch
+"@react-email/render": patch
+"@react-email/body": patch
+"@react-email/font": patch
+"@react-email/head": patch
+"@react-email/html": patch
+"@react-email/link": patch
+"@react-email/text": patch
+"@react-email/img": patch
+"@react-email/row": patch
+"@react-email/hr": patch
+---
+
+Move react and react-dom to just dependencies for better DX

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -16,6 +16,19 @@ const components = packages
 
 function readPackage(pkg) {
   if (components.includes(pkg.name)) {
+    if (
+      "react" in pkg.dependencies &&
+      pkg.dependencies["react"] === "^18.0 || ^19.0 || ^19.0.0-rc"
+    ) {
+      pkg.dependencies.react = "19.0.0-rc-02c0e824-20241028";
+    }
+    if (
+      "react-dom" in pkg.dependencies &&
+      pkg.dependencies["react-dom"] === "^18.0 || ^19.0 || ^19.0.0-rc"
+    ) {
+      pkg.dependencies["react-dom"] = "19.0.0-rc-02c0e824-20241028";
+    }
+
     if ("react" in pkg.peerDependencies) {
       pkg.peerDependencies.react = "19.0.0-rc-02c0e824-20241028";
     }

--- a/packages/body/package.json
+++ b/packages/body/package.json
@@ -30,7 +30,7 @@
     "test:watch": "vitest",
     "test": "vitest run"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -42,7 +42,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/code-block/package.json
+++ b/packages/code-block/package.json
@@ -40,8 +40,9 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "peerDependencies": {
-    "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+  "dependencies": {
+    "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+    "prismjs": "1.29.0"
   },
   "devDependencies": {
     "@react-email/render": "workspace:*",
@@ -52,8 +53,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "dependencies": {
-    "prismjs": "1.29.0"
   }
 }

--- a/packages/code-inline/package.json
+++ b/packages/code-inline/package.json
@@ -34,7 +34,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/column/package.json
+++ b/packages/column/package.json
@@ -42,7 +42,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -60,9 +60,7 @@
     "@react-email/row": "workspace:0.0.11",
     "@react-email/section": "workspace:0.0.15",
     "@react-email/tailwind": "workspace:1.0.2",
-    "@react-email/text": "workspace:0.0.10"
-  },
-  "peerDependencies": {
+    "@react-email/text": "workspace:0.0.10",
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -42,7 +42,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -30,7 +30,7 @@
     "test:watch": "vitest",
     "test": "vitest run"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -42,7 +42,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/heading/package.json
+++ b/packages/heading/package.json
@@ -42,7 +42,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/hr/package.json
+++ b/packages/hr/package.json
@@ -42,7 +42,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -42,7 +42,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -42,7 +42,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -42,7 +42,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -46,7 +46,8 @@
     "access": "public"
   },
   "license": "MIT",
-  "peerDependencies": {
+  "dependencies": {
+    "md-to-react-email": "5.0.2",
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {
@@ -54,8 +55,5 @@
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",
     "typescript": "5.1.6"
-  },
-  "dependencies": {
-    "md-to-react-email": "5.0.2"
   }
 }

--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -42,7 +42,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -87,11 +87,9 @@
   "dependencies": {
     "html-to-text": "9.0.5",
     "js-beautify": "^1.14.11",
-    "react-promise-suspense": "0.3.4"
-  },
-  "peerDependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc",
-    "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+    "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-promise-suspense": "0.3.4"
   },
   "devDependencies": {
     "@types/react": "npm:types-react@19.0.0-rc.1",

--- a/packages/row/package.json
+++ b/packages/row/package.json
@@ -42,7 +42,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/section/package.json
+++ b/packages/section/package.json
@@ -42,7 +42,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -43,7 +43,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -42,7 +42,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   '@types/react': npm:types-react@19.0.0-rc.1
   '@types/react-dom': npm:types-react-dom@19.0.0-rc.1
 
-pnpmfileChecksum: peavqwq6bixcnybwoo6g2i6vta
+pnpmfileChecksum: 5ltuaxv2wlfok4dbiqlujxtslm
 
 importers:
 


### PR DESCRIPTION
This PR is meant to be merged just on canary and released for testing on real situations
as to ensure that we are not going to get peerDependencies errors. If this ends up causing 
issues that we can't really get around, and ends up becoming something we don't want
we'll just revert and the next releases are going to be without this.
