### PR TITLE
feat(root): Improved reliability on first install

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "pnpm install --frozen-lockfile && email build",
+    "build": "email build",
     "dev": "email dev",
     "start": "email start",
     "export": "email export"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --external react",
-    "postinstall": "turbo run build",
+    "prepare": "turbo run build",
     "clean": "rm -rf dist",
     "dev": "tsup src/index.ts --format esm,cjs --dts --external react --watch"
   },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -22,6 +22,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --external react",
+    "postinstall": "turbo run build",
     "clean": "rm -rf dist",
     "dev": "tsup src/index.ts --format esm,cjs --dts --external react --watch"
   },

--- a/packages/create-email/package.json
+++ b/packages/create-email/package.json
@@ -27,7 +27,8 @@
     "create-email": "src/index.js"
   },
   "devDependencies": {
-    "react-email-starter": "workspace:*",
+    "@react-email/components": "workspace:0.0.35",
+    "react-email": "workspace:4.0.3",
     "tsconfig": "workspace:*",
     "typescript": "5.8.2"
   }

--- a/packages/create-email/package.json
+++ b/packages/create-email/package.json
@@ -27,6 +27,7 @@
     "create-email": "src/index.js"
   },
   "devDependencies": {
+    "react-email-starter": "workspace:*",
     "tsconfig": "workspace:*",
     "typescript": "5.8.2"
   }

--- a/packages/create-email/package.json
+++ b/packages/create-email/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@react-email/components": "workspace:0.0.35",
+    "react": "19.0.0",
     "react-email": "workspace:4.0.3",
     "tsconfig": "workspace:*",
     "typescript": "5.8.2"

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -6,7 +6,8 @@
     "email": "./dist/cli/index.js"
   },
   "scripts": {
-    "build": "tsup-node && node ./scripts/build-preview-server.mjs && pnpm install --frozen-lockfile",
+    "build": "tsup-node && node ./scripts/build-preview-server.mjs",
+    "postinstall": "turbo run build",
     "caniemail:fetch": "node ./scripts/fill-caniemail-data.mjs",
     "clean": "rm -rf dist",
     "dev": "tsup-node --watch",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "tsup-node && node ./scripts/build-preview-server.mjs",
-    "postinstall": "turbo run build",
+    "prepare": "turbo run build",
     "caniemail:fetch": "node ./scripts/fill-caniemail-data.mjs",
     "clean": "rm -rf dist",
     "dev": "tsup-node --watch",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -6,7 +6,7 @@
     "email": "./dist/cli/index.js"
   },
   "scripts": {
-    "build": "tsup-node && node ./scripts/build-preview-server.mjs",
+    "build": "tsup-node && node ./scripts/build-preview-server.mjs && pnpm install --frozen-lockfile",
     "caniemail:fetch": "node ./scripts/fill-caniemail-data.mjs",
     "clean": "rm -rf dist",
     "dev": "tsup-node --watch",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "tsup-node && node ./scripts/build-preview-server.mjs",
-    "postinstall": "turbo run build && pnpm install --frozen-lockfile --ignore-scripts",
+    "postinstall": "turbo run build",
     "caniemail:fetch": "node ./scripts/fill-caniemail-data.mjs",
     "clean": "rm -rf dist",
     "dev": "tsup-node --watch",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "tsup-node && node ./scripts/build-preview-server.mjs",
-    "postinstall": "turbo run build",
+    "postinstall": "turbo run build && pnpm install --frozen-lockfile --ignore-scripts",
     "caniemail:fetch": "node ./scripts/fill-caniemail-data.mjs",
     "clean": "rm -rf dist",
     "dev": "tsup-node --watch",

--- a/packages/react-email/src/cli/commands/build.ts
+++ b/packages/react-email/src/cli/commands/build.ts
@@ -179,6 +179,7 @@ const updatePackageJson = async (builtPreviewAppPath: string) => {
   // email templates without `@react-email/render` being installed.
   delete packageJson.devDependencies['@react-email/render'];
   delete packageJson.devDependencies['@react-email/components'];
+  delete packageJson.scripts.prepare;
   await fs.promises.writeFile(
     packageJsonPath,
     JSON.stringify(packageJson),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -680,6 +680,9 @@ importers:
       '@react-email/components':
         specifier: workspace:0.0.35
         version: link:../components
+      react:
+        specifier: 19.0.0
+        version: 19.0.0
       react-email:
         specifier: workspace:4.0.3
         version: link:../react-email

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,6 +677,9 @@ importers:
         specifier: 6.1.2
         version: 6.1.2
     devDependencies:
+      react-email-starter:
+        specifier: workspace:*
+        version: link:template
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,9 +677,12 @@ importers:
         specifier: 6.1.2
         version: 6.1.2
     devDependencies:
-      react-email-starter:
-        specifier: workspace:*
-        version: link:template
+      '@react-email/components':
+        specifier: workspace:0.0.35
+        version: link:../components
+      react-email:
+        specifier: workspace:4.0.3
+        version: link:../react-email
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig


### PR DESCRIPTION
This PR also improves the reliability of the initial `pnpm install` by using the `prepare` script on `react-email` and `@react-email/components` to build them both as they are needed on other packages. The initial `pnpm install` still shows a warning, but it does work after just `pnpm install` on a fresh clone.

This PR also adds in a dev dependency for `create-email` on `react-email` and `@react-email/components` so that dependencies are properly resolved there in `turbo test`.
