### PR TITLE
feat(create-email): Use latest from specified tag for `react-email` and `@react-email/components`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "turbo run build --filter=!react-email-starter",
-    "dev": "turbo run dev --filter=!react-email-starter --parallel --concurrency 25",
-    "release": "turbo run build --filter=./packages/* --filter=!react-email-starter && pnpm changeset publish",
+    "build": "turbo run build",
+    "dev": "turbo run dev --parallel --concurrency 25",
+    "release": "turbo run build --filter=./packages/* && pnpm changeset publish",
     "canary:enter": "changeset pre enter canary",
     "canary:exit": "changeset pre exit",
     "version": "changeset version && pnpm install --no-frozen-lockfile && pnpm lint:fix",

--- a/packages/create-email/package.json
+++ b/packages/create-email/package.json
@@ -27,9 +27,7 @@
     "create-email": "src/index.js"
   },
   "devDependencies": {
-    "@react-email/components": "0.0.37-canary.0",
     "react": "19.0.0",
-    "react-email": "4.1.0-canary.0",
     "tsconfig": "workspace:*",
     "typescript": "5.8.2"
   }

--- a/packages/create-email/src/index.js
+++ b/packages/create-email/src/index.js
@@ -8,7 +8,19 @@ import logSymbols from 'log-symbols';
 import ora from 'ora';
 import { tree } from './tree.js';
 
-const init = async (name) => {
+const getLatestVersionOfTag = async (packageName, tag) => {
+  const response = await fetch(
+    `https://registry.npmjs.org/${packageName}/${tag}`,
+  );
+  const data = await response.json();
+  if (typeof data === 'string' && data.startsWith('version not found')) {
+    console.error(`Tag ${tag} does not exist for ${packageName}.`);
+    process.exit(1);
+  }
+  return data.version;
+};
+
+const init = async (name, { tag }) => {
   let projectPath = name;
 
   if (!projectPath) {
@@ -39,25 +51,18 @@ const init = async (name) => {
     resolvedProjectPath,
     './package.json',
   );
-  const templatePackageJson = JSON.parse(
-    fse.readFileSync(templatePackageJsonPath, 'utf8'),
-  );
-  for (const key in templatePackageJson.dependencies) {
-    // We remove any workspace prefix that might have been added for the purposes
-    // of being used locally
-    templatePackageJson.dependencies[key] = templatePackageJson.dependencies[
-      key
-    ].replace('workspace:', '');
-  }
-  for (const key in templatePackageJson.devDependencies) {
-    // We remove any workspace prefix that might have been added for the purposes
-    // of being used locally
-    templatePackageJson.devDependencies[key] =
-      templatePackageJson.devDependencies[key].replace('workspace:', '');
-  }
+  const templatePackageJson = fse.readFileSync(templatePackageJsonPath, 'utf8');
   fse.writeFileSync(
     templatePackageJsonPath,
-    JSON.stringify(templatePackageJson, null, 2),
+    templatePackageJson
+      .replace(
+        'INSERT_COMPONENTS_VERSION',
+        await getLatestVersionOfTag('@react-email/components', tag),
+      )
+      .replace(
+        'INSERT_REACT_EMAIL_VERSION',
+        await getLatestVersionOfTag('react-email', tag),
+      ),
     'utf8',
   );
 
@@ -80,6 +85,7 @@ new Command()
   .name('create-email')
   .version('0.0.30-canary.0')
   .description('The easiest way to get started with React Email')
-  .arguments('[dir]', 'path to initialize the project')
+  .arguments('[dir]', 'Path to initialize the project')
+  .option('-t, --tag <tag>', 'Tag of React Email versions to use', 'latest')
   .action(init)
   .parse(process.argv);

--- a/packages/create-email/src/index.js
+++ b/packages/create-email/src/index.js
@@ -13,11 +13,19 @@ const getLatestVersionOfTag = async (packageName, tag) => {
     `https://registry.npmjs.org/${packageName}/${tag}`,
   );
   const data = await response.json();
+
   if (typeof data === 'string' && data.startsWith('version not found')) {
     console.error(`Tag ${tag} does not exist for ${packageName}.`);
     process.exit(1);
   }
-  return data.version;
+
+  const { version } = data;
+
+  if (!/^\d+\.\d+\.\d+.*$/.test(version)) {
+    console.error('Invalid version received, something has gone very wrong.');
+  }
+
+  return version;
 };
 
 const init = async (name, { tag }) => {

--- a/packages/create-email/src/index.spec.ts
+++ b/packages/create-email/src/index.spec.ts
@@ -26,7 +26,7 @@ describe('automatic setup', () => {
     );
   });
 
-  test.sequential('install', () => {
+  test.sequential('install', { timeout: 40_000 }, () => {
     const installProcess = spawnSync('npm', ['install'], {
       shell: true,
       cwd: path.resolve(starterPath),

--- a/packages/create-email/src/index.spec.ts
+++ b/packages/create-email/src/index.spec.ts
@@ -26,6 +26,20 @@ describe('automatic setup', () => {
     );
   });
 
+  test.sequential('install', () => {
+    const installProcess = spawnSync('npm', ['install'], {
+      shell: true,
+      cwd: path.resolve(starterPath),
+      stdio: 'pipe'
+    });
+    if (installProcess.stderr) {
+      console.log(installProcess.stderr.toString());
+    }
+    expect(installProcess.status, 'starter npm install should return 0').toBe(
+      0,
+    );
+  });
+
   test.sequential('export', () => {
     const exportProcess = spawnSync('npm', ['run export'], {
       shell: true,

--- a/packages/create-email/src/index.spec.ts
+++ b/packages/create-email/src/index.spec.ts
@@ -30,7 +30,7 @@ describe('automatic setup', () => {
     const installProcess = spawnSync('npm', ['install'], {
       shell: true,
       cwd: path.resolve(starterPath),
-      stdio: 'pipe'
+      stdio: 'pipe',
     });
     if (installProcess.stderr) {
       console.log(installProcess.stderr.toString());

--- a/packages/create-email/template/package.json
+++ b/packages/create-email/template/package.json
@@ -8,13 +8,13 @@
     "export": "email export"
   },
   "dependencies": {
-    "@react-email/components": "^0.0.36",
+    "@react-email/components": "INSERT_COMPONENTS_VERSION",
     "react-dom": "19.0.0",
     "react": "19.0.0"
   },
   "devDependencies": {
     "@types/react": "19.0.1",
     "@types/react-dom": "19.0.1",
-    "react-email": "^4.0.7"
+    "react-email": "INSERT_REACT_EMAIL_VERSION"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,43 +458,15 @@ importers:
         specifier: 6.1.2
         version: 6.1.2
     devDependencies:
-      '@react-email/components':
-        specifier: 0.0.37-canary.0
-        version: 0.0.37-canary.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: 19.0.0
         version: 19.0.0
-      react-email:
-        specifier: 4.1.0-canary.0
-        version: 4.1.0-canary.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
       typescript:
         specifier: 5.8.2
         version: 5.8.2
-
-  packages/create-email/template:
-    dependencies:
-      '@react-email/components':
-        specifier: ^0.0.36
-        version: 0.0.36(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      react:
-        specifier: 19.0.0
-        version: 19.0.0
-      react-dom:
-        specifier: 19.0.0
-        version: 19.0.0(react@19.0.0)
-    devDependencies:
-      '@types/react':
-        specifier: 19.0.1
-        version: 19.0.1
-      '@types/react-dom':
-        specifier: 19.0.1
-        version: 19.0.1
-      react-email:
-        specifier: ^4.0.7
-        version: 4.0.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
   packages/font:
     dependencies:
@@ -3423,106 +3395,6 @@ packages:
   '@radix-ui/rect@1.1.0':
     resolution: {integrity: sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==}
 
-  '@react-email/body@0.0.11':
-    resolution: {integrity: sha512-ZSD2SxVSgUjHGrB0Wi+4tu3MEpB4fYSbezsFNEJk2xCWDBkFiOeEsjTmR5dvi+CxTK691hQTQlHv0XWuP7ENTg==}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/button@0.0.19':
-    resolution: {integrity: sha512-HYHrhyVGt7rdM/ls6FuuD6XE7fa7bjZTJqB2byn6/oGsfiEZaogY77OtoLL/mrQHjHjZiJadtAMSik9XLcm7+A==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/code-block@0.0.12':
-    resolution: {integrity: sha512-Faw3Ij9+/Qwq6moWaeHnV8Hn7ekc/EqyAzPi6yUar21dhcqYugCC4Da1x4d9nA9zC0H9KU3lYVJczh8D3cA+Eg==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/code-inline@0.0.5':
-    resolution: {integrity: sha512-MmAsOzdJpzsnY2cZoPHFPk6uDO/Ncpb4Kh1hAt9UZc1xOW3fIzpe1Pi9y9p6wwUmpaeeDalJxAxH6/fnTquinA==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/column@0.0.13':
-    resolution: {integrity: sha512-Lqq17l7ShzJG/d3b1w/+lVO+gp2FM05ZUo/nW0rjxB8xBICXOVv6PqjDnn3FXKssvhO5qAV20lHM6S+spRhEwQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/components@0.0.36':
-    resolution: {integrity: sha512-VMh+OQplAnG8JMLlJjdnjt+ThJZ+JVkp0q2YMS2NEz+T88N22bLD2p7DZO0QgtNaKgumOhJI/0a2Q7VzCrwu5g==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/components@0.0.37-canary.0':
-    resolution: {integrity: sha512-luZN+zOB36YTvIt/SA3N4GsNMeonzOZsIgcBkqZO0q4vOqi0kiLbzOgztDhI9v11OnWXTikbH5rzq01M3P4xMA==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/container@0.0.15':
-    resolution: {integrity: sha512-Qo2IQo0ru2kZq47REmHW3iXjAQaKu4tpeq/M8m1zHIVwKduL2vYOBQWbC2oDnMtWPmkBjej6XxgtZByxM6cCFg==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/font@0.0.9':
-    resolution: {integrity: sha512-4zjq23oT9APXkerqeslPH3OZWuh5X4crHK6nx82mVHV2SrLba8+8dPEnWbaACWTNjOCbcLIzaC9unk7Wq2MIXw==}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/head@0.0.12':
-    resolution: {integrity: sha512-X2Ii6dDFMF+D4niNwMAHbTkeCjlYYnMsd7edXOsi0JByxt9wNyZ9EnhFiBoQdqkE+SMDcu8TlNNttMrf5sJeMA==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/heading@0.0.15':
-    resolution: {integrity: sha512-xF2GqsvBrp/HbRHWEfOgSfRFX+Q8I5KBEIG5+Lv3Vb2R/NYr0s8A5JhHHGf2pWBMJdbP4B2WHgj/VUrhy8dkIg==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/hr@0.0.11':
-    resolution: {integrity: sha512-S1gZHVhwOsd1Iad5IFhpfICwNPMGPJidG/Uysy1AwmspyoAP5a4Iw3OWEpINFdgh9MHladbxcLKO2AJO+cA9Lw==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/html@0.0.11':
-    resolution: {integrity: sha512-qJhbOQy5VW5qzU74AimjAR9FRFQfrMa7dn4gkEXKMB/S9xZN8e1yC1uA9C15jkXI/PzmJ0muDIWmFwatm5/+VA==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/img@0.0.11':
-    resolution: {integrity: sha512-aGc8Y6U5C3igoMaqAJKsCpkbm1XjguQ09Acd+YcTKwjnC2+0w3yGUJkjWB2vTx4tN8dCqQCXO8FmdJpMfOA9EQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/link@0.0.12':
-    resolution: {integrity: sha512-vF+xxQk2fGS1CN7UPQDbzvcBGfffr+GjTPNiWM38fhBfsLv6A/YUfaqxWlmL7zLzVmo0K2cvvV9wxlSyNba1aQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/markdown@0.0.14':
-    resolution: {integrity: sha512-5IsobCyPkb4XwnQO8uFfGcNOxnsg3311GRXhJ3uKv51P7Jxme4ycC/MITnwIZ10w2zx7HIyTiqVzTj4XbuIHbg==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/preview@0.0.12':
-    resolution: {integrity: sha512-g/H5fa9PQPDK6WUEG7iTlC19sAktI23qyoiJtMLqQiXFCfWeQMhqjLGKeLSKkfzszqmfJCjZtpSiKtBoOdxp3Q==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
   '@react-email/render@1.0.1':
     resolution: {integrity: sha512-W3gTrcmLOVYnG80QuUp22ReIT/xfLsVJ+n7ghSlG2BITB8evNABn1AO2rGQoXuK84zKtDAlxCdm3hRyIpZdGSA==}
     engines: {node: '>=18.0.0'}
@@ -3530,27 +3402,8 @@ packages:
       react: 19.0.0
       react-dom: 19.0.0
 
-  '@react-email/render@1.0.6':
-    resolution: {integrity: sha512-zNueW5Wn/4jNC1c5LFgXzbUdv5Lhms+FWjOvWAhal7gx5YVf0q6dPJ0dnR70+ifo59gcMLwCZEaTS9EEuUhKvQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-      react-dom: 19.0.0
-
-  '@react-email/row@0.0.12':
-    resolution: {integrity: sha512-HkCdnEjvK3o+n0y0tZKXYhIXUNPDx+2vq1dJTmqappVHXS5tXS6W5JOPZr5j+eoZ8gY3PShI2LWj5rWF7ZEtIQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
   '@react-email/section@0.0.14':
     resolution: {integrity: sha512-+fYWLb4tPU1A/+GE5J1+SEMA7/wR3V30lQ+OR9t2kAJqNrARDbMx0bLnYnR1QL5TiFRz0pCF05SQUobk6gHEDQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/section@0.0.16':
-    resolution: {integrity: sha512-FjqF9xQ8FoeUZYKSdt8sMIKvoT9XF8BrzhT3xiFKdEMwYNbsDflcjfErJe3jb7Wj/es/lKTbV5QR1dnLzGpL3w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: 19.0.0
@@ -3563,24 +3416,6 @@ packages:
 
   '@react-email/tailwind@0.0.17':
     resolution: {integrity: sha512-SVl0YO9b9/8EiNtvYnXTlimehwv6rz5v6JRb60IYqwWRRF6ZDHiLkAq/94o5SMrhLtPZWErcr4VleGumB+pFUg==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/tailwind@1.0.4':
-    resolution: {integrity: sha512-tJdcusncdqgvTUYZIuhNC6LYTfL9vNTSQpwWdTCQhQ1lsrNCEE4OKCSdzSV3S9F32pi0i0xQ+YPJHKIzGjdTSA==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/tailwind@1.1.0-canary.0':
-    resolution: {integrity: sha512-UNmZP+hwETpaI+CgNOsu0r5lu/+oHpwbkrt2ZHojrY8HIMmIqMLiN9MLIMqFAULfYO31x576smPS569xup7oQA==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: 19.0.0
-
-  '@react-email/text@0.1.1':
-    resolution: {integrity: sha512-Zo9tSEzkO3fODLVH1yVhzVCiwETfeEL5wU93jXKWo2DHoMuiZ9Iabaso3T0D0UjhrCB1PBMeq2YiejqeToTyIQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: 19.0.0
@@ -7563,16 +7398,6 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  react-email@4.0.7:
-    resolution: {integrity: sha512-XCXlfZLKv9gHd/ZwUEhCpRGc/FJLZGYczeuG1kVR/be2PlkwEB4gjX9ARBbRFv86ncbtpOu/wI6jD6kadRyAKw==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-
-  react-email@4.1.0-canary.0:
-    resolution: {integrity: sha512-15SWw4UFCHrv5+2qw9F4fLE6Ny28w6ZlQjhniHyExAC2qmCOxj1OIYXNoAr3TGD011/uM4x3n0LmwwWIAP8KfA==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -11359,120 +11184,6 @@ snapshots:
 
   '@radix-ui/rect@1.1.0': {}
 
-  '@react-email/body@0.0.11(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
-  '@react-email/button@0.0.19(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
-  '@react-email/code-block@0.0.12(react@19.0.0)':
-    dependencies:
-      prismjs: 1.30.0
-      react: 19.0.0
-
-  '@react-email/code-inline@0.0.5(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
-  '@react-email/column@0.0.13(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
-  '@react-email/components@0.0.36(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      '@react-email/body': 0.0.11(react@19.0.0)
-      '@react-email/button': 0.0.19(react@19.0.0)
-      '@react-email/code-block': 0.0.12(react@19.0.0)
-      '@react-email/code-inline': 0.0.5(react@19.0.0)
-      '@react-email/column': 0.0.13(react@19.0.0)
-      '@react-email/container': 0.0.15(react@19.0.0)
-      '@react-email/font': 0.0.9(react@19.0.0)
-      '@react-email/head': 0.0.12(react@19.0.0)
-      '@react-email/heading': 0.0.15(react@19.0.0)
-      '@react-email/hr': 0.0.11(react@19.0.0)
-      '@react-email/html': 0.0.11(react@19.0.0)
-      '@react-email/img': 0.0.11(react@19.0.0)
-      '@react-email/link': 0.0.12(react@19.0.0)
-      '@react-email/markdown': 0.0.14(react@19.0.0)
-      '@react-email/preview': 0.0.12(react@19.0.0)
-      '@react-email/render': 1.0.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@react-email/row': 0.0.12(react@19.0.0)
-      '@react-email/section': 0.0.16(react@19.0.0)
-      '@react-email/tailwind': 1.0.4(react@19.0.0)
-      '@react-email/text': 0.1.1(react@19.0.0)
-      react: 19.0.0
-    transitivePeerDependencies:
-      - react-dom
-
-  '@react-email/components@0.0.37-canary.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      '@react-email/body': 0.0.11(react@19.0.0)
-      '@react-email/button': 0.0.19(react@19.0.0)
-      '@react-email/code-block': 0.0.12(react@19.0.0)
-      '@react-email/code-inline': 0.0.5(react@19.0.0)
-      '@react-email/column': 0.0.13(react@19.0.0)
-      '@react-email/container': 0.0.15(react@19.0.0)
-      '@react-email/font': 0.0.9(react@19.0.0)
-      '@react-email/head': 0.0.12(react@19.0.0)
-      '@react-email/heading': 0.0.15(react@19.0.0)
-      '@react-email/hr': 0.0.11(react@19.0.0)
-      '@react-email/html': 0.0.11(react@19.0.0)
-      '@react-email/img': 0.0.11(react@19.0.0)
-      '@react-email/link': 0.0.12(react@19.0.0)
-      '@react-email/markdown': 0.0.14(react@19.0.0)
-      '@react-email/preview': 0.0.12(react@19.0.0)
-      '@react-email/render': 1.0.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@react-email/row': 0.0.12(react@19.0.0)
-      '@react-email/section': 0.0.16(react@19.0.0)
-      '@react-email/tailwind': 1.1.0-canary.0(react@19.0.0)
-      '@react-email/text': 0.1.1(react@19.0.0)
-      react: 19.0.0
-    transitivePeerDependencies:
-      - react-dom
-
-  '@react-email/container@0.0.15(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
-  '@react-email/font@0.0.9(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
-  '@react-email/head@0.0.12(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
-  '@react-email/heading@0.0.15(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
-  '@react-email/hr@0.0.11(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
-  '@react-email/html@0.0.11(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
-  '@react-email/img@0.0.11(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
-  '@react-email/link@0.0.12(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
-  '@react-email/markdown@0.0.14(react@19.0.0)':
-    dependencies:
-      md-to-react-email: 5.0.5(react@19.0.0)
-      react: 19.0.0
-
-  '@react-email/preview@0.0.12(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
   '@react-email/render@1.0.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       html-to-text: 9.0.5
@@ -11481,23 +11192,7 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       react-promise-suspense: 0.3.4
 
-  '@react-email/render@1.0.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      html-to-text: 9.0.5
-      prettier: 3.5.3
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-      react-promise-suspense: 0.3.4
-
-  '@react-email/row@0.0.12(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
   '@react-email/section@0.0.14(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
-  '@react-email/section@0.0.16(react@19.0.0)':
     dependencies:
       react: 19.0.0
 
@@ -11510,18 +11205,6 @@ snapshots:
       - ts-node
 
   '@react-email/tailwind@0.0.17(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
-  '@react-email/tailwind@1.0.4(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
-  '@react-email/tailwind@1.1.0-canary.0(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-
-  '@react-email/text@0.1.1(react@19.0.0)':
     dependencies:
       react: 19.0.0
 
@@ -16429,64 +16112,6 @@ snapshots:
       - uglify-js
       - utf-8-validate
       - webpack-cli
-
-  react-email@4.0.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
-    dependencies:
-      '@babel/parser': 7.24.5
-      '@babel/traverse': 7.25.6
-      chalk: 4.1.2
-      chokidar: 4.0.3
-      commander: 11.1.0
-      debounce: 2.0.0
-      esbuild: 0.25.0
-      glob: 10.3.4
-      log-symbols: 4.1.0
-      mime-types: 2.1.35
-      next: 15.2.4(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      normalize-path: 3.0.0
-      ora: 5.4.1
-      socket.io: 4.8.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@opentelemetry/api'
-      - '@playwright/test'
-      - babel-plugin-macros
-      - babel-plugin-react-compiler
-      - bufferutil
-      - react
-      - react-dom
-      - sass
-      - supports-color
-      - utf-8-validate
-
-  react-email@4.1.0-canary.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
-    dependencies:
-      '@babel/parser': 7.24.5
-      '@babel/traverse': 7.25.6
-      chalk: 4.1.2
-      chokidar: 4.0.3
-      commander: 11.1.0
-      debounce: 2.0.0
-      esbuild: 0.25.0
-      glob: 10.3.4
-      log-symbols: 4.1.0
-      mime-types: 2.1.35
-      next: 15.2.4(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      normalize-path: 3.0.0
-      ora: 5.4.1
-      socket.io: 4.8.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@opentelemetry/api'
-      - '@playwright/test'
-      - babel-plugin-macros
-      - babel-plugin-react-compiler
-      - bufferutil
-      - react
-      - react-dom
-      - sass
-      - supports-color
-      - utf-8-validate
 
   react-is@16.13.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
 packages:
   - "apps/*"
   - "packages/*"
-  - "packages/create-email/template"
   - "benchmarks/*"


### PR DESCRIPTION
This completely unties the version of other packages from the starter, as it just fetches off from the given tag. The new usage is something like

```bash 
npx create-email --tag latest/canary/alpha
```

With `latest` being used as default when `--tag` is not provided.