### PR TITLE
FIX: fix(types): correct typo in SupportEntryCategory type

### DIFF
--- a/packages/preview-server/src/actions/email-validation/check-compatibility.ts
+++ b/packages/preview-server/src/actions/email-validation/check-compatibility.ts
@@ -68,14 +68,14 @@ export type Platform =
   | 'windows-mail'
   | 'outlook-com';
 
-export type SupportEntryCategroy = 'html' | 'css' | 'image' | 'others';
+export type SupportEntryCategory = 'html' | 'css' | 'image' | 'others';
 
 export interface SupportEntry {
   slug: string;
   title: string;
   description: string | null;
   url: string;
-  category: SupportEntryCategroy;
+  category: SupportEntryCategory;
   tags: string[];
   keywords: string | null;
   last_test_date: string;


### PR DESCRIPTION
I stomped on this typo while I was working on another thing
From `Categroy` to `Category`
