### PR TITLE
docs(readme): split build and run instructions for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,13 @@ All components were tested using the most popular email clients.
 pnpm install
 ```
 
-#### Build and run packages
+#### Build
+
+```sh
+pnpm build
+```
+
+#### Run packages
 
 ```sh
 pnpm dev


### PR DESCRIPTION
Without running the build command first, dev didn't work the first time.

<img width="1078" alt="Screenshot 2025-05-22 at 12 58 49 PM" src="https://github.com/user-attachments/assets/908e417b-f8c2-40f2-acc6-2d6939bf3a80" />

The docs already mention building and running, but with my suggestion, it's easier to copy and paste the exact commands. It's also a bit more explicit, which helps avoid confusion.
