### PR TITLE
chore(docs): update current year in `why` line

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It reduces the pain of coding responsive emails with dark mode support. It also 
 
 ## Why
 
-We believe that email is an extremely important medium for people to communicate. However, we need to stop developing emails like 2010, and rethink how email can be done in 2022 and beyond. Email development needs a revamp. A renovation. Modernized for the way we build web apps today.
+We believe that email is an extremely important medium for people to communicate. However, we need to stop developing emails like 2010, and rethink how email can be done in 2025 and beyond. Email development needs a revamp. A renovation. Modernized for the way we build web apps today.
 
 ## Install
 

--- a/apps/docs/introduction.mdx
+++ b/apps/docs/introduction.mdx
@@ -11,7 +11,7 @@ import Integrations from '/snippets/integrations.mdx'
 
 ## Why
 
-We believe that email is an extremely important medium for people to communicate. However, we need to stop developing emails like 2010, and rethink how email can be done in 2024 and beyond. Email development needs a revamp. A renovation. Modernized for the way we build web apps today.
+We believe that email is an extremely important medium for people to communicate. However, we need to stop developing emails like 2010, and rethink how email can be done in {new Date().getFullYear()} and beyond. Email development needs a revamp. A renovation. Modernized for the way we build web apps today.
 
 ## Getting Started
 


### PR DESCRIPTION
### Update year `2024` to current year in introduction documentation.
Fixes https://github.com/resend/react-email/issues/2052