### PR TITLE
fix(react-email): Linter not being able to handle tailwind config import with path alias

### DIFF
--- a/.changeset/fifty-streets-kick.md
+++ b/.changeset/fifty-streets-kick.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Add support for path aliases when linter runs tailwind config

--- a/packages/react-email/src/utils/caniemail/tailwind/get-tailwind-config.ts
+++ b/packages/react-email/src/utils/caniemail/tailwind/get-tailwind-config.ts
@@ -88,33 +88,17 @@ const getConfigFromImport = async (
   sourcePath: string,
 ): Promise<TailwindConfig> => {
   const configRelativePath = tailwindConfigImport.source.value;
-  const configImportPath = path.resolve(
-    path.dirname(sourcePath),
-    configRelativePath,
-  );
-  const configFilepath = getFirstExistingFilepath([
-    configImportPath,
-    `${configImportPath}.ts`,
-    `${configImportPath}.js`,
-    `${configImportPath}.mjs`,
-    `${configImportPath}.cjs`,
-  ]);
-
-  if (configFilepath === undefined) {
-    throw new Error(
-      `Could not find Tailwind config by inferring it's extension type (tried .ts, .js, .mjs and .cjs).`,
-      {
-        cause: {
-          configPath: configImportPath,
-          sourcePath,
-        },
-      },
-    );
-  }
+  const sourceDirpath = path.dirname(sourcePath);
+  const configFilepath = path.join(sourceDirpath, configRelativePath);
 
   const configBuildResult = await esbuild.build({
     bundle: true,
-    entryPoints: [configFilepath],
+    stdin: {
+      contents: `import tailwindConfig from "${configRelativePath}"; 
+export { tailwindConfig };`,
+      loader: 'tsx',
+      resolveDir: path.dirname(sourcePath)
+    },
     platform: 'node',
     write: false,
     format: 'cjs',
@@ -128,17 +112,15 @@ const getConfigFromImport = async (
   }
   const configModule = runBundledCode(configFile.text, configFilepath);
   if (isErr(configModule)) {
-    throw new Error('Error when trying to run the config file', {
-      cause: configModule.error,
-    });
+    throw new Error(`Error when trying to run the config file: ${configModule.error}`);
   }
 
   if (
     typeof configModule.value === 'object' &&
     configModule.value !== null &&
-    'default' in configModule.value
+    'tailwindConfig' in configModule.value
   ) {
-    return configModule.value.default as TailwindConfig;
+    return configModule.value.tailwindConfig as TailwindConfig;
   }
 
   throw new Error(

--- a/packages/react-email/src/utils/caniemail/tailwind/get-tailwind-config.ts
+++ b/packages/react-email/src/utils/caniemail/tailwind/get-tailwind-config.ts
@@ -97,7 +97,7 @@ const getConfigFromImport = async (
       contents: `import tailwindConfig from "${configRelativePath}"; 
 export { tailwindConfig };`,
       loader: 'tsx',
-      resolveDir: path.dirname(sourcePath)
+      resolveDir: path.dirname(sourcePath),
     },
     platform: 'node',
     write: false,
@@ -112,7 +112,9 @@ export { tailwindConfig };`,
   }
   const configModule = runBundledCode(configFile.text, configFilepath);
   if (isErr(configModule)) {
-    throw new Error(`Error when trying to run the config file: ${configModule.error}`);
+    throw new Error(
+      `Error when trying to run the config file: ${configModule.error}`,
+    );
   }
 
   if (


### PR DESCRIPTION
Before this PR, we tried to find the config assuming that the import specifier was a proper path, but it could also be using a path alias, so this PR fixes that by offloading the work to find the proper path to esbuild through defining a virtual file that imports with the same import specifier.