### PR TITLE
chore(web): Improve stability of checkSpam test

### DIFF
--- a/apps/web/src/app/api/check-spam/__snapshots__/check-spam.spec.tsx.snap
+++ b/apps/web/src/app/api/check-spam/__snapshots__/check-spam.spec.tsx.snap
@@ -24,20 +24,6 @@ exports[`checkSpam() > with most spammy email 1`] = `
 }
 `;
 
-exports[`checkSpam() > with papermark email template 1`] = `
-{
-  "checks": [
-    {
-      "description": "Invisible text + long lines",
-      "name": "FONT_INVIS_LONG_LINE",
-      "points": 0.4,
-    },
-  ],
-  "isSpam": false,
-  "points": 0.4,
-}
-`;
-
 exports[`checkSpam() > with stripe email template using true base url 1`] = `
 {
   "checks": [],

--- a/apps/web/src/app/api/check-spam/check-spam.spec.tsx
+++ b/apps/web/src/app/api/check-spam/check-spam.spec.tsx
@@ -30,13 +30,4 @@ describe('checkSpam()', () => {
 
     expect(await checkSpam(html, plainText)).toMatchSnapshot();
   });
-
-  test('with papermark email template', async () => {
-    const html = await render(<PapermarkYearInReviewEmail />);
-    const plainText = await render(<PapermarkYearInReviewEmail />, {
-      plainText: true,
-    });
-
-    expect(await checkSpam(html, plainText)).toMatchSnapshot();
-  });
 });

--- a/apps/web/src/app/api/check-spam/check-spam.spec.tsx
+++ b/apps/web/src/app/api/check-spam/check-spam.spec.tsx
@@ -1,5 +1,4 @@
 import { render } from '@react-email/components';
-import PapermarkYearInReviewEmail from '../../../../../demo/emails/notifications/papermark-year-in-review';
 import { checkSpam } from './check-spam';
 import { StripeWelcomeEmail } from './testing/stripe-welcome-email';
 


### PR DESCRIPTION
This PR removes the papermark spam checking test, as it seems to be giving off different results from time to time.