### PR TITLE
fix(react-email): Module importing for separate tailwind configs

### DIFF
--- a/packages/react-email/src/utils/caniemail/tailwind/get-tailwind-config.ts
+++ b/packages/react-email/src/utils/caniemail/tailwind/get-tailwind-config.ts
@@ -74,7 +74,7 @@ export const getTailwindConfig = async (
       } catch (exception) {
         console.warn(exception);
         console.warn(
-          `Tried reading the config defined directly in the Tailwind component but was unable to, probably because it isn't a valid javascript object by itself.`,
+          `Tried reading the config defined directly in the Tailwind component but was unable to, probably because it can't run by itself.`,
         );
       }
     }
@@ -123,7 +123,7 @@ const getConfigFromImport = async (
   const configFile = configBuildResult.outputFiles[0];
   if (configFile === undefined) {
     throw new Error(
-      'Could not build config file as it was found as undefined, this is a bug please open an issue.',
+      'Could not build config file as it was found as undefined, this is most likely a bug, please open an issue.',
     );
   }
   const configModule = runBundledCode(configFile.text, configFilepath);

--- a/packages/react-email/src/utils/caniemail/tailwind/get-tailwind-config.ts
+++ b/packages/react-email/src/utils/caniemail/tailwind/get-tailwind-config.ts
@@ -113,7 +113,7 @@ const getConfigFromImport = async (
   }
 
   const configBuildResult = await esbuild.build({
-    bundle: false,
+    bundle: true,
     entryPoints: [configFilepath],
     platform: 'node',
     write: false,


### PR DESCRIPTION
This does indeed add the support for importing modules inside separate `tailwind.config` files, but it's required to be a separate file. If it isn't in a separate file, the code inside `config` is copied and ran with `new Function(...)` without any dependencies, if it has some. While the config file is bundled this inlined config is not, meaning it is kind of a limitation.

Fixes one of the problems in #2025