### PR TITLE
feat(react-email, preview-server): fixed equal versions for both

### DIFF
--- a/.changeset/common-goats-find.md
+++ b/.changeset/common-goats-find.md
@@ -1,0 +1,6 @@
+---
+"@react-email/preview-server": patch
+"react-email": patch
+---
+
+Use the same version for the preview-server and react-email

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "linked": [],
+  "fixed": [["react-email", "@react-email/preview-server"]],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/packages/preview-server/_index.js
+++ b/packages/preview-server/_index.js
@@ -1,4 +1,0 @@
-/**
- * this file is just a placeholder file so that import.meta.resolve and require.resolve can properly
- * find out the path to this module. This file does not do anything nor does it need to export anything of value.
- */

--- a/packages/preview-server/index.mjs
+++ b/packages/preview-server/index.mjs
@@ -1,0 +1,16 @@
+/**
+ * this file is required so that import.meta.resolve and require.resolve can properly can find the module for this package
+ */
+import fs from "node:fs/promises";
+import url from "node:url";
+import path from "node:path";
+const filename = url.fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
+const packageJson = JSON.parse(
+  await fs.readFile(path.join(dirname, "package.json"), "utf-8"),
+);
+
+/**
+  * @type {string}
+  */
+export const version = packageJson.version;

--- a/packages/preview-server/index.mjs
+++ b/packages/preview-server/index.mjs
@@ -1,16 +1,17 @@
 /**
  * this file is required so that import.meta.resolve and require.resolve can properly can find the module for this package
  */
-import fs from "node:fs/promises";
-import url from "node:url";
-import path from "node:path";
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import url from 'node:url';
+
 const filename = url.fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
 const packageJson = JSON.parse(
-  await fs.readFile(path.join(dirname, "package.json"), "utf-8"),
+  await fs.readFile(path.join(dirname, 'package.json'), 'utf-8'),
 );
 
 /**
-  * @type {string}
-  */
+ * @type {string}
+ */
 export const version = packageJson.version;

--- a/packages/preview-server/package.json
+++ b/packages/preview-server/package.json
@@ -9,7 +9,7 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
-  "main": "./_index.js",
+  "main": "./index.mjs",
   "dependencies": {
     "@babel/core": "7.26.10",
     "@babel/parser": "^7.27.0",

--- a/packages/react-email/src/utils/get-preview-server-location.ts
+++ b/packages/react-email/src/utils/get-preview-server-location.ts
@@ -1,32 +1,51 @@
-import path from 'node:path';
-import url from 'node:url';
-import { createJiti } from 'jiti';
-import { addDevDependency } from 'nypm';
-import prompts from 'prompts';
+import path from "node:path";
+import url from "node:url";
+import { createJiti } from "jiti";
+import { addDevDependency } from "nypm";
+import prompts from "prompts";
+import { packageJson } from "./packageJson.js";
+
+const ensurePreviewServerInstalled = async (
+  message: string,
+): Promise<never> => {
+  const response = await prompts({
+    type: "confirm",
+    name: "installPreviewServer",
+    message,
+    initial: true,
+  });
+  if (response.installPreviewServer) {
+    console.log('Installing "@react-email/preview-server"');
+    await addDevDependency(
+      `@react-email/preview-server@${packageJson.version}`,
+    );
+    process.exit(0);
+  } else {
+    process.exit(0);
+  }
+};
 
 export const getPreviewServerLocation = async () => {
   const usersProject = createJiti(process.cwd());
   let previewServerLocation!: string;
   try {
     previewServerLocation = path.dirname(
-      url.parse(usersProject.esmResolve('@react-email/preview-server'), true)
+      url.parse(usersProject.esmResolve("@react-email/preview-server"), true)
         .path!,
     );
   } catch (_exception) {
-    const response = await prompts({
-      type: 'confirm',
-      name: 'installPreviewServer',
-      message:
-        'To run the preview server, the pacakge "@react-email/preview-server" must be installed. Would you like to install it?',
-      initial: true,
-    });
-    if (response.installPreviewServer) {
-      console.log('Installing "@react-email/preview-server"');
-      await addDevDependency('@react-email/preview-server');
-      process.exit(0);
-    } else {
-      process.exit(0);
-    }
+    await ensurePreviewServerInstalled(
+      'To run the preview server, the package "@react-email/preview-server" must be installed. Would you like to install it?',
+    );
   }
+  const { version } = (await import(previewServerLocation)) as {
+    version: string;
+  };
+  if (version !== packageJson.version) {
+    await ensurePreviewServerInstalled(
+      `To run the preview server, the version of "@react-email/preview-server" must match the version of "react-email" (${packageJson.version}). Would you like to install it?`,
+    );
+  }
+
   return previewServerLocation;
 };

--- a/packages/react-email/src/utils/get-preview-server-location.ts
+++ b/packages/react-email/src/utils/get-preview-server-location.ts
@@ -41,7 +41,6 @@ export const getPreviewServerLocation = async () => {
   const { version } = await usersProject.import<{
     version: string;
   }>('@react-email/preview-server');
-  console.log(version);
   if (version !== packageJson.version) {
     await ensurePreviewServerInstalled(
       `To run the preview server, the version of "@react-email/preview-server" must match the version of "react-email" (${packageJson.version}). Would you like to install it?`,

--- a/packages/react-email/src/utils/get-preview-server-location.ts
+++ b/packages/react-email/src/utils/get-preview-server-location.ts
@@ -38,9 +38,10 @@ export const getPreviewServerLocation = async () => {
       'To run the preview server, the package "@react-email/preview-server" must be installed. Would you like to install it?',
     );
   }
-  const { version } = (await import(previewServerLocation)) as {
+  const { version } = await usersProject.import<{
     version: string;
-  };
+  }>("@react-email/preview-server");
+  console.log(version);
   if (version !== packageJson.version) {
     await ensurePreviewServerInstalled(
       `To run the preview server, the version of "@react-email/preview-server" must match the version of "react-email" (${packageJson.version}). Would you like to install it?`,

--- a/packages/react-email/src/utils/get-preview-server-location.ts
+++ b/packages/react-email/src/utils/get-preview-server-location.ts
@@ -1,16 +1,16 @@
-import path from "node:path";
-import url from "node:url";
-import { createJiti } from "jiti";
-import { addDevDependency } from "nypm";
-import prompts from "prompts";
-import { packageJson } from "./packageJson.js";
+import path from 'node:path';
+import url from 'node:url';
+import { createJiti } from 'jiti';
+import { addDevDependency } from 'nypm';
+import prompts from 'prompts';
+import { packageJson } from './packageJson.js';
 
 const ensurePreviewServerInstalled = async (
   message: string,
 ): Promise<never> => {
   const response = await prompts({
-    type: "confirm",
-    name: "installPreviewServer",
+    type: 'confirm',
+    name: 'installPreviewServer',
     message,
     initial: true,
   });
@@ -30,7 +30,7 @@ export const getPreviewServerLocation = async () => {
   let previewServerLocation!: string;
   try {
     previewServerLocation = path.dirname(
-      url.parse(usersProject.esmResolve("@react-email/preview-server"), true)
+      url.parse(usersProject.esmResolve('@react-email/preview-server'), true)
         .path!,
     );
   } catch (_exception) {
@@ -40,7 +40,7 @@ export const getPreviewServerLocation = async () => {
   }
   const { version } = await usersProject.import<{
     version: string;
-  }>("@react-email/preview-server");
+  }>('@react-email/preview-server');
   console.log(version);
   if (version !== packageJson.version) {
     await ensurePreviewServerInstalled(


### PR DESCRIPTION
the demo deploy is failing because we haven't yet released an on-par version of `@react-email/preview-server` with the current `react-email` one