### PR TITLE
feat(render): Separate pretty from render

### DIFF
--- a/.changeset/strong-peas-kneel.md
+++ b/.changeset/strong-peas-kneel.md
@@ -1,0 +1,5 @@
+---
+"@react-email/render": minor
+---
+
+Deprecate the `pretty` option for `render` in favor of standalone `pretty` function

--- a/apps/docs/utilities/render.mdx
+++ b/apps/docs/utilities/render.mdx
@@ -50,7 +50,7 @@ export default MyTemplate;
 
 Import an existing React component and convert into a HTML string.
 
-<Info>You can use the `pretty` option to beautify the output.</Info>
+<Info>You can use the `pretty` function to beautify the output.</Info>
 
 ```jsx
 import { MyTemplate } from './email';
@@ -115,6 +115,9 @@ Click me [https://example.com]
 
 ## Options
 
+<ResponseField name="pretty" type="boolean" deprecated>
+  Beautify HTML output
+</ResponseField>
 <ResponseField name="plainText" type="boolean">
   Generate plain text version
 </ResponseField>

--- a/apps/docs/utilities/render.mdx
+++ b/apps/docs/utilities/render.mdx
@@ -54,7 +54,7 @@ Import an existing React component and convert into a HTML string.
 
 ```jsx
 import { MyTemplate } from './email';
-import { render } from '@react-email/render';
+import { render, pretty } from '@react-email/render';
 
 const html = await pretty(await render(<MyTemplate />));
 

--- a/apps/docs/utilities/render.mdx
+++ b/apps/docs/utilities/render.mdx
@@ -56,9 +56,7 @@ Import an existing React component and convert into a HTML string.
 import { MyTemplate } from './email';
 import { render } from '@react-email/render';
 
-const html = await render(<MyTemplate />, {
-  pretty: true,
-});
+const html = await pretty(await render(<MyTemplate />));
 
 console.log(html);
 ```
@@ -117,13 +115,9 @@ Click me [https://example.com]
 
 ## Options
 
-<ResponseField name="pretty" type="boolean">
-  Beautify HTML output
-</ResponseField>
 <ResponseField name="plainText" type="boolean">
   Generate plain text version
 </ResponseField>
 <ResponseField name="htmlToTextOptions" type="HtmlToTextOptions">
   `html-to-text` [options](https://github.com/html-to-text/node-html-to-text/tree/master/packages/html-to-text#options) used for rendering
 </ResponseField>
-

--- a/apps/web/components/ensure-matching-variants.spec.tsx
+++ b/apps/web/components/ensure-matching-variants.spec.tsx
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
-import { render, pretty } from '@react-email/components';
+import { pretty, render } from '@react-email/components';
 import { parse, stringify } from 'html-to-ast';
 import type { Attr, IDoc as Doc } from 'html-to-ast/dist/types';
 import postcss from 'postcss';
@@ -84,9 +84,11 @@ describe('copy-paste components', () => {
           await pretty(await render(<Layout>{tailwindElement}</Layout>)),
         );
         const inlineStylesHtml = getComparableHtml(
-          await pretty(await render(
-            <Layout withTailwind={false}>{inlineStylesElement}</Layout>
-          )),
+          await pretty(
+            await render(
+              <Layout withTailwind={false}>{inlineStylesElement}</Layout>,
+            ),
+          ),
         );
         expect(tailwindHtml).toBe(inlineStylesHtml);
       }

--- a/apps/web/components/ensure-matching-variants.spec.tsx
+++ b/apps/web/components/ensure-matching-variants.spec.tsx
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
-import { render } from '@react-email/components';
+import { render, pretty } from '@react-email/components';
 import { parse, stringify } from 'html-to-ast';
 import type { Attr, IDoc as Doc } from 'html-to-ast/dist/types';
 import postcss from 'postcss';
@@ -81,13 +81,12 @@ describe('copy-paste components', () => {
           inlineStylesVariantPath,
         );
         const tailwindHtml = getComparableHtml(
-          await render(<Layout>{tailwindElement}</Layout>, { pretty: true }),
+          await pretty(await render(<Layout>{tailwindElement}</Layout>)),
         );
         const inlineStylesHtml = getComparableHtml(
-          await render(
-            <Layout withTailwind={false}>{inlineStylesElement}</Layout>,
-            { pretty: true },
-          ),
+          await pretty(await render(
+            <Layout withTailwind={false}>{inlineStylesElement}</Layout>
+          )),
         );
         expect(tailwindHtml).toBe(inlineStylesHtml);
       }

--- a/apps/web/src/app/components/get-imported-components-for.tsx
+++ b/apps/web/src/app/components/get-imported-components-for.tsx
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { parse } from '@babel/parser';
 import traverse from '@babel/traverse';
-import { render, pretty } from '@react-email/components';
+import { pretty, render } from '@react-email/components';
 import { z } from 'zod';
 import { Layout } from '../../../components/_components/layout';
 import type { Category, Component } from '../../../components/structure';

--- a/apps/web/src/app/components/get-imported-components-for.tsx
+++ b/apps/web/src/app/components/get-imported-components-for.tsx
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { parse } from '@babel/parser';
 import traverse from '@babel/traverse';
-import { render } from '@react-email/components';
+import { render, pretty } from '@react-email/components';
 import { z } from 'zod';
 import { Layout } from '../../../components/_components/layout';
 import type { Category, Component } from '../../../components/structure';
@@ -84,9 +84,7 @@ export const getImportedComponent = async (
   if (variantFilenames.length === 1 && variantFilenames[0] === 'index.tsx') {
     const filePath = path.join(dirpath, 'index.tsx');
     const element = <Layout>{await getComponentElement(filePath)}</Layout>;
-    const html = await render(element, {
-      pretty: true,
-    });
+    const html = await pretty(await render(element));
     const fileContent = await fs.readFile(filePath, 'utf8');
     const code = getComponentCodeFrom(fileContent);
     return {
@@ -121,9 +119,7 @@ export const getImportedComponent = async (
 
   const element = <Layout>{elements[0]}</Layout>;
 
-  codePerVariant.html = await render(element, {
-    pretty: true,
-  });
+  codePerVariant.html = await pretty(await render(element));
 
   return {
     ...component,

--- a/packages/react-email/src/actions/render-email-by-path.tsx
+++ b/packages/react-email/src/actions/render-email-by-path.tsx
@@ -19,8 +19,8 @@ export interface RenderedEmailMetadata {
 export type EmailRenderingResult =
   | RenderedEmailMetadata
   | {
-      error: ErrorObject;
-    };
+    error: ErrorObject;
+  };
 
 const cache = new Map<string, EmailRenderingResult>();
 
@@ -58,15 +58,16 @@ export const renderEmailByPath = async (
     emailComponent: Email,
     createElement,
     render,
+    pretty,
     sourceMapToOriginalFile,
   } = componentResult;
 
   const previewProps = Email.PreviewProps || {};
   const EmailComponent = Email as React.FC;
   try {
-    const markup = await render(createElement(EmailComponent, previewProps), {
-      pretty: true,
-    });
+    const markup = await pretty(
+      await render(createElement(EmailComponent, previewProps))
+    );
     const plainText = await render(
       createElement(EmailComponent, previewProps),
       {

--- a/packages/react-email/src/actions/render-email-by-path.tsx
+++ b/packages/react-email/src/actions/render-email-by-path.tsx
@@ -19,8 +19,8 @@ export interface RenderedEmailMetadata {
 export type EmailRenderingResult =
   | RenderedEmailMetadata
   | {
-    error: ErrorObject;
-  };
+      error: ErrorObject;
+    };
 
 const cache = new Map<string, EmailRenderingResult>();
 
@@ -66,7 +66,7 @@ export const renderEmailByPath = async (
   const EmailComponent = Email as React.FC;
   try {
     const markup = await pretty(
-      await render(createElement(EmailComponent, previewProps))
+      await render(createElement(EmailComponent, previewProps)),
     );
     const plainText = await render(
       createElement(EmailComponent, previewProps),

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -1,6 +1,6 @@
 import fs, { unlinkSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { pretty, type Options } from '@react-email/components';
+import type { Options } from '@react-email/components';
 import { type BuildFailure, build } from 'esbuild';
 import { glob } from 'glob';
 import logSymbols from 'log-symbols';
@@ -125,7 +125,8 @@ export const exportTemplates = async (
         emailModule.reactEmailCreateReactElement(emailModule.default, {}),
         options,
       );
-      if (!options.plainText && options.pretty) rendered = await emailModule.pretty(rendered);
+      if (!options.plainText && options.pretty)
+        rendered = await emailModule.pretty(rendered);
       const htmlPath = template.replace(
         '.cjs',
         options.plainText ? '.txt' : '.html',

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -1,6 +1,6 @@
 import fs, { unlinkSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import type { Options } from '@react-email/components';
+import { pretty, type Options } from '@react-email/components';
 import { type BuildFailure, build } from 'esbuild';
 import { glob } from 'glob';
 import logSymbols from 'log-symbols';
@@ -29,6 +29,7 @@ const getEmailTemplatesFromDirectory = (emailDirectory: EmailsDirectory) => {
 
 type ExportTemplatesOptions = Options & {
   silent?: boolean;
+  pretty?: boolean;
 };
 
 /*
@@ -117,12 +118,14 @@ export const exportTemplates = async (
           element: React.ReactElement,
           options: Record<string, unknown>,
         ) => Promise<string>;
+        pretty: (str: string, options?: Options) => Promise<string>;
         reactEmailCreateReactElement: typeof React.createElement;
       };
-      const rendered = await emailModule.render(
+      let rendered = await emailModule.render(
         emailModule.reactEmailCreateReactElement(emailModule.default, {}),
         options,
       );
+      if (!options.plainText && options.pretty) rendered = await emailModule.pretty(rendered);
       const htmlPath = template.replace(
         '.cjs',
         options.plainText ? '.txt' : '.html',

--- a/packages/react-email/src/cli/commands/testing/export.spec.ts
+++ b/packages/react-email/src/cli/commands/testing/export.spec.ts
@@ -11,8 +11,8 @@ test(
     );
     const pathToDumpMarkup = path.resolve(__dirname, './out');
     await exportTemplates(pathToDumpMarkup, pathToEmailsDirectory, {
-      pretty: true,
       silent: true,
+      pretty: true,
     });
 
     expect(fs.existsSync(pathToDumpMarkup)).toBe(true);

--- a/packages/react-email/src/cli/index.ts
+++ b/packages/react-email/src/cli/index.ts
@@ -49,7 +49,7 @@ program
     false,
   )
   .action(({ outDir, pretty, plainText, silent, dir: srcDir }) =>
-    exportTemplates(outDir, srcDir, { pretty, silent, plainText }),
+    exportTemplates(outDir, srcDir, { silent, plainText, pretty }),
   );
 
 program.parse();

--- a/packages/react-email/src/utils/esbuild/renderring-utilities-exporter.ts
+++ b/packages/react-email/src/utils/esbuild/renderring-utilities-exporter.ts
@@ -28,7 +28,7 @@ export const renderingUtilitiesExporter = (emailTemplates: string[]) => ({
       async ({ path: pathToFile }) => {
         return {
           contents: `${await fs.readFile(pathToFile, 'utf8')};
-          export { render } from 'react-email-module-that-will-export-render'
+          export { render, pretty } from 'react-email-module-that-will-export-render'
           export { createElement as reactEmailCreateReactElement } from 'react';
         `,
           loader: path.extname(pathToFile).slice(1) as Loader,

--- a/packages/react-email/src/utils/get-email-component.ts
+++ b/packages/react-email/src/utils/get-email-component.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import type { render } from '@react-email/components';
+import type { render, pretty } from '@react-email/components';
 import { type BuildFailure, type OutputFile, build } from 'esbuild';
 import type React from 'react';
 import type { RawSourceMap } from 'source-map-js';
@@ -14,6 +14,7 @@ import type { ErrorObject } from './types/error-object';
 const EmailComponentModule = z.object({
   default: z.any(),
   render: z.function(),
+  pretty: z.function(),
   reactEmailCreateReactElement: z.function(),
 });
 
@@ -21,14 +22,16 @@ export const getEmailComponent = async (
   emailPath: string,
 ): Promise<
   | {
-      emailComponent: EmailComponent;
+    emailComponent: EmailComponent;
 
-      createElement: typeof React.createElement;
+    createElement: typeof React.createElement;
 
-      render: typeof render;
+    render: typeof render;
 
-      sourceMapToOriginalFile: RawSourceMap;
-    }
+    pretty: typeof pretty;
+
+    sourceMapToOriginalFile: RawSourceMap;
+  }
   | { error: ErrorObject }
 > => {
   let outputFiles: OutputFile[];
@@ -126,6 +129,7 @@ export const getEmailComponent = async (
   return {
     emailComponent: componentModule.default as EmailComponent,
     render: componentModule.render as typeof render,
+    pretty: componentModule.pretty,
     createElement:
       componentModule.reactEmailCreateReactElement as typeof React.createElement,
 

--- a/packages/react-email/src/utils/get-email-component.ts
+++ b/packages/react-email/src/utils/get-email-component.ts
@@ -129,7 +129,7 @@ export const getEmailComponent = async (
   return {
     emailComponent: componentModule.default as EmailComponent,
     render: componentModule.render as typeof render,
-    pretty: componentModule.pretty,
+    pretty: componentModule.pretty as typeof pretty,
     createElement:
       componentModule.reactEmailCreateReactElement as typeof React.createElement,
 

--- a/packages/react-email/src/utils/get-email-component.ts
+++ b/packages/react-email/src/utils/get-email-component.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import type { render, pretty } from '@react-email/components';
+import type { pretty, render } from '@react-email/components';
 import { type BuildFailure, type OutputFile, build } from 'esbuild';
 import type React from 'react';
 import type { RawSourceMap } from 'source-map-js';
@@ -22,16 +22,16 @@ export const getEmailComponent = async (
   emailPath: string,
 ): Promise<
   | {
-    emailComponent: EmailComponent;
+      emailComponent: EmailComponent;
 
-    createElement: typeof React.createElement;
+      createElement: typeof React.createElement;
 
-    render: typeof render;
+      render: typeof render;
 
-    pretty: typeof pretty;
+      pretty: typeof pretty;
 
-    sourceMapToOriginalFile: RawSourceMap;
-  }
+      sourceMapToOriginalFile: RawSourceMap;
+    }
   | { error: ErrorObject }
 > => {
   let outputFiles: OutputFile[];

--- a/packages/render/src/browser/index.ts
+++ b/packages/render/src/browser/index.ts
@@ -12,3 +12,4 @@ export * from './render';
 
 export * from '../shared/options';
 export * from '../shared/plain-text-selectors';
+export * from '../shared/utils/pretty';

--- a/packages/render/src/browser/render.tsx
+++ b/packages/render/src/browser/render.tsx
@@ -4,9 +4,9 @@ import type {
   PipeableStream,
   ReactDOMServerReadableStream,
 } from 'react-dom/server';
+import { pretty } from '../node';
 import type { Options } from '../shared/options';
 import { plainTextSelectors } from '../shared/plain-text-selectors';
-import { pretty } from '../node';
 
 const decoder = new TextDecoder('utf-8');
 

--- a/packages/render/src/browser/render.tsx
+++ b/packages/render/src/browser/render.tsx
@@ -6,7 +6,6 @@ import type {
 } from 'react-dom/server';
 import type { Options } from '../shared/options';
 import { plainTextSelectors } from '../shared/plain-text-selectors';
-import { pretty } from '../shared/utils/pretty';
 
 const decoder = new TextDecoder('utf-8');
 
@@ -85,10 +84,6 @@ export const render = async (
     '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">';
 
   const document = `${doctype}${html.replace(/<!DOCTYPE.*?>/, '')}`;
-
-  if (options?.pretty) {
-    return pretty(document);
-  }
 
   return document;
 };

--- a/packages/render/src/browser/render.tsx
+++ b/packages/render/src/browser/render.tsx
@@ -84,10 +84,10 @@ export const render = async (
   const doctype =
     '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">';
 
-  let document = `${doctype}${html.replace(/<!DOCTYPE.*?>/, '')}`;
+  const document = `${doctype}${html.replace(/<!DOCTYPE.*?>/, '')}`;
 
   if (options?.pretty) {
-    document = await pretty(document);
+    return pretty(document);
   }
 
   return document;

--- a/packages/render/src/browser/render.tsx
+++ b/packages/render/src/browser/render.tsx
@@ -6,6 +6,7 @@ import type {
 } from 'react-dom/server';
 import type { Options } from '../shared/options';
 import { plainTextSelectors } from '../shared/plain-text-selectors';
+import { pretty } from '../node';
 
 const decoder = new TextDecoder('utf-8');
 
@@ -83,7 +84,11 @@ export const render = async (
   const doctype =
     '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">';
 
-  const document = `${doctype}${html.replace(/<!DOCTYPE.*?>/, '')}`;
+  let document = `${doctype}${html.replace(/<!DOCTYPE.*?>/, '')}`;
+
+  if (options?.pretty) {
+    document = await pretty(document);
+  }
 
   return document;
 };

--- a/packages/render/src/node/index.ts
+++ b/packages/render/src/node/index.ts
@@ -12,3 +12,4 @@ export * from './render';
 
 export * from '../shared/options';
 export * from '../shared/plain-text-selectors';
+export * from '../shared/utils/pretty';

--- a/packages/render/src/node/render.tsx
+++ b/packages/render/src/node/render.tsx
@@ -2,8 +2,8 @@ import { convert } from 'html-to-text';
 import { Suspense } from 'react';
 import type { Options } from '../shared/options';
 import { plainTextSelectors } from '../shared/plain-text-selectors';
-import { readStream } from './read-stream';
 import { pretty } from '../shared/utils/pretty';
+import { readStream } from './read-stream';
 
 export const render = async (
   element: React.ReactElement,

--- a/packages/render/src/node/render.tsx
+++ b/packages/render/src/node/render.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react';
 import type { Options } from '../shared/options';
 import { plainTextSelectors } from '../shared/plain-text-selectors';
 import { readStream } from './read-stream';
+import { pretty } from '../shared/utils/pretty';
 
 export const render = async (
   element: React.ReactElement,
@@ -40,7 +41,11 @@ export const render = async (
   const doctype =
     '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">';
 
-  const document = `${doctype}${html.replace(/<!DOCTYPE.*?>/, '')}`;
+  let document = `${doctype}${html.replace(/<!DOCTYPE.*?>/, '')}`;
+
+  if (options?.pretty) {
+    document = await pretty(document);
+  }
 
   return document;
 };

--- a/packages/render/src/node/render.tsx
+++ b/packages/render/src/node/render.tsx
@@ -2,7 +2,6 @@ import { convert } from 'html-to-text';
 import { Suspense } from 'react';
 import type { Options } from '../shared/options';
 import { plainTextSelectors } from '../shared/plain-text-selectors';
-import { pretty } from '../shared/utils/pretty';
 import { readStream } from './read-stream';
 
 export const render = async (
@@ -42,10 +41,6 @@ export const render = async (
     '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">';
 
   const document = `${doctype}${html.replace(/<!DOCTYPE.*?>/, '')}`;
-
-  if (options?.pretty) {
-    return pretty(document);
-  }
 
   return document;
 };

--- a/packages/render/src/node/render.tsx
+++ b/packages/render/src/node/render.tsx
@@ -41,10 +41,10 @@ export const render = async (
   const doctype =
     '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">';
 
-  let document = `${doctype}${html.replace(/<!DOCTYPE.*?>/, '')}`;
+  const document = `${doctype}${html.replace(/<!DOCTYPE.*?>/, '')}`;
 
   if (options?.pretty) {
-    document = await pretty(document);
+    return pretty(document);
   }
 
   return document;

--- a/packages/render/src/shared/options.ts
+++ b/packages/render/src/shared/options.ts
@@ -1,11 +1,21 @@
 import type { HtmlToTextOptions } from 'html-to-text';
+// biome-ignore lint/correctness/noUnusedImports: this is used in the deprecated doc
+import type { pretty } from './utils/pretty';
 
-export type Options = (
+export type Options =
   | {
     plainText?: false;
+    /**
+     * @deprecated use {@link pretty} instead
+     */
+    pretty?: boolean;
   }
   | {
     plainText?: true;
+    /**
+     * @deprecated use {@link pretty} instead
+     */
+    pretty?: boolean;
     /**
      * These are options you can pass down directly to the library we use for
      * converting the rendered email's HTML into plain text.
@@ -13,5 +23,4 @@ export type Options = (
      * @see https://github.com/html-to-text/node-html-to-text
      */
     htmlToTextOptions?: HtmlToTextOptions;
-  }
-);
+  };

--- a/packages/render/src/shared/options.ts
+++ b/packages/render/src/shared/options.ts
@@ -1,19 +1,17 @@
 import type { HtmlToTextOptions } from 'html-to-text';
 
-export type Options = {
-  pretty?: boolean;
-} & (
+export type Options = (
   | {
-      plainText?: false;
-    }
+    plainText?: false;
+  }
   | {
-      plainText?: true;
-      /**
-       * These are options you can pass down directly to the library we use for
-       * converting the rendered email's HTML into plain text.
-       *
-       * @see https://github.com/html-to-text/node-html-to-text
-       */
-      htmlToTextOptions?: HtmlToTextOptions;
-    }
+    plainText?: true;
+    /**
+     * These are options you can pass down directly to the library we use for
+     * converting the rendered email's HTML into plain text.
+     *
+     * @see https://github.com/html-to-text/node-html-to-text
+     */
+    htmlToTextOptions?: HtmlToTextOptions;
+  }
 );

--- a/packages/render/src/shared/options.ts
+++ b/packages/render/src/shared/options.ts
@@ -2,20 +2,17 @@ import type { HtmlToTextOptions } from 'html-to-text';
 // biome-ignore lint/correctness/noUnusedImports: this is used in the deprecated doc
 import type { pretty } from './utils/pretty';
 
-export type Options =
-  | {
+export type Options = {
+  /**
+   * @deprecated use {@link pretty} instead
+   */
+  pretty?: boolean;
+} & (
+    | {
       plainText?: false;
-      /**
-       * @deprecated use {@link pretty} instead
-       */
-      pretty?: boolean;
     }
-  | {
+    | {
       plainText?: true;
-      /**
-       * @deprecated use {@link pretty} instead
-       */
-      pretty?: boolean;
       /**
        * These are options you can pass down directly to the library we use for
        * converting the rendered email's HTML into plain text.
@@ -23,4 +20,5 @@ export type Options =
        * @see https://github.com/html-to-text/node-html-to-text
        */
       htmlToTextOptions?: HtmlToTextOptions;
-    };
+    }
+  );

--- a/packages/render/src/shared/options.ts
+++ b/packages/render/src/shared/options.ts
@@ -4,23 +4,23 @@ import type { pretty } from './utils/pretty';
 
 export type Options =
   | {
-    plainText?: false;
-    /**
-     * @deprecated use {@link pretty} instead
-     */
-    pretty?: boolean;
-  }
+      plainText?: false;
+      /**
+       * @deprecated use {@link pretty} instead
+       */
+      pretty?: boolean;
+    }
   | {
-    plainText?: true;
-    /**
-     * @deprecated use {@link pretty} instead
-     */
-    pretty?: boolean;
-    /**
-     * These are options you can pass down directly to the library we use for
-     * converting the rendered email's HTML into plain text.
-     *
-     * @see https://github.com/html-to-text/node-html-to-text
-     */
-    htmlToTextOptions?: HtmlToTextOptions;
-  };
+      plainText?: true;
+      /**
+       * @deprecated use {@link pretty} instead
+       */
+      pretty?: boolean;
+      /**
+       * These are options you can pass down directly to the library we use for
+       * converting the rendered email's HTML into plain text.
+       *
+       * @see https://github.com/html-to-text/node-html-to-text
+       */
+      htmlToTextOptions?: HtmlToTextOptions;
+    };

--- a/packages/render/src/shared/options.ts
+++ b/packages/render/src/shared/options.ts
@@ -8,10 +8,10 @@ export type Options = {
    */
   pretty?: boolean;
 } & (
-    | {
+  | {
       plainText?: false;
     }
-    | {
+  | {
       plainText?: true;
       /**
        * These are options you can pass down directly to the library we use for
@@ -21,4 +21,4 @@ export type Options = {
        */
       htmlToTextOptions?: HtmlToTextOptions;
     }
-  );
+);


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

Compliment to the feature request https://github.com/resend/react-email/discussions/1905

This takes the call to `pretty` out of the render functions and exports it separately. The new usage is `const html = await pretty(await render(<MyTemplate/>));`

# Test plan
One test is failing, and I'm a bit stumped. By throwing the exception on line 142 of export.ts, I was able to get this error message. I've done what I can to pipe it through the custom import faker, not sure what's wrong.

```
 FAIL  src/cli/commands/testing/export.spec.ts > email export
TypeError: emailModule.pretty is not a function
 ❯ Module.exportTemplates src/cli/commands/export.ts:128:76
    126|         options,
    127|       );
    128|       if (!options.plainText && shouldPretty) rendered = await emailModule.pretty(rendered);
       |                                                                            ^
    129|       const htmlPath = template.replace(
    130|         '.cjs',
 ❯ src/cli/commands/testing/export.spec.ts:11:3

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯

  Snapshots  1 obsolete
             ↳ src/cli/commands/testing/export.spec.ts
               · email export 1

 Test Files  1 failed | 5 passed (6)
      Tests  1 failed | 11 passed (12)
```