### PR TITLE
fix(cli): Correct typo in cliPacakgeLocation to cliPackageLocation

### DIFF
--- a/packages/react-email/src/cli/commands/build.ts
+++ b/packages/react-email/src/cli/commands/build.ts
@@ -8,7 +8,7 @@ import {
   getEmailsDirectoryMetadata,
 } from '../../utils/get-emails-directory-metadata';
 import { registerSpinnerAutostopping } from '../../utils/register-spinner-autostopping';
-import { cliPacakgeLocation } from '../utils';
+import { cliPackageLocation } from '../utils';
 
 interface Args {
   dir: string;
@@ -242,7 +242,7 @@ export const build = async ({
     }
 
     spinner.text = 'Copying preview app from CLI to `.react-email`';
-    await fs.promises.cp(cliPacakgeLocation, builtPreviewAppPath, {
+    await fs.promises.cp(cliPackageLocation, builtPreviewAppPath, {
       recursive: true,
       filter: (source: string) => {
         // do not copy the CLI files

--- a/packages/react-email/src/cli/utils/preview/start-dev-server.ts
+++ b/packages/react-email/src/cli/utils/preview/start-dev-server.ts
@@ -27,7 +27,7 @@ const safeAsyncServerListen = (server: http.Server, port: number) => {
 };
 
 export const isDev = !__filename.endsWith(path.join('cli', 'index.js'));
-export const cliPacakgeLocation = isDev
+export const cliPackageLocation = isDev
   ? path.resolve(__dirname, '../../../..')
   : path.resolve(__dirname, '../..');
 export const previewServerLocation = isDev


### PR DESCRIPTION
Hi, I was analyzing the CLI code and found a typo, so I fixed it.

- `cliPacakgeLocation` => `cliPackageLocation`