### PR TITLE
fix(react-email): Dependents of dependents of email templates not causing hot reloads 

### DIFF
--- a/.changeset/eleven-wombats-make.md
+++ b/.changeset/eleven-wombats-make.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Fix dependent of dependents not causing hot reloads

--- a/packages/react-email/src/cli/utils/preview/hot-reloading/setup-hot-reloading.ts
+++ b/packages/react-email/src/cli/utils/preview/hot-reloading/setup-hot-reloading.ts
@@ -78,7 +78,7 @@ export const setupHotreloading = async (
 
     const newFilesOutsideEmailsDirectory = getFilesOutsideEmailsDirectory();
     // updates the files outside of the user's emails directory by unwatching
-    // the inexistant ones and watching the new ones
+    // the inexistent ones and watching the new ones
     //
     // this is necessary to avoid the issue mentioned here https://github.com/resend/react-email/issues/1433#issuecomment-2177515290
     for (const p of filesOutsideEmailsDirectory) {

--- a/packages/react-email/src/hooks/use-email-rendering-result.ts
+++ b/packages/react-email/src/hooks/use-email-rendering-result.ts
@@ -5,9 +5,9 @@ import {
   renderEmailByPath,
 } from '../actions/render-email-by-path';
 import { isBuilding } from '../app/env';
-import { useHotreload } from './use-hot-reload';
 import { useEmails } from '../contexts/emails';
 import { containsEmailTemplate } from '../utils/contains-email-template';
+import { useHotreload } from './use-hot-reload';
 
 export const useEmailRenderingResult = (
   emailPath: string,
@@ -29,7 +29,9 @@ export const useEmailRenderingResult = (
           // going to be equivalent to the slug
           change.filename;
 
-        if (containsEmailTemplate(slugForChangedEmail, emailsDirectoryMetadata)) {
+        if (
+          containsEmailTemplate(slugForChangedEmail, emailsDirectoryMetadata)
+        ) {
           continue;
         }
 

--- a/packages/react-email/src/hooks/use-email-rendering-result.ts
+++ b/packages/react-email/src/hooks/use-email-rendering-result.ts
@@ -6,6 +6,8 @@ import {
 } from '../actions/render-email-by-path';
 import { isBuilding } from '../app/env';
 import { useHotreload } from './use-hot-reload';
+import { useEmails } from '../contexts/emails';
+import { containsEmailTemplate } from '../utils/contains-email-template';
 
 export const useEmailRenderingResult = (
   emailPath: string,
@@ -14,6 +16,8 @@ export const useEmailRenderingResult = (
   const [renderingResult, setRenderingResult] = useState(
     serverEmailRenderedResult,
   );
+
+  const { emailsDirectoryMetadata } = useEmails();
 
   if (!isBuilding) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -25,10 +29,13 @@ export const useEmailRenderingResult = (
           // going to be equivalent to the slug
           change.filename;
 
+        if (containsEmailTemplate(slugForChangedEmail, emailsDirectoryMetadata)) {
+          continue;
+        }
+
         const pathForChangedEmail =
           await getEmailPathFromSlug(slugForChangedEmail);
 
-        // We always render the email template here so that we can allow
         const newRenderingResult = await renderEmailByPath(
           pathForChangedEmail,
           true,

--- a/packages/react-email/src/utils/contains-email-template.spec.ts
+++ b/packages/react-email/src/utils/contains-email-template.spec.ts
@@ -1,0 +1,86 @@
+import path from 'node:path';
+import { containsEmailTemplate } from './contains-email-template';
+
+test('containsEmailTemplate()', async () => {
+  const emailsDirectoryPath = path.resolve(
+    __dirname,
+    '../../../../apps/demo/emails',
+  );
+  const directory = {
+    absolutePath: emailsDirectoryPath,
+    directoryName: 'emails',
+    relativePath: '',
+    emailFilenames: [],
+    subDirectories: [
+      {
+        absolutePath: `${emailsDirectoryPath}/magic-links`,
+        directoryName: 'magic-links',
+        relativePath: 'magic-links',
+        emailFilenames: [
+          'aws-verify-email',
+          'linear-login-code',
+          'notion-magic-link',
+          'plaid-verify-identity',
+          'raycast-magic-link',
+          'slack-confirm',
+        ],
+        subDirectories: [],
+      },
+      {
+        absolutePath: `${emailsDirectoryPath}/newsletters`,
+        directoryName: 'newsletters',
+        relativePath: 'newsletters',
+        emailFilenames: [
+          'codepen-challengers',
+          'google-play-policy-update',
+          'stack-overflow-tips',
+        ],
+        subDirectories: [],
+      },
+      {
+        absolutePath: `${emailsDirectoryPath}/notifications`,
+        directoryName: 'notifications',
+        relativePath: 'notifications',
+        emailFilenames: [
+          'github-access-token',
+          'papermark-year-in-review',
+          'vercel-invite-user',
+          'yelp-recent-login',
+        ],
+        subDirectories: [],
+      },
+      {
+        absolutePath: `${emailsDirectoryPath}/receipts`,
+        directoryName: 'receipts',
+        relativePath: 'receipts',
+        emailFilenames: ['apple-receipt', 'nike-receipt'],
+        subDirectories: [],
+      },
+      {
+        absolutePath: `${emailsDirectoryPath}/reset-password`,
+        directoryName: 'reset-password',
+        relativePath: 'reset-password',
+        emailFilenames: ['dropbox-reset-password', 'twitch-reset-password'],
+        subDirectories: [],
+      },
+      {
+        absolutePath: `${emailsDirectoryPath}/reviews`,
+        directoryName: 'reviews',
+        relativePath: 'reviews',
+        emailFilenames: ['airbnb-review', 'amazon-review'],
+        subDirectories: [],
+      },
+      {
+        absolutePath: `${emailsDirectoryPath}/welcome`,
+        directoryName: 'welcome',
+        relativePath: 'welcome',
+        emailFilenames: ['koala-welcome', 'netlify-welcome', 'stripe-welcome'],
+        subDirectories: [],
+      },
+    ],
+  };
+  expect(containsEmailTemplate('welcome/koala-welcome', directory)).toBe(true);
+  expect(containsEmailTemplate('welcome/missing-template', directory)).toBe(
+    false,
+  );
+});

--- a/packages/react-email/src/utils/contains-email-template.ts
+++ b/packages/react-email/src/utils/contains-email-template.ts
@@ -1,4 +1,4 @@
-import type { EmailsDirectory } from "./get-emails-directory-metadata";
+import type { EmailsDirectory } from './get-emails-directory-metadata';
 
 export const containsEmailTemplate = (
   relativeEmailPath: string,

--- a/packages/react-email/src/utils/contains-email-template.ts
+++ b/packages/react-email/src/utils/contains-email-template.ts
@@ -1,0 +1,23 @@
+import type { EmailsDirectory } from "./get-emails-directory-metadata";
+
+export const containsEmailTemplate = (
+  relativeEmailPath: string,
+  directory: EmailsDirectory,
+) => {
+  const remainingSegments = relativeEmailPath
+    .replace(directory.relativePath, '')
+    .split('/')
+    .filter(Boolean);
+  if (remainingSegments.length === 1) {
+    const emailFilename = remainingSegments[0]!;
+    return directory.emailFilenames.includes(emailFilename);
+  }
+  const subDirectory = directory.subDirectories.find(
+    (sub) => sub.relativePath === remainingSegments[0],
+  );
+  if (subDirectory === undefined) {
+    return false;
+  }
+
+  return containsEmailTemplate(relativeEmailPath, subDirectory);
+};

--- a/packages/react-email/src/utils/get-email-component.ts
+++ b/packages/react-email/src/utils/get-email-component.ts
@@ -106,21 +106,6 @@ export const getEmailComponent = async (
     };
   }
 
-  if (typeof parseResult.data.default !== 'function') {
-    return {
-      error: improveErrorWithSourceMap(
-        new Error(
-          `The email component at ${emailPath} does not contain a default exported function`,
-          {
-            cause: parseResult.error,
-          },
-        ),
-        emailPath,
-        sourceMapToEmail,
-      ),
-    };
-  }
-
   const { data: componentModule } = parseResult;
 
   return {

--- a/packages/react-email/src/utils/get-email-component.ts
+++ b/packages/react-email/src/utils/get-email-component.ts
@@ -12,7 +12,7 @@ import type { EmailTemplate as EmailComponent } from './types/email-template';
 import type { ErrorObject } from './types/error-object';
 
 const EmailComponentModule = z.object({
-  default: z.any(),
+  default: z.function(),
   render: z.function(),
   reactEmailCreateReactElement: z.function(),
 });

--- a/packages/react-email/src/utils/get-email-component.ts
+++ b/packages/react-email/src/utils/get-email-component.ts
@@ -12,7 +12,7 @@ import type { EmailTemplate as EmailComponent } from './types/email-template';
 import type { ErrorObject } from './types/error-object';
 
 const EmailComponentModule = z.object({
-  default: z.function(),
+  default: z.any(),
   render: z.function(),
   reactEmailCreateReactElement: z.function(),
 });
@@ -96,6 +96,21 @@ export const getEmailComponent = async (
       error: improveErrorWithSourceMap(
         new Error(
           `The email component at ${emailPath} does not contain the expected exports`,
+          {
+            cause: parseResult.error,
+          },
+        ),
+        emailPath,
+        sourceMapToEmail,
+      ),
+    };
+  }
+
+  if (typeof parseResult.data.default !== 'function') {
+    return {
+      error: improveErrorWithSourceMap(
+        new Error(
+          `The email component at ${emailPath} does not contain a default exported function`,
           {
             cause: parseResult.error,
           },

--- a/packages/react-email/src/utils/get-emails-directory-metadata.ts
+++ b/packages/react-email/src/utils/get-emails-directory-metadata.ts
@@ -44,7 +44,6 @@ export interface EmailsDirectory {
   subDirectories: EmailsDirectory[];
 }
 
-
 const mergeDirectoriesWithSubDirectories = (
   emailsDirectoryMetadata: EmailsDirectory,
 ): EmailsDirectory => {

--- a/packages/react-email/src/utils/get-emails-directory-metadata.ts
+++ b/packages/react-email/src/utils/get-emails-directory-metadata.ts
@@ -12,7 +12,7 @@ const isFileAnEmail = (fullPath: string): boolean => {
   if (!['.js', '.tsx', '.jsx'].includes(ext)) return false;
 
   // This is to avoid a possible race condition where the file doesn't exist anymore
-  // once we are checking if it is an actual email, this couuld cause issues that
+  // once we are checking if it is an actual email, this could cause issues that
   // would be very hard to debug and find out the why of it happening.
   if (!fs.existsSync(fullPath)) {
     return false;
@@ -43,6 +43,7 @@ export interface EmailsDirectory {
   emailFilenames: string[];
   subDirectories: EmailsDirectory[];
 }
+
 
 const mergeDirectoriesWithSubDirectories = (
   emailsDirectoryMetadata: EmailsDirectory,


### PR DESCRIPTION
Meant for #2078.

The main problem was that the component was being treated as an email template on the hot reloading code which is then fixed with

https://github.com/resend/react-email/blob/fe84d5c2de8cd8d61d87dcfd713c343f0dc2f50f/packages/react-email/src/hooks/use-email-rendering-result.ts#L32-L36

Alongside a unit test to ensure this function works as intended. This PR also ends up fixing the error in https://github.com/resend/react-email/issues/1872#issuecomment-2773299339