### PR TITLE
feat(docs): Add IndiePitcher integration and example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Emails built with React Email can be converted into HTML and sent using any emai
 - [AWS SES](https://github.com/resend/react-email/tree/main/examples/aws-ses)
 - [Plunk](https://github.com/resend/react-email/tree/main/examples/plunk)
 - [Scaleway](https://github.com/resend/react-email/tree/main/examples/scaleway)
+- [IndiePitcher](https://github.com/resend/react-email/tree/main/examples/indiepitcher)
 
 ## Support
 

--- a/apps/docs/integrations/indiepitcher.mdx
+++ b/apps/docs/integrations/indiepitcher.mdx
@@ -1,0 +1,79 @@
+---
+title: "Send email using IndiePitcher"
+sidebarTitle: "IndiePitcher"
+description: "Learn how to send an email using React Email and the IndiePitcher Node.js SDK."
+"og:image": "https://react.email/static/covers/react-email.png"
+---
+
+## 1. Install dependencies
+
+Get the [@react-email/components](https://www.npmjs.com/package/@react-email/components) package and the [IndiePitcher Node.js SDK](https://www.npmjs.com/package/indiepitcher).
+
+<CodeGroup>
+
+```sh npm
+npm install indiepitcher @react-email/components
+```
+
+```sh yarn
+yarn add indiepitcher @react-email/components
+```
+
+```sh pnpm
+pnpm add indiepitcher @react-email/components
+```
+
+</CodeGroup>
+
+## 2. Create an email using React
+
+Start by building your email template in a `.jsx` or `.tsx` file.
+
+```tsx email.tsx
+import * as React from "react";
+import { Html, Button } from "@react-email/components";
+
+export function Email(props) {
+  const { url } = props;
+
+  return (
+    <Html lang="en">
+      <Button href={url}>Click me</Button>
+    </Html>
+  );
+}
+
+export default Email;
+```
+
+## 3. Convert to HTML and send email
+
+Import the email template you just built, convert into an HTML string, and use the IndiePitcher SDK to send it.
+
+```tsx
+import { IndiePitcher } from 'indiepitcher';
+import { render } from "@react-email/components";
+import { Email } from "./email";
+
+const indiePitcher = new IndiePitcher(process.env.INDIEPITCHER_API_KEY || '');
+
+const emailHtml = await render(<Email url="https://example.com" />);
+
+await indiePitcher.sendEmail({
+  to: 'petr@indiepitcher.com',
+  subject: 'Hello world',
+  body: emailHtml,
+  bodyFormat: 'html',
+});
+```
+
+## Try it yourself
+
+<Card
+  title="IndiePitcher example"
+  icon="arrow-up-right-from-square"
+  iconType="duotone"
+  href="https://github.com/resend/react-email/tree/main/examples/indiepitcher"
+>
+  See the full source code.
+</Card>

--- a/apps/docs/integrations/indiepitcher.mdx
+++ b/apps/docs/integrations/indiepitcher.mdx
@@ -60,7 +60,7 @@ const indiePitcher = new IndiePitcher(process.env.INDIEPITCHER_API_KEY || '');
 const emailHtml = await render(<Email url="https://example.com" />);
 
 await indiePitcher.sendEmail({
-  to: 'petr@indiepitcher.com',
+  to: 'hello@indiepitcher.com',
   subject: 'Hello world',
   body: emailHtml,
   bodyFormat: 'html',

--- a/apps/docs/mint.json
+++ b/apps/docs/mint.json
@@ -113,7 +113,8 @@
         "integrations/postmark",
         "integrations/aws-ses",
         "integrations/mailersend",
-        "integrations/plunk"
+        "integrations/plunk",
+        "integrations/indiepitcher"
       ]
     }
   ],

--- a/examples/indiepitcher/CHANGELOG.md
+++ b/examples/indiepitcher/CHANGELOG.md
@@ -1,0 +1,137 @@
+# react-email-with-indiepitcher
+
+## 1.0.8
+
+### Patch Changes
+
+- @react-email/components@0.0.33
+
+## 1.0.8-canary.1
+
+### Patch Changes
+
+- @react-email/components@0.0.33-canary.1
+
+## 1.0.8-canary.0
+
+### Patch Changes
+
+- @react-email/components@0.0.33-canary.0
+
+## 1.0.7
+
+### Patch Changes
+
+- @react-email/components@0.0.32
+
+## 1.0.6
+
+### Patch Changes
+
+- @react-email/components@0.0.31
+
+## 1.0.5
+
+### Patch Changes
+
+- @react-email/components@0.0.30
+
+## 1.0.4
+
+### Patch Changes
+
+- Updated dependencies [467af4e]
+- Updated dependencies [b34aa90]
+  - @react-email/components@0.0.29
+
+## 1.0.4-canary.5
+
+### Patch Changes
+
+- Updated dependencies [467af4e]
+  - @react-email/components@0.0.29-canary.5
+
+## 1.0.4-canary.4
+
+### Patch Changes
+
+- @react-email/components@0.0.29-canary.4
+
+## 1.0.4-canary.3
+
+### Patch Changes
+
+- @react-email/components@0.0.29-canary.3
+
+## 1.0.4-canary.2
+
+### Patch Changes
+
+- @react-email/components@0.0.29-canary.2
+
+## 1.0.4-canary.1
+
+### Patch Changes
+
+- @react-email/components@0.0.29-canary.1
+
+## 1.0.4-canary.0
+
+### Patch Changes
+
+- Updated dependencies [f7833da]
+  - @react-email/components@0.0.29-canary.0
+
+## 1.0.3
+
+### Patch Changes
+
+- @react-email/components@0.0.28
+
+## 1.0.2
+
+### Patch Changes
+
+- @react-email/components@0.0.27
+
+## 1.0.1
+
+### Patch Changes
+
+- @react-email/components@0.0.26
+
+## 1.0.1-canary.5
+
+### Patch Changes
+
+- @react-email/components@0.0.26-canary.5
+
+## 1.0.1-canary.4
+
+### Patch Changes
+
+- @react-email/components@0.0.26-canary.4
+
+## 1.0.1-canary.3
+
+### Patch Changes
+
+- @react-email/components@0.0.26-canary.3
+
+## 1.0.1-canary.2
+
+### Patch Changes
+
+- @react-email/components@0.0.26-canary.2
+
+## 1.0.1-canary.1
+
+### Patch Changes
+
+- @react-email/components@0.0.26-canary.1
+
+## 1.0.1-canary.0
+
+### Patch Changes
+
+- @react-email/components@0.0.26-canary.0

--- a/examples/indiepitcher/package.json
+++ b/examples/indiepitcher/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "react-email-with-indiepitcher",
+  "version": "1.0.8",
+  "license": "MIT",
+  "private": true,
+  "sideEffects": false,
+  "type": "module",
+  "main": "./dist/index.js",
+  "files": ["dist/**"],
+  "scripts": {
+    "build": "tsup-node src/index.tsx --format esm --target node20",
+    "dev": "tsup-node src/index.tsx --format esm --target node20 --watch",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "indiepitcher": "1.4.0",
+    "@react-email/components": "workspace:0.0.33",
+    "react": "^19",
+    "react-dom": "^19"
+  },
+  "devDependencies": {
+    "tsup": "6.2.3",
+    "typescript": "4.8.3"
+  }
+}

--- a/examples/indiepitcher/src/email.tsx
+++ b/examples/indiepitcher/src/email.tsx
@@ -1,0 +1,13 @@
+import { Button, Html } from '@react-email/components';
+
+interface EmailProps {
+  url: string;
+}
+
+export const Email: React.FC<Readonly<EmailProps>> = ({ url }) => {
+  return (
+    <Html lang="en">
+      <Button href={url}>Click me</Button>
+    </Html>
+  );
+};

--- a/examples/indiepitcher/src/index.tsx
+++ b/examples/indiepitcher/src/index.tsx
@@ -1,0 +1,14 @@
+import { IndiePitcher } from 'indiepitcher';
+import { render } from '@react-email/components';
+import { Email } from './email';
+
+const indiePitcher = new IndiePitcher(process.env.INDIEPITCHER_API_KEY || '');
+
+const emailHtml = await render(<Email url="https://example.com" />);
+
+await indiePitcher.sendEmail({
+  to: 'petr@indiepitcher.com',
+  subject: 'Hello world',
+  body: emailHtml,
+  bodyFormat: 'html',
+});

--- a/examples/indiepitcher/src/index.tsx
+++ b/examples/indiepitcher/src/index.tsx
@@ -7,7 +7,7 @@ const indiePitcher = new IndiePitcher(process.env.INDIEPITCHER_API_KEY || '');
 const emailHtml = await render(<Email url="https://example.com" />);
 
 await indiePitcher.sendEmail({
-  to: 'petr@indiepitcher.com',
+  to: 'hello@indiepitcher.com',
   subject: 'Hello world',
   body: emailHtml,
   bodyFormat: 'html',

--- a/examples/indiepitcher/tsconfig.json
+++ b/examples/indiepitcher/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": false,
+    "isolatedModules": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "jsx": "react-jsx",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "target": "ESNext",
+    "types": ["vitest/globals"]
+  },
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,28 @@ importers:
         specifier: 4.8.3
         version: 4.8.3
 
+  examples/indiepitcher:
+    dependencies:
+      '@react-email/components':
+        specifier: workspace:0.0.33
+        version: link:../../packages/components
+      indiepitcher:
+        specifier: 1.4.0
+        version: 1.4.0
+      react:
+        specifier: 19.0.0
+        version: 19.0.0
+      react-dom:
+        specifier: 19.0.0
+        version: 19.0.0(react@19.0.0)
+    devDependencies:
+      tsup:
+        specifier: 6.2.3
+        version: 6.2.3(@swc/core@1.4.15(@swc/helpers@0.5.15))(postcss@8.5.1)(typescript@4.8.3)
+      typescript:
+        specifier: 4.8.3
+        version: 4.8.3
+
   examples/mailersend:
     dependencies:
       '@react-email/components':
@@ -5792,6 +5814,10 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  indiepitcher@1.4.0:
+    resolution: {integrity: sha512-TSL8ft31EE/51DqNrVFkbG1W83yZt8KbuYAL3OIElbuinftzd5aNprz+kSmkUWTDUswoqqNPXs9tFXtyh0/zKA==}
+    engines: {node: '>=18'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -13099,6 +13125,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  indiepitcher@1.4.0: {}
 
   inflight@1.0.6:
     dependencies:


### PR DESCRIPTION
This PR adds example of how to use react email with [IndiePitcher](https://indiepitcher.com).
