### PR TITLE
Fix: fix(caniemail-data): lowercase svg keyword in html-svg entry

### DIFF
--- a/packages/preview-server/src/actions/email-validation/caniemail-data.ts
+++ b/packages/preview-server/src/actions/email-validation/caniemail-data.ts
@@ -79458,7 +79458,7 @@ export const supportEntries: SupportEntry[] = [
     "url": "https://www.caniemail.com/features/html-svg/",
     "category": "html",
     "tags": [],
-    "keywords": "image, SVG",
+    "keywords": "image, svg",
     "last_test_date": "2020-02-06",
     "test_url": "https://www.caniemail.com/tests/images.html",
     "test_results_url": "https://app.emailonacid.com/app/acidtest/xm1T5nQ1MKtHpVSJidhagmt3Z53CjqbkMhorlvuM0Gz57/list",


### PR DESCRIPTION
Fix for the issue https://github.com/resend/react-email/issues/2193

<img width="1512" alt="Screenshot 2025-05-22 at 1 28 34 AM" src="https://github.com/user-attachments/assets/f2a223f5-27a4-4de3-a495-5bc4ba8df584" />
