### PR TITLE
feat(ci): Improved version of dependency check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,38 +95,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check for pinned dependencies
-        run: |
-          node -e '
-            const fs = require("fs");
-            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
-            const errors = [];
-
-            function isPinned(version) {
-              if (version.startsWith("workspace:")) {
-                return true;
-              }
-              if (version.startsWith("npm:")) {
-                return true;
-              }
-              return /^\d+\.\d+\.\d+$|^[a-z]+:[a-z]+@\d+$/.test(version);
-            }
-
-            for (const [dep, version] of Object.entries(pkg.dependencies || {})) {
-              if (!isPinned(version)) {
-                errors.push(`Dependency "${dep}" is not pinned: "${version}"`);
-              }
-            }
-
-            for (const [dep, version] of Object.entries(pkg.devDependencies || {})) {
-              if (!isPinned(version)) {
-                errors.push(`Dev dependency "${dep}" is not pinned: "${version}"`);
-              }
-            }
-
-            if (errors.length > 0) {
-              console.error(`\n${errors.join("\n")}\n`);
-              process.exit(1);
-            } else {
-              console.log("All dependencies are pinned.");
-            }
-          '
+        run: npx tsx ./scripts/check-dependency-versions.ts

--- a/scripts/check-dependency-versions.ts
+++ b/scripts/check-dependency-versions.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs/promises';
+
+(async () => {
+  const pkg: {
+    dependencies: Record<string, string>;
+    devDependencies: Record<string, string>;
+  } = JSON.parse(await fs.readFile('package.json', 'utf8'));
+  const errors = [];
+
+  function isPinned(version: string) {
+    if (version.startsWith('workspace:')) {
+      return true;
+    }
+    if (version.startsWith('npm:')) {
+      return true;
+    }
+    if (/^\d+\.\d+\.\d+(-\S+)?$/.test(version)) {
+      return true;
+    }
+    if (/^[a-z]+:[a-z]+@\d+$/.test(version)) {
+      return true;
+    }
+    return false;
+  }
+
+  for (const [dep, version] of Object.entries(pkg.dependencies || {})) {
+    if (!isPinned(version)) {
+      errors.push(`Dependency "${dep}" is not pinned: "${version}"`);
+    }
+  }
+
+  for (const [dep, version] of Object.entries(pkg.devDependencies || {})) {
+    if (!isPinned(version)) {
+      errors.push(`Dev dependency "${dep}" is not pinned: "${version}"`);
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error(`\n${errors.join('\n')}\n`);
+    process.exit(1);
+  } else {
+    console.log('All dependencies are pinned.');
+  }
+})();


### PR DESCRIPTION
This improves it by separating the code we ran for checking into a file in `scripts/check-dependency-versions.ts`. It also
changes the regexes so that the dependency checks work with versions that have suffixes like `2.0.0-beta.1`.
