### PR TITLE
fix(react-email): mobile's sidebar broken in preview server

### DIFF
--- a/.changeset/famous-pants-cross.md
+++ b/.changeset/famous-pants-cross.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+fix mobile's sidebar broken in the preview server

--- a/packages/react-email/src/app/layout.tsx
+++ b/packages/react-email/src/app/layout.tsx
@@ -27,8 +27,8 @@ const RootLayout = async ({ children }: { children: React.ReactNode }) => {
       className={`${inter.variable} ${sfMono.variable} font-sans`}
       lang="en"
     >
-      <body className="relative flex h-screen flex-col bg-black text-slate-11 leading-loose selection:bg-cyan-5 selection:text-cyan-12">
-        <div className="bg-gradient-to-t from-slate-3 flex">
+      <body className="relative h-screen bg-black text-slate-11 leading-loose selection:bg-cyan-5 selection:text-cyan-12">
+        <div className="bg-gradient-to-t from-slate-3 flex flex-col">
           <EmailsProvider
             initialEmailsDirectoryMetadata={emailsDirectoryMetadata}
           >

--- a/packages/react-email/src/components/shell.tsx
+++ b/packages/react-email/src/components/shell.tsx
@@ -81,7 +81,10 @@ export const Shell = ({ children, currentEmailOpenSlug }: ShellProps) => {
             'inline-block relative overflow-hidden will-change-[width]',
             'w-full h-full',
             '[transition:width_0.2s_ease-in-out,_transform_0.2s_ease-in-out]',
-            sidebarToggled && 'lg:w-[calc(100%-16rem)]',
+            {
+              'lg:w-[calc(100%-16rem)]': sidebarToggled,
+              'opacity-0 lg:opacity-100': !sidebarToggled,
+            },
           )}
         >
           {children}


### PR DESCRIPTION
The problem was the wrapper `div` we have that didn't include the `flex-col` that we had before #2251. Another thing was the background for the floating sidebar, this PR sets the opacity of everything to 0 once the sidebar is open to give way to the gradient in the background