### PR TITLE
fix(react-email): Unwanted email re-renders when switching templates

### DIFF
--- a/.changeset/purple-feet-share.md
+++ b/.changeset/purple-feet-share.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Fix emails being re-rendered each time there is navigation in the preview server

--- a/packages/react-email/src/actions/get-email-path-from-slug.ts
+++ b/packages/react-email/src/actions/get-email-path-from-slug.ts
@@ -1,10 +1,11 @@
 'use server';
 import path from 'node:path';
 import fs from 'node:fs';
+import { cache } from 'react';
 import { emailsDirectoryAbsolutePath } from '../utils/emails-directory-absolute-path';
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export const getEmailPathFromSlug = async (slug: string) => {
+export const getEmailPathFromSlug = cache(async (slug: string) => {
   if (['.tsx', '.jsx', '.ts', '.js'].includes(path.extname(slug)))
     return path.join(emailsDirectoryAbsolutePath, slug);
 
@@ -25,4 +26,4 @@ export const getEmailPathFromSlug = async (slug: string) => {
 
     This is most likely not an issue with the preview server. It most likely is that the email doesn't exist.`,
   );
-};
+});

--- a/packages/react-email/src/actions/get-emails-directory-metadata.ts
+++ b/packages/react-email/src/actions/get-emails-directory-metadata.ts
@@ -58,64 +58,66 @@ const mergeDirectoriesWithSubDirectories = (
   return currentResultingMergedDirectory;
 };
 
-export const getEmailsDirectoryMetadata = cache(async (
-  absolutePathToEmailsDirectory: string,
-  keepFileExtensions = false,
-  isSubDirectory = false,
+export const getEmailsDirectoryMetadata = cache(
+  async (
+    absolutePathToEmailsDirectory: string,
+    keepFileExtensions = false,
+    isSubDirectory = false,
 
-  baseDirectoryPath = absolutePathToEmailsDirectory,
-): Promise<EmailsDirectory | undefined> => {
-  if (!fs.existsSync(absolutePathToEmailsDirectory)) return;
+    baseDirectoryPath = absolutePathToEmailsDirectory,
+  ): Promise<EmailsDirectory | undefined> => {
+    if (!fs.existsSync(absolutePathToEmailsDirectory)) return;
 
-  const dirents = await fs.promises.readdir(absolutePathToEmailsDirectory, {
-    withFileTypes: true,
-  });
+    const dirents = await fs.promises.readdir(absolutePathToEmailsDirectory, {
+      withFileTypes: true,
+    });
 
-  const emailFilenames = dirents
-    .filter((dirent) =>
-      isFileAnEmail(path.join(absolutePathToEmailsDirectory, dirent.name)),
-    )
-    .map((dirent) =>
-      keepFileExtensions
-        ? dirent.name
-        : dirent.name.replace(path.extname(dirent.name), ''),
+    const emailFilenames = dirents
+      .filter((dirent) =>
+        isFileAnEmail(path.join(absolutePathToEmailsDirectory, dirent.name)),
+      )
+      .map((dirent) =>
+        keepFileExtensions
+          ? dirent.name
+          : dirent.name.replace(path.extname(dirent.name), ''),
+      );
+
+    const subDirectories = await Promise.all(
+      dirents
+        .filter(
+          (dirent) =>
+            dirent.isDirectory() &&
+            !dirent.name.startsWith('_') &&
+            dirent.name !== 'static',
+        )
+        .map((dirent) => {
+          const direntAbsolutePath = path.join(
+            absolutePathToEmailsDirectory,
+            dirent.name,
+          );
+
+          return getEmailsDirectoryMetadata(
+            direntAbsolutePath,
+            keepFileExtensions,
+            true,
+            baseDirectoryPath,
+          ) as Promise<EmailsDirectory>;
+        }),
     );
 
-  const subDirectories = await Promise.all(
-    dirents
-      .filter(
-        (dirent) =>
-          dirent.isDirectory() &&
-          !dirent.name.startsWith('_') &&
-          dirent.name !== 'static',
-      )
-      .map((dirent) => {
-        const direntAbsolutePath = path.join(
-          absolutePathToEmailsDirectory,
-          dirent.name,
-        );
+    const emailsMetadata = {
+      absolutePath: absolutePathToEmailsDirectory,
+      relativePath: path.relative(
+        baseDirectoryPath,
+        absolutePathToEmailsDirectory,
+      ),
+      directoryName: absolutePathToEmailsDirectory.split(path.sep).pop()!,
+      emailFilenames,
+      subDirectories,
+    } satisfies EmailsDirectory;
 
-        return getEmailsDirectoryMetadata(
-          direntAbsolutePath,
-          keepFileExtensions,
-          true,
-          baseDirectoryPath,
-        ) as Promise<EmailsDirectory>;
-      }),
-  );
-
-  const emailsMetadata = {
-    absolutePath: absolutePathToEmailsDirectory,
-    relativePath: path.relative(
-      baseDirectoryPath,
-      absolutePathToEmailsDirectory,
-    ),
-    directoryName: absolutePathToEmailsDirectory.split(path.sep).pop()!,
-    emailFilenames,
-    subDirectories,
-  } satisfies EmailsDirectory;
-
-  return isSubDirectory
-    ? mergeDirectoriesWithSubDirectories(emailsMetadata)
-    : emailsMetadata;
-});
+    return isSubDirectory
+      ? mergeDirectoriesWithSubDirectories(emailsMetadata)
+      : emailsMetadata;
+  },
+);

--- a/packages/react-email/src/actions/get-emails-directory-metadata.ts
+++ b/packages/react-email/src/actions/get-emails-directory-metadata.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import fs from 'node:fs';
 import path from 'node:path';
+import { cache } from 'react';
 
 const isFileAnEmail = (fullPath: string): boolean => {
   const stat = fs.statSync(fullPath);
@@ -57,7 +58,7 @@ const mergeDirectoriesWithSubDirectories = (
   return currentResultingMergedDirectory;
 };
 
-export const getEmailsDirectoryMetadata = async (
+export const getEmailsDirectoryMetadata = cache(async (
   absolutePathToEmailsDirectory: string,
   keepFileExtensions = false,
   isSubDirectory = false,
@@ -117,4 +118,4 @@ export const getEmailsDirectoryMetadata = async (
   return isSubDirectory
     ? mergeDirectoriesWithSubDirectories(emailsMetadata)
     : emailsMetadata;
-};
+});

--- a/packages/react-email/src/actions/render-email-by-path.tsx
+++ b/packages/react-email/src/actions/render-email-by-path.tsx
@@ -18,8 +18,8 @@ export interface RenderedEmailMetadata {
 export type EmailRenderingResult =
   | RenderedEmailMetadata
   | {
-      error: ErrorObject;
-    };
+    error: ErrorObject;
+  };
 
 export const renderEmailByPath = async (
   emailPath: string,

--- a/packages/react-email/src/actions/render-email-by-path.tsx
+++ b/packages/react-email/src/actions/render-email-by-path.tsx
@@ -18,8 +18,8 @@ export interface RenderedEmailMetadata {
 export type EmailRenderingResult =
   | RenderedEmailMetadata
   | {
-    error: ErrorObject;
-  };
+      error: ErrorObject;
+    };
 
 export const renderEmailByPath = async (
   emailPath: string,

--- a/packages/react-email/src/app/preview/[...slug]/page.tsx
+++ b/packages/react-email/src/app/preview/[...slug]/page.tsx
@@ -49,15 +49,15 @@ This is most likely not an issue with the preview server. Maybe there was a typo
     throw exception;
   }
 
-  let serverEmailRenderingResult: EmailRenderingResult | undefined;
-  if (process.env.NEXT_PUBLIC_IS_BUILDING === 'true') {
-    serverEmailRenderingResult = await renderEmailByPath(emailPath);
+  const serverEmailRenderingResult = await renderEmailByPath(emailPath);
 
-    if ('error' in serverEmailRenderingResult) {
-      throw new Error(serverEmailRenderingResult.error.message, {
-        cause: serverEmailRenderingResult.error,
-      });
-    }
+  if (
+    process.env.NEXT_PUBLIC_IS_BUILDING === 'true' &&
+    'error' in serverEmailRenderingResult
+  ) {
+    throw new Error(serverEmailRenderingResult.error.message, {
+      cause: serverEmailRenderingResult.error,
+    });
   }
 
   return (

--- a/packages/react-email/src/app/preview/[...slug]/page.tsx
+++ b/packages/react-email/src/app/preview/[...slug]/page.tsx
@@ -3,7 +3,6 @@ import { Suspense } from 'react';
 import { redirect } from 'next/navigation';
 import { getEmailPathFromSlug } from '../../../actions/get-email-path-from-slug';
 import { getEmailsDirectoryMetadata } from '../../../actions/get-emails-directory-metadata';
-import type { EmailRenderingResult } from '../../../actions/render-email-by-path';
 import { renderEmailByPath } from '../../../actions/render-email-by-path';
 import { emailsDirectoryAbsolutePath } from '../../../utils/emails-directory-absolute-path';
 import Home from '../../page';

--- a/packages/react-email/src/app/preview/[...slug]/preview.tsx
+++ b/packages/react-email/src/app/preview/[...slug]/preview.tsx
@@ -4,7 +4,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import React from 'react';
 import { Toaster } from 'sonner';
 import { useHotreload } from '../../../hooks/use-hot-reload';
-import type { EmailRenderingResult } from '../../../actions/render-email-by-path';
+import type { EmailRenderingResult } from '../../../actions/rnder-email-by-path';
 import { CodeContainer } from '../../../components/code-container';
 import { Shell } from '../../../components/shell';
 import { Tooltip } from '../../../components/tooltip';
@@ -88,55 +88,63 @@ const Preview = ({
     >
       {/* This relative is so that when there is any error the user can still switch between emails */}
       <div className="relative h-full">
-        {renderingResult && 'error' in renderingResult ? (
-          <RenderingError error={renderingResult.error} />
-        ) : null}
-
-        {/* If this is undefined means that the initial server render of the email had errors */}
-        {renderingResult && hasNoErrors ? (
+        {renderingResult ? (
           <>
-            {activeView === 'desktop' && (
-              <iframe
-                className="w-full bg-white h-[calc(100vh_-_140px)] lg:h-[calc(100vh_-_70px)]"
-                srcDoc={renderedEmailMetadata.markup}
-                title={slug}
-              />
-            )}
+            {'error' in renderingResult ? (
+              <RenderingError error={renderingResult.error} />
+            ) : null}
 
-            {activeView === 'mobile' && (
-              <iframe
-                className="w-[360px] bg-white h-[calc(100vh_-_140px)] lg:h-[calc(100vh_-_70px)] mx-auto"
-                srcDoc={renderedEmailMetadata.markup}
-                title={slug}
-              />
-            )}
-
-            {activeView === 'source' && (
-              <div className="flex gap-6 mx-auto p-6 max-w-3xl">
-                <Tooltip.Provider>
-                  <CodeContainer
-                    activeLang={activeLang}
-                    markups={[
-                      {
-                        language: 'jsx',
-                        content: renderedEmailMetadata.reactMarkup,
-                      },
-                      {
-                        language: 'markup',
-                        content: renderedEmailMetadata.markup,
-                      },
-                      {
-                        language: 'markdown',
-                        content: renderedEmailMetadata.plainText,
-                      },
-                    ]}
-                    setActiveLang={handleLangChange}
+            {hasNoErrors ? (
+              <>
+                {activeView === 'desktop' && (
+                  <iframe
+                    className="w-full bg-white h-[calc(100vh_-_140px)] lg:h-[calc(100vh_-_70px)]"
+                    srcDoc={renderedEmailMetadata.markup}
+                    title={slug}
                   />
-                </Tooltip.Provider>
-              </div>
-            )}
+                )}
+
+                {activeView === 'mobile' && (
+                  <iframe
+                    className="w-[360px] bg-white h-[calc(100vh_-_140px)] lg:h-[calc(100vh_-_70px)] mx-auto"
+                    srcDoc={renderedEmailMetadata.markup}
+                    title={slug}
+                  />
+                )}
+
+                {activeView === 'source' && (
+                  <div className="flex gap-6 mx-auto p-6 max-w-3xl">
+                    <Tooltip.Provider>
+                      <CodeContainer
+                        activeLang={activeLang}
+                        markups={[
+                          {
+                            language: 'jsx',
+                            content: renderedEmailMetadata.reactMarkup,
+                          },
+                          {
+                            language: 'markup',
+                            content: renderedEmailMetadata.markup,
+                          },
+                          {
+                            language: 'markdown',
+                            content: renderedEmailMetadata.plainText,
+                          },
+                        ]}
+                        setActiveLang={handleLangChange}
+                      />
+                    </Tooltip.Provider>
+                  </div>
+                )}
+              </>
+            ) : null}
           </>
-        ) : null}
+        ) : (
+          <div className="w-full bg-white flex h-[calc(100vh_-_140px)] lg:h-[calc(100vh_-_70px)] py-12">
+            <div className="w-[600px] h-full bg-gray-100 relative border border-solid border-gray-200 mx-auto rounded-lg" />
+          </div>
+        )}
+
         <Toaster />
       </div>
     </Shell>

--- a/packages/react-email/src/app/preview/[...slug]/preview.tsx
+++ b/packages/react-email/src/app/preview/[...slug]/preview.tsx
@@ -4,7 +4,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import React from 'react';
 import { Toaster } from 'sonner';
 import { useHotreload } from '../../../hooks/use-hot-reload';
-import type { EmailRenderingResult } from '../../../actions/rnder-email-by-path';
+import type { EmailRenderingResult } from '../../../actions/render-email-by-path';
 import { CodeContainer } from '../../../components/code-container';
 import { Shell } from '../../../components/shell';
 import { Tooltip } from '../../../components/tooltip';

--- a/packages/react-email/src/app/preview/[...slug]/preview.tsx
+++ b/packages/react-email/src/app/preview/[...slug]/preview.tsx
@@ -34,7 +34,6 @@ const Preview = ({
 
   const renderingResult = useEmailRenderingResult(
     emailPath,
-    slug,
     serverRenderingResult,
   );
 

--- a/packages/react-email/src/app/preview/[...slug]/preview.tsx
+++ b/packages/react-email/src/app/preview/[...slug]/preview.tsx
@@ -16,14 +16,14 @@ interface PreviewProps {
   slug: string;
   emailPath: string;
   pathSeparator: string;
-  renderingResult: EmailRenderingResult;
+  serverRenderingResult: EmailRenderingResult | undefined;
 }
 
 const Preview = ({
   slug,
   emailPath,
   pathSeparator,
-  renderingResult: initialRenderingResult,
+  serverRenderingResult,
 }: PreviewProps) => {
   const router = useRouter();
   const pathname = usePathname();
@@ -35,13 +35,13 @@ const Preview = ({
 
   const renderingResult = useEmailRenderingResult(
     emailPath,
-    initialRenderingResult,
+    serverRenderingResult,
   );
 
   const renderedEmailMetadata = useRenderingMetadata(
     emailPath,
     renderingResult,
-    initialRenderingResult,
+    serverRenderingResult,
   );
 
   if (process.env.NEXT_PUBLIC_IS_BUILDING !== 'true') {
@@ -74,7 +74,9 @@ const Preview = ({
     router.push(`${pathname}?${params.toString()}`);
   };
 
-  const hasNoErrors = typeof renderedEmailMetadata !== 'undefined';
+  const hasNoErrors =
+    typeof renderingResult !== 'undefined' &&
+    typeof renderedEmailMetadata !== 'undefined';
 
   return (
     <Shell
@@ -86,12 +88,12 @@ const Preview = ({
     >
       {/* This relative is so that when there is any error the user can still switch between emails */}
       <div className="relative h-full">
-        {'error' in renderingResult ? (
+        {renderingResult && 'error' in renderingResult ? (
           <RenderingError error={renderingResult.error} />
         ) : null}
 
         {/* If this is undefined means that the initial server render of the email had errors */}
-        {hasNoErrors ? (
+        {renderingResult && hasNoErrors ? (
           <>
             {activeView === 'desktop' && (
               <iframe

--- a/packages/react-email/src/contexts/emails.tsx
+++ b/packages/react-email/src/contexts/emails.tsx
@@ -1,10 +1,5 @@
 'use client';
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useState,
-} from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import {
   getEmailsDirectoryMetadata,
   type EmailsDirectory,
@@ -18,15 +13,15 @@ import { getEmailPathFromSlug } from '../actions/get-email-path-from-slug';
 
 const EmailsContext = createContext<
   | {
-    emailsDirectoryMetadata: EmailsDirectory;
-    /**
-     * Uses the hot reloaded bundled build and rendering email result
-     */
-    useEmailRenderingResult: (
-      emailPath: string,
-      serverEmailRenderedResult: EmailRenderingResult | undefined,
-    ) => EmailRenderingResult | undefined;
-  }
+      emailsDirectoryMetadata: EmailsDirectory;
+      /**
+       * Uses the hot reloaded bundled build and rendering email result
+       */
+      useEmailRenderingResult: (
+        emailPath: string,
+        serverEmailRenderedResult: EmailRenderingResult | undefined,
+      ) => EmailRenderingResult | undefined;
+    }
   | undefined
 >(undefined);
 

--- a/packages/react-email/src/hooks/use-email-rendering-result.ts
+++ b/packages/react-email/src/hooks/use-email-rendering-result.ts
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import {
+  renderEmailByPath,
+  type EmailRenderingResult,
+} from '../actions/render-email-by-path';
+import { getEmailPathFromSlug } from '../actions/get-email-path-from-slug';
+import { useHotreload } from './use-hot-reload';
+
+export const useEmailRenderingResult = (
+  emailPath: string,
+  emailSlug: string,
+  serverEmailRenderedResult: EmailRenderingResult,
+) => {
+  const [renderingResult, setRenderingResult] = useState(
+    serverEmailRenderedResult,
+  );
+
+  if (process.env.NEXT_PUBLIC_IS_BUILDING !== 'true') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useHotreload(async (changes) => {
+      for await (const change of changes) {
+        const slugForChangedEmail =
+          // ex: apple-receipt.tsx
+          // it will be the path relative to the emails directory, so it is already
+          // going to be equivalent to the slug
+          change.filename;
+
+        if (slugForChangedEmail === emailSlug) {
+          setRenderingResult(
+            await renderEmailByPath(emailPath, true),
+          );
+        }
+      }
+    });
+  }
+
+  return renderingResult;
+};

--- a/packages/react-email/src/hooks/use-email-rendering-result.ts
+++ b/packages/react-email/src/hooks/use-email-rendering-result.ts
@@ -27,10 +27,11 @@ export const useEmailRenderingResult = (
         const pathForChangedEmail =
           await getEmailPathFromSlug(slugForChangedEmail);
 
+        // We always render the email template here so that we can allow 
+        const newRenderingResult = await renderEmailByPath(pathForChangedEmail, true);
+
         if (pathForChangedEmail === emailPath) {
-          setRenderingResult(
-            await renderEmailByPath(emailPath, true),
-          );
+          setRenderingResult(newRenderingResult);
         }
       }
     });

--- a/packages/react-email/src/hooks/use-email-rendering-result.ts
+++ b/packages/react-email/src/hooks/use-email-rendering-result.ts
@@ -27,8 +27,11 @@ export const useEmailRenderingResult = (
         const pathForChangedEmail =
           await getEmailPathFromSlug(slugForChangedEmail);
 
-        // We always render the email template here so that we can allow 
-        const newRenderingResult = await renderEmailByPath(pathForChangedEmail, true);
+        // We always render the email template here so that we can allow
+        const newRenderingResult = await renderEmailByPath(
+          pathForChangedEmail,
+          true,
+        );
 
         if (pathForChangedEmail === emailPath) {
           setRenderingResult(newRenderingResult);

--- a/packages/react-email/src/hooks/use-email-rendering-result.ts
+++ b/packages/react-email/src/hooks/use-email-rendering-result.ts
@@ -8,7 +8,6 @@ import { useHotreload } from './use-hot-reload';
 
 export const useEmailRenderingResult = (
   emailPath: string,
-  emailSlug: string,
   serverEmailRenderedResult: EmailRenderingResult,
 ) => {
   const [renderingResult, setRenderingResult] = useState(
@@ -25,7 +24,10 @@ export const useEmailRenderingResult = (
           // going to be equivalent to the slug
           change.filename;
 
-        if (slugForChangedEmail === emailSlug) {
+        const pathForChangedEmail =
+          await getEmailPathFromSlug(slugForChangedEmail);
+
+        if (pathForChangedEmail === emailPath) {
           setRenderingResult(
             await renderEmailByPath(emailPath, true),
           );

--- a/packages/react-email/src/hooks/use-rendering-metadata.ts
+++ b/packages/react-email/src/hooks/use-rendering-metadata.ts
@@ -15,10 +15,12 @@ const lastRenderingMetadataPerEmailPath = {} as Record<
  */
 export const useRenderingMetadata = (
   emailPath: string,
-  renderingResult: EmailRenderingResult,
-  initialRenderingMetadata?: EmailRenderingResult,
+  renderingResult: EmailRenderingResult | undefined,
+  initialRenderingMetadata: EmailRenderingResult | undefined,
 ): RenderedEmailMetadata | undefined => {
   useEffect(() => {
+    if (!renderingResult) return;
+
     if ('markup' in renderingResult) {
       lastRenderingMetadataPerEmailPath[emailPath] = renderingResult;
     } else if (
@@ -30,7 +32,11 @@ export const useRenderingMetadata = (
     }
   }, [renderingResult, emailPath, initialRenderingMetadata]);
 
-  return 'error' in renderingResult
-    ? lastRenderingMetadataPerEmailPath[emailPath]
-    : renderingResult;
+  if (renderingResult) {
+    return 'error' in renderingResult
+      ? lastRenderingMetadataPerEmailPath[emailPath]
+      : renderingResult;
+  }
+
+  return undefined;
 };

--- a/packages/react-email/src/hooks/use-rendering-metadata.ts
+++ b/packages/react-email/src/hooks/use-rendering-metadata.ts
@@ -15,28 +15,22 @@ const lastRenderingMetadataPerEmailPath = {} as Record<
  */
 export const useRenderingMetadata = (
   emailPath: string,
-  renderingResult: EmailRenderingResult | undefined,
-  initialRenderingMetadata: EmailRenderingResult | undefined,
+  renderingResult: EmailRenderingResult,
+  serverRenderingMetadata: EmailRenderingResult,
 ): RenderedEmailMetadata | undefined => {
   useEffect(() => {
-    if (!renderingResult) return;
-
     if ('markup' in renderingResult) {
       lastRenderingMetadataPerEmailPath[emailPath] = renderingResult;
     } else if (
-      typeof initialRenderingMetadata !== 'undefined' &&
-      'markup' in initialRenderingMetadata &&
+      typeof serverRenderingMetadata !== 'undefined' &&
+      'markup' in serverRenderingMetadata &&
       typeof lastRenderingMetadataPerEmailPath[emailPath] === 'undefined'
     ) {
-      lastRenderingMetadataPerEmailPath[emailPath] = initialRenderingMetadata;
+      lastRenderingMetadataPerEmailPath[emailPath] = serverRenderingMetadata;
     }
-  }, [renderingResult, emailPath, initialRenderingMetadata]);
+  }, [renderingResult, emailPath, serverRenderingMetadata]);
 
-  if (renderingResult) {
-    return 'error' in renderingResult
-      ? lastRenderingMetadataPerEmailPath[emailPath]
-      : renderingResult;
-  }
-
-  return undefined;
+  return 'error' in renderingResult
+    ? lastRenderingMetadataPerEmailPath[emailPath]
+    : renderingResult;
 };


### PR DESCRIPTION
The problem that was happening was something like this

https://github.com/user-attachments/assets/186fdf16-720c-424a-9653-2b9cc1945169

Every time the user navigated, even if it was to the same page already open, it would always re-render the email template, even if it was already rendered. When we first implemented the current architecture for the preview server, with Next.js 14, RSCs would always be cached in such a way that this navigation wouldn't re-render the RSC for the `/preview/[slug]` page, but as of Next.js 15 this does not seem to be the case.

The solution I chose for this was to store a cache for rendered emails in the server instead of in the client, this allows for the `renderEmailByPath` to return the cache when navigating across pages but also leads to less code and easier maintainability.