### PR TITLE
fix(code-block): Typo "PrismLanguage"

### DIFF
--- a/.changeset/shaggy-beers-leave.md
+++ b/.changeset/shaggy-beers-leave.md
@@ -1,0 +1,5 @@
+---
+"@react-email/code-block": patch
+---
+
+Fix typo in the PrismLanguage type

--- a/packages/code-block/src/code-block.tsx
+++ b/packages/code-block/src/code-block.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import * as React from "react";
-import type { PrismLangauge } from "./languages-available";
+import type { PrismLanguage } from "./languages-available";
 import type { Theme } from "./themes";
 import { Prism } from "./prism";
 
@@ -16,7 +16,7 @@ export type CodeBlockProps = Readonly<{
   fontFamily?: string;
 
   theme: Theme;
-  language: PrismLangauge;
+  language: PrismLanguage;
   code: string;
 }>;
 

--- a/packages/code-block/src/languages-available.ts
+++ b/packages/code-block/src/languages-available.ts
@@ -1,4 +1,4 @@
-export type PrismLangauge =
+export type PrismLanguage =
   | "markup"
   | "html"
   | "xml"

--- a/packages/tailwind/readme.md
+++ b/packages/tailwind/readme.md
@@ -77,8 +77,8 @@ and the class names associated with them on a `<style>` tag on the `<head>` elem
 
 ### The treatment for Tailwind's CSS variables
 
-Emails don't really have great support for CSS variables, 
-so we needed to use a custom postcss plugin alongisde Tailwind to resolve 
+Emails don't really have great support for CSS variables,
+so we needed to use a custom postcss plugin alongisde Tailwind to resolve
 all of these variables. When the plugin finds a CSS Variable that it cannot resolve,
 it leaves it without any changes.
 


### PR DESCRIPTION
Hi there!

I noticed there is a little typo in the source code while using the code-block component. You wrote **PrismLangauge** instead of **PrimsLanguage**
