### PR TITLE
fix(react-email): No error with missing default function export

### DIFF
--- a/.changeset/wet-planes-camp.md
+++ b/.changeset/wet-planes-camp.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Add error message for when an email template does not have a default export

--- a/packages/react-email/src/utils/get-email-component.ts
+++ b/packages/react-email/src/utils/get-email-component.ts
@@ -106,6 +106,21 @@ export const getEmailComponent = async (
     };
   }
 
+  if (typeof parseResult.data.default !== 'function') {
+    return {
+      error: improveErrorWithSourceMap(
+        new Error(
+          `The email component at ${emailPath} does not contain a default exported function`,
+          {
+            cause: parseResult.error,
+          },
+        ),
+        emailPath,
+        sourceMapToEmail,
+      ),
+    };
+  }
+
   const { data: componentModule } = parseResult;
 
   return {


### PR DESCRIPTION
This PR adds a proper error message for when the user doesn't have a default exported function on their email template