### PR TITLE
chore(react-email): Add console.error on uncaught exceptions

### DIFF
--- a/packages/react-email/src/cli/utils/preview/start-dev-server.ts
+++ b/packages/react-email/src/cli/utils/preview/start-dev-server.ts
@@ -203,10 +203,7 @@ process.on(
 );
 
 // catches uncaught exceptions
-process.on(
-  'uncaughtException',
-  (error) => {
-    console.error(error);
-    makeExitHandler({ shouldKillProcess: true, killWithErrorCode: true })
-  },
-);
+process.on('uncaughtException', (error) => {
+  console.error(error);
+  makeExitHandler({ shouldKillProcess: true, killWithErrorCode: true })();
+});

--- a/packages/react-email/src/cli/utils/preview/start-dev-server.ts
+++ b/packages/react-email/src/cli/utils/preview/start-dev-server.ts
@@ -171,7 +171,7 @@ const makeExitHandler =
       | { shouldKillProcess: false }
       | { shouldKillProcess: true; killWithErrorCode: boolean },
   ) =>
-  (_codeOrSignal: number | NodeJS.Signals) => {
+  () => {
     if (typeof devServer !== 'undefined') {
       console.log('\nshutting down dev server');
       devServer.close();
@@ -205,5 +205,8 @@ process.on(
 // catches uncaught exceptions
 process.on(
   'uncaughtException',
-  makeExitHandler({ shouldKillProcess: true, killWithErrorCode: true }),
+  (error) => {
+    console.error(error);
+    makeExitHandler({ shouldKillProcess: true, killWithErrorCode: true })
+  },
 );


### PR DESCRIPTION
For some time I noticed that when there was an uncaught exception the process would just close without any feedback. The problem
was that we were simply hooking into the `uncaughtException` event emitted on the `process` and were not writing it into the console
and instead closing the process with code 1. This PR fixes it by simply logging the error before closing the process.
