### PR TITLE
fix(react-email):  Detection of files with various export patterns

### DIFF
--- a/.changeset/shy-fans-allow.md
+++ b/.changeset/shy-fans-allow.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Fix detection of files with various export patterns

--- a/packages/react-email/src/utils/get-emails-directory-metadata.ts
+++ b/packages/react-email/src/utils/get-emails-directory-metadata.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import fs from "node:fs";
-import path from "node:path";
+import fs from 'node:fs';
+import path from 'node:path';
 
 const isFileAnEmail = (fullPath: string): boolean => {
   const stat = fs.statSync(fullPath);
@@ -9,7 +9,7 @@ const isFileAnEmail = (fullPath: string): boolean => {
 
   const { ext } = path.parse(fullPath);
 
-  if (![".js", ".tsx", ".jsx"].includes(ext)) return false;
+  if (!['.js', '.tsx', '.jsx'].includes(ext)) return false;
 
   // This is to avoid a possible race condition where the file doesn't exist anymore
   // once we are checking if it is an actual email, this couuld cause issues that
@@ -20,7 +20,7 @@ const isFileAnEmail = (fullPath: string): boolean => {
 
   // check with a heuristic to see if the file has at least
   // a default export (ES6) or module.exports (CommonJS) or named exports (MDX)
-  const fileContents = fs.readFileSync(fullPath, "utf8");
+  const fileContents = fs.readFileSync(fullPath, 'utf8');
 
   // Check for ES6 export default syntax
   const hasES6DefaultExport = /\bexport\s+default\b/gm.test(fileContents);
@@ -30,7 +30,7 @@ const isFileAnEmail = (fullPath: string): boolean => {
 
   // Check for named exports (used in MDX files) and ensure at least one is marked as default
   const hasNamedExport = /\bexport\s+\{[^}]*\bdefault\b[^}]*\}/gm.test(
-    fileContents
+    fileContents,
   );
 
   return hasES6DefaultExport || hasCommonJSExport || hasNamedExport;
@@ -45,7 +45,7 @@ export interface EmailsDirectory {
 }
 
 const mergeDirectoriesWithSubDirectories = (
-  emailsDirectoryMetadata: EmailsDirectory
+  emailsDirectoryMetadata: EmailsDirectory,
 ): EmailsDirectory => {
   let currentResultingMergedDirectory: EmailsDirectory =
     emailsDirectoryMetadata;
@@ -59,7 +59,7 @@ const mergeDirectoriesWithSubDirectories = (
       ...onlySubDirectory,
       directoryName: path.join(
         currentResultingMergedDirectory.directoryName,
-        onlySubDirectory.directoryName
+        onlySubDirectory.directoryName,
       ),
     };
   }
@@ -72,7 +72,7 @@ export const getEmailsDirectoryMetadata = async (
   keepFileExtensions = false,
   isSubDirectory = false,
 
-  baseDirectoryPath = absolutePathToEmailsDirectory
+  baseDirectoryPath = absolutePathToEmailsDirectory,
 ): Promise<EmailsDirectory | undefined> => {
   if (!fs.existsSync(absolutePathToEmailsDirectory)) return;
 
@@ -82,12 +82,12 @@ export const getEmailsDirectoryMetadata = async (
 
   const emailFilenames = dirents
     .filter((dirent) =>
-      isFileAnEmail(path.join(absolutePathToEmailsDirectory, dirent.name))
+      isFileAnEmail(path.join(absolutePathToEmailsDirectory, dirent.name)),
     )
     .map((dirent) =>
       keepFileExtensions
         ? dirent.name
-        : dirent.name.replace(path.extname(dirent.name), "")
+        : dirent.name.replace(path.extname(dirent.name), ''),
     );
 
   const subDirectories = await Promise.all(
@@ -95,29 +95,29 @@ export const getEmailsDirectoryMetadata = async (
       .filter(
         (dirent) =>
           dirent.isDirectory() &&
-          !dirent.name.startsWith("_") &&
-          dirent.name !== "static"
+          !dirent.name.startsWith('_') &&
+          dirent.name !== 'static',
       )
       .map((dirent) => {
         const direntAbsolutePath = path.join(
           absolutePathToEmailsDirectory,
-          dirent.name
+          dirent.name,
         );
 
         return getEmailsDirectoryMetadata(
           direntAbsolutePath,
           keepFileExtensions,
           true,
-          baseDirectoryPath
+          baseDirectoryPath,
         ) as Promise<EmailsDirectory>;
-      })
+      }),
   );
 
   const emailsMetadata = {
     absolutePath: absolutePathToEmailsDirectory,
     relativePath: path.relative(
       baseDirectoryPath,
-      absolutePathToEmailsDirectory
+      absolutePathToEmailsDirectory,
     ),
     directoryName: absolutePathToEmailsDirectory.split(path.sep).pop()!,
     emailFilenames,

--- a/packages/react-email/src/utils/get-emails-directory-metadata.ts
+++ b/packages/react-email/src/utils/get-emails-directory-metadata.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import fs from 'node:fs';
-import path from 'node:path';
+import fs from "node:fs";
+import path from "node:path";
 
 const isFileAnEmail = (fullPath: string): boolean => {
   const stat = fs.statSync(fullPath);
@@ -9,7 +9,7 @@ const isFileAnEmail = (fullPath: string): boolean => {
 
   const { ext } = path.parse(fullPath);
 
-  if (!['.js', '.tsx', '.jsx'].includes(ext)) return false;
+  if (![".js", ".tsx", ".jsx"].includes(ext)) return false;
 
   // This is to avoid a possible race condition where the file doesn't exist anymore
   // once we are checking if it is an actual email, this couuld cause issues that
@@ -20,7 +20,7 @@ const isFileAnEmail = (fullPath: string): boolean => {
 
   // check with a heuristic to see if the file has at least
   // a default export (ES6) or module.exports (CommonJS) or named exports (MDX)
-  const fileContents = fs.readFileSync(fullPath, 'utf8');
+  const fileContents = fs.readFileSync(fullPath, "utf8");
 
   // Check for ES6 export default syntax
   const hasES6DefaultExport = /\bexport\s+default\b/gm.test(fileContents);
@@ -28,8 +28,10 @@ const isFileAnEmail = (fullPath: string): boolean => {
   // Check for CommonJS module.exports syntax
   const hasCommonJSExport = /\bmodule\.exports\s*=/gm.test(fileContents);
 
-  // Check for named exports (used in MDX files)
-  const hasNamedExport = /\bexport\s+\{/gm.test(fileContents);
+  // Check for named exports (used in MDX files) and ensure at least one is marked as default
+  const hasNamedExport = /\bexport\s+\{[^}]*\bdefault\b[^}]*\}/gm.test(
+    fileContents
+  );
 
   return hasES6DefaultExport || hasCommonJSExport || hasNamedExport;
 };
@@ -43,7 +45,7 @@ export interface EmailsDirectory {
 }
 
 const mergeDirectoriesWithSubDirectories = (
-  emailsDirectoryMetadata: EmailsDirectory,
+  emailsDirectoryMetadata: EmailsDirectory
 ): EmailsDirectory => {
   let currentResultingMergedDirectory: EmailsDirectory =
     emailsDirectoryMetadata;
@@ -57,7 +59,7 @@ const mergeDirectoriesWithSubDirectories = (
       ...onlySubDirectory,
       directoryName: path.join(
         currentResultingMergedDirectory.directoryName,
-        onlySubDirectory.directoryName,
+        onlySubDirectory.directoryName
       ),
     };
   }
@@ -70,7 +72,7 @@ export const getEmailsDirectoryMetadata = async (
   keepFileExtensions = false,
   isSubDirectory = false,
 
-  baseDirectoryPath = absolutePathToEmailsDirectory,
+  baseDirectoryPath = absolutePathToEmailsDirectory
 ): Promise<EmailsDirectory | undefined> => {
   if (!fs.existsSync(absolutePathToEmailsDirectory)) return;
 
@@ -80,12 +82,12 @@ export const getEmailsDirectoryMetadata = async (
 
   const emailFilenames = dirents
     .filter((dirent) =>
-      isFileAnEmail(path.join(absolutePathToEmailsDirectory, dirent.name)),
+      isFileAnEmail(path.join(absolutePathToEmailsDirectory, dirent.name))
     )
     .map((dirent) =>
       keepFileExtensions
         ? dirent.name
-        : dirent.name.replace(path.extname(dirent.name), ''),
+        : dirent.name.replace(path.extname(dirent.name), "")
     );
 
   const subDirectories = await Promise.all(
@@ -93,29 +95,29 @@ export const getEmailsDirectoryMetadata = async (
       .filter(
         (dirent) =>
           dirent.isDirectory() &&
-          !dirent.name.startsWith('_') &&
-          dirent.name !== 'static',
+          !dirent.name.startsWith("_") &&
+          dirent.name !== "static"
       )
       .map((dirent) => {
         const direntAbsolutePath = path.join(
           absolutePathToEmailsDirectory,
-          dirent.name,
+          dirent.name
         );
 
         return getEmailsDirectoryMetadata(
           direntAbsolutePath,
           keepFileExtensions,
           true,
-          baseDirectoryPath,
+          baseDirectoryPath
         ) as Promise<EmailsDirectory>;
-      }),
+      })
   );
 
   const emailsMetadata = {
     absolutePath: absolutePathToEmailsDirectory,
     relativePath: path.relative(
       baseDirectoryPath,
-      absolutePathToEmailsDirectory,
+      absolutePathToEmailsDirectory
     ),
     directoryName: absolutePathToEmailsDirectory.split(path.sep).pop()!,
     emailFilenames,

--- a/packages/react-email/src/utils/get-emails-directory-metadata.ts
+++ b/packages/react-email/src/utils/get-emails-directory-metadata.ts
@@ -19,10 +19,19 @@ const isFileAnEmail = (fullPath: string): boolean => {
   }
 
   // check with a heuristic to see if the file has at least
-  // a default export
+  // a default export (ES6) or module.exports (CommonJS) or named exports (MDX)
   const fileContents = fs.readFileSync(fullPath, 'utf8');
 
-  return /\bexport\s+default\b/gm.test(fileContents);
+  // Check for ES6 export default syntax
+  const hasES6DefaultExport = /\bexport\s+default\b/gm.test(fileContents);
+
+  // Check for CommonJS module.exports syntax
+  const hasCommonJSExport = /\bmodule\.exports\s*=/gm.test(fileContents);
+
+  // Check for named exports (used in MDX files)
+  const hasNamedExport = /\bexport\s+\{/gm.test(fileContents);
+
+  return hasES6DefaultExport || hasCommonJSExport || hasNamedExport;
 };
 
 export interface EmailsDirectory {

--- a/packages/react-email/src/utils/js-email-detection.spec.ts
+++ b/packages/react-email/src/utils/js-email-detection.spec.ts
@@ -1,54 +1,24 @@
-import fs from 'node:fs';
-import path from 'node:path';
-import { getEmailsDirectoryMetadata } from './get-emails-directory-metadata';
+import path from "node:path";
+import { getEmailsDirectoryMetadata } from "./get-emails-directory-metadata";
 
-describe('JavaScript Email Detection', () => {
-  const testingDir = path.resolve(__dirname, 'testing');
+describe("JavaScript Email Detection", async () => {
+  const testingDir = path.resolve(__dirname, "testing");
+  const emailsMetadata = await getEmailsDirectoryMetadata(testingDir, true);
 
-  test('should detect JavaScript files with ES6 export default syntax', async () => {
-    const emailsMetadata = await getEmailsDirectoryMetadata(testingDir, true);
-
+  it("should detect JavaScript files with ES6 export default syntax", async () => {
     expect(emailsMetadata).toBeDefined();
     expect(emailsMetadata?.emailFilenames).toContain(
-      'js-email-export-default.js',
+      "js-email-export-default.js"
     );
   });
 
-  test('should detect JavaScript files with CommonJS module.exports', async () => {
-    const emailsMetadata = await getEmailsDirectoryMetadata(testingDir, true);
-
+  it("should detect JavaScript files with CommonJS module.exports", async () => {
     expect(emailsMetadata).toBeDefined();
-    expect(emailsMetadata?.emailFilenames).toContain('js-email-test.js');
+    expect(emailsMetadata?.emailFilenames).toContain("js-email-test.js");
   });
 
-  test('should detect MDX-style JavaScript files with named exports', async () => {
-    const emailsMetadata = await getEmailsDirectoryMetadata(testingDir, true);
-
+  it("should detect MDX-style JavaScript files with named exports", async () => {
     expect(emailsMetadata).toBeDefined();
-    expect(emailsMetadata?.emailFilenames).toContain('mdx-email-test.js');
-  });
-
-  // This test will help us understand the current behavior
-  test('debug: examine the regex pattern used for detection', () => {
-    // Read the file content
-    const jsExportDefaultFile = path.join(
-      testingDir,
-      'js-email-export-default.js',
-    );
-    const jsModuleExportsFile = path.join(testingDir, 'js-email-test.js');
-    const mdxEmailFile = path.join(testingDir, 'mdx-email-test.js');
-
-    const exportDefaultContent = fs.readFileSync(jsExportDefaultFile, 'utf8');
-    const moduleExportsContent = fs.readFileSync(jsModuleExportsFile, 'utf8');
-    const mdxEmailContent = fs.readFileSync(mdxEmailFile, 'utf8');
-
-    // Test the current regex pattern
-    const currentPattern = /\bexport\s+default\b/gm;
-    const moduleExportsPattern = /\bmodule\.exports\s*=/gm;
-    const namedExportPattern = /\bexport\s+\{/gm;
-
-    expect(currentPattern.test(exportDefaultContent)).toBe(true);
-    expect(moduleExportsPattern.test(moduleExportsContent)).toBe(true);
-    expect(namedExportPattern.test(mdxEmailContent)).toBe(true);
+    expect(emailsMetadata?.emailFilenames).toContain("mdx-email-test.js");
   });
 });

--- a/packages/react-email/src/utils/js-email-detection.spec.ts
+++ b/packages/react-email/src/utils/js-email-detection.spec.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { getEmailsDirectoryMetadata } from './get-emails-directory-metadata';
+
+describe('JavaScript Email Detection', () => {
+  const testingDir = path.resolve(__dirname, 'testing');
+
+  test('should detect JavaScript files with ES6 export default syntax', async () => {
+    const emailsMetadata = await getEmailsDirectoryMetadata(testingDir, true);
+
+    expect(emailsMetadata).toBeDefined();
+    expect(emailsMetadata?.emailFilenames).toContain(
+      'js-email-export-default.js',
+    );
+  });
+
+  test('should detect JavaScript files with CommonJS module.exports', async () => {
+    const emailsMetadata = await getEmailsDirectoryMetadata(testingDir, true);
+
+    expect(emailsMetadata).toBeDefined();
+    expect(emailsMetadata?.emailFilenames).toContain('js-email-test.js');
+  });
+
+  test('should detect MDX-style JavaScript files with named exports', async () => {
+    const emailsMetadata = await getEmailsDirectoryMetadata(testingDir, true);
+
+    expect(emailsMetadata).toBeDefined();
+    expect(emailsMetadata?.emailFilenames).toContain('mdx-email-test.js');
+  });
+
+  // This test will help us understand the current behavior
+  test('debug: examine the regex pattern used for detection', () => {
+    // Read the file content
+    const jsExportDefaultFile = path.join(
+      testingDir,
+      'js-email-export-default.js',
+    );
+    const jsModuleExportsFile = path.join(testingDir, 'js-email-test.js');
+    const mdxEmailFile = path.join(testingDir, 'mdx-email-test.js');
+
+    const exportDefaultContent = fs.readFileSync(jsExportDefaultFile, 'utf8');
+    const moduleExportsContent = fs.readFileSync(jsModuleExportsFile, 'utf8');
+    const mdxEmailContent = fs.readFileSync(mdxEmailFile, 'utf8');
+
+    // Test the current regex pattern
+    const currentPattern = /\bexport\s+default\b/gm;
+    const moduleExportsPattern = /\bmodule\.exports\s*=/gm;
+    const namedExportPattern = /\bexport\s+\{/gm;
+
+    expect(currentPattern.test(exportDefaultContent)).toBe(true);
+    expect(moduleExportsPattern.test(moduleExportsContent)).toBe(true);
+    expect(namedExportPattern.test(mdxEmailContent)).toBe(true);
+  });
+});

--- a/packages/react-email/src/utils/js-email-detection.spec.ts
+++ b/packages/react-email/src/utils/js-email-detection.spec.ts
@@ -1,24 +1,24 @@
-import path from "node:path";
-import { getEmailsDirectoryMetadata } from "./get-emails-directory-metadata";
+import path from 'node:path';
+import { getEmailsDirectoryMetadata } from './get-emails-directory-metadata';
 
-describe("JavaScript Email Detection", async () => {
-  const testingDir = path.resolve(__dirname, "testing");
+describe('JavaScript Email Detection', async () => {
+  const testingDir = path.resolve(__dirname, 'testing');
   const emailsMetadata = await getEmailsDirectoryMetadata(testingDir, true);
 
-  it("should detect JavaScript files with ES6 export default syntax", async () => {
+  it('should detect JavaScript files with ES6 export default syntax', async () => {
     expect(emailsMetadata).toBeDefined();
     expect(emailsMetadata?.emailFilenames).toContain(
-      "js-email-export-default.js"
+      'js-email-export-default.js',
     );
   });
 
-  it("should detect JavaScript files with CommonJS module.exports", async () => {
+  it('should detect JavaScript files with CommonJS module.exports', async () => {
     expect(emailsMetadata).toBeDefined();
-    expect(emailsMetadata?.emailFilenames).toContain("js-email-test.js");
+    expect(emailsMetadata?.emailFilenames).toContain('js-email-test.js');
   });
 
-  it("should detect MDX-style JavaScript files with named exports", async () => {
+  it('should detect MDX-style JavaScript files with named exports', async () => {
     expect(emailsMetadata).toBeDefined();
-    expect(emailsMetadata?.emailFilenames).toContain("mdx-email-test.js");
+    expect(emailsMetadata?.emailFilenames).toContain('mdx-email-test.js');
   });
 });

--- a/packages/react-email/src/utils/testing/js-email-export-default.js
+++ b/packages/react-email/src/utils/testing/js-email-export-default.js
@@ -1,0 +1,18 @@
+// A JavaScript email component with ES6 export default
+import { Button, Html } from '@react-email/components';
+import React from 'react';
+
+function Email() {
+  return (
+    <Html>
+      <Button
+        href="https://example.com"
+        style={{ background: '#000', color: '#fff', padding: '12px 20px' }}
+      >
+        Click me
+      </Button>
+    </Html>
+  );
+}
+
+export default Email;

--- a/packages/react-email/src/utils/testing/js-email-test.js
+++ b/packages/react-email/src/utils/testing/js-email-test.js
@@ -1,0 +1,18 @@
+// A simple JavaScript email component
+const React = require('react');
+const { Html, Button } = require('@react-email/components');
+
+function Email() {
+  return (
+    <Html>
+      <Button
+        href="https://example.com"
+        style={{ background: '#000', color: '#fff', padding: '12px 20px' }}
+      >
+        Click me
+      </Button>
+    </Html>
+  );
+}
+
+module.exports = Email;

--- a/packages/react-email/src/utils/testing/mdx-email-test.js
+++ b/packages/react-email/src/utils/testing/mdx-email-test.js
@@ -1,0 +1,128 @@
+import { Button, Html } from '@react-email/components';
+import { useMDXComponents as _provideComponents } from 'react';
+import {
+  Fragment as _Fragment,
+  jsxDEV as _jsxDEV,
+} from 'react/jsx-dev-runtime';
+
+const MDXLayout = function Email2() {
+  return _jsxDEV(
+    Html,
+    {
+      children: _jsxDEV(
+        Button,
+        {
+          href: 'https://example.com',
+          style: {
+            background: '#000',
+            color: '#fff',
+            padding: '12px 20px',
+          },
+          children: 'Click me',
+        },
+        void 0,
+        false,
+        {
+          fileName:
+            '/Users/david/src/silencia-ai/silencia/proto/emails-raw/em1.mdx',
+          lineNumber: 7,
+          columnNumber: 7,
+        },
+        this,
+      ),
+    },
+    void 0,
+    false,
+    {
+      fileName:
+        '/Users/david/src/silencia-ai/silencia/proto/emails-raw/em1.mdx',
+      lineNumber: 6,
+      columnNumber: 5,
+    },
+    this,
+  );
+};
+
+function _createMdxContent(props) {
+  const _components = {
+    h1: 'h1',
+    ..._provideComponents(),
+    ...props.components,
+  };
+  return _jsxDEV(
+    _Fragment,
+    {
+      children: [
+        _jsxDEV(
+          _components.h1,
+          {
+            children: 'Hello!',
+          },
+          void 0,
+          false,
+          {
+            fileName:
+              '/Users/david/src/silencia-ai/silencia/proto/emails-raw/em1.mdx',
+            lineNumber: 17,
+            columnNumber: 1,
+          },
+          this,
+        ),
+        '\n',
+        _jsxDEV(
+          Email,
+          {},
+          void 0,
+          false,
+          {
+            fileName:
+              '/Users/david/src/silencia-ai/silencia/proto/emails-raw/em1.mdx',
+            lineNumber: 19,
+            columnNumber: 1,
+          },
+          this,
+        ),
+      ],
+    },
+    void 0,
+    true,
+    {
+      fileName:
+        '/Users/david/src/silencia-ai/silencia/proto/emails-raw/em1.mdx',
+      lineNumber: 1,
+      columnNumber: 1,
+    },
+    this,
+  );
+}
+
+function MDXContent(props = {}) {
+  return _jsxDEV(
+    MDXLayout,
+    {
+      ...props,
+      children: _jsxDEV(
+        _createMdxContent,
+        {
+          ...props,
+        },
+        void 0,
+        false,
+        {
+          fileName:
+            '/Users/david/src/silencia-ai/silencia/proto/emails-raw/em1.mdx',
+        },
+        this,
+      ),
+    },
+    void 0,
+    false,
+    {
+      fileName:
+        '/Users/david/src/silencia-ai/silencia/proto/emails-raw/em1.mdx',
+    },
+    this,
+  );
+}
+
+export { MDXContent as default };


### PR DESCRIPTION
# Fix: Add support for detecting JavaScript files with various export patterns

## Problem
The React Email preview tool was not correctly displaying `.js` files in the preview, despite the code explicitly including `.js` in the list of supported file extensions. After investigation, we discovered that the issue was in the email detection logic, which was only checking for ES6 `export default` syntax, missing other common JavaScript export patterns.

## Solution
Enhanced the `isFileAnEmail` function in `get-emails-directory-metadata.ts` to detect three different export patterns:

1. ES6 export default syntax: `export default Component`
2. CommonJS module exports: `module.exports = Component`
3. Named exports (used in MDX-generated files): `export { Component as default }`

## Implementation Details
- Added regex patterns to detect each export style
- Created comprehensive tests to verify the behavior with different file types
- Ensured backward compatibility with existing email templates
- Added detailed comments to explain the detection logic

## Testing
Created a test suite with sample email files in different formats:
- Standard ES6 export default
- CommonJS module.exports
- MDX-style named exports

All tests pass, confirming that the preview tool now correctly identifies and displays JavaScript email templates regardless of their export pattern.

## Impact
This fix enables support for:
- CommonJS-style email templates
- MDX-generated email templates
- Any JavaScript file that exports components using any of the supported patterns

Users can now write email templates using their preferred JavaScript syntax or tooling without worrying about compatibility with the preview tool.
