### PR TITLE
fix(react-email): Null byte characters being rendered in the preview

### DIFF
--- a/packages/react-email/src/actions/render-email-by-path.tsx
+++ b/packages/react-email/src/actions/render-email-by-path.tsx
@@ -18,8 +18,8 @@ export interface RenderedEmailMetadata {
 export type EmailRenderingResult =
   | RenderedEmailMetadata
   | {
-      error: ErrorObject;
-    };
+    error: ErrorObject;
+  };
 
 export const renderEmailByPath = async (
   emailPath: string,
@@ -83,7 +83,10 @@ export const renderEmailByPath = async (
     });
 
     return {
-      markup,
+      // This ensures that no null byte character ends up in the rendered
+      // markup making users suspect of any issues. These null byte characters
+      // only seem to happen with React 18, as it has no similar incident with React 19.
+      markup: markup.replaceAll('\0', ''),
       plainText,
       reactMarkup,
     };

--- a/packages/render/src/node/read-stream.ts
+++ b/packages/render/src/node/read-stream.ts
@@ -29,11 +29,9 @@ export const readStream = async (
     });
     stream.pipe(writable);
 
-    return new Promise<string>((resolve, reject) => {
+    await new Promise<void>((resolve, reject) => {
       writable.on("error", reject);
-      writable.on("close", () => {
-        resolve(result);
-      });
+      writable.on("close", () => { resolve(); });
     });
   }
 


### PR DESCRIPTION
This is meant to address
https://github.com/resend/react-email/issues/1667#issuecomment-2446675902. The
issue there is very similar to the proper issue as a whole, but the problem now
seems to be caused by react-dom itself, so it is unavaoidable. 

What is happening is that in the end of the second to last chunk of rendered
bytes react-dom is including a null-byte character that is very much not
included in the original React code. Much less in the underlying components.
This also seems to only be present in React 18.

Considering that the null byte character does not cause any issues when sending
to email clients, as they are just not rendered, the fix while we support React
18 is going to be simply replacing all null byte characters before rendering in
the preview server.
