### PR TITLE
feat(ci): release workflow for `main`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
-name: Version
+name: Release
 on:
   push:
     branches:
       - main
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
-  version:
+  release:
     runs-on: buildjet-4vcpu-ubuntu-2204
     permissions: 
       contents: write
@@ -39,10 +39,12 @@ jobs:
         # This step errors if it is not in prerelease mode
         continue-on-error: true
         run: pnpm canary:exit
-      - name: Create Release Pull Request
+      - name: Create "Version packages" PR or publish release
         uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc
         with:
           version: pnpm run version
+          publish: pnpm run release
           title: "chore(root): Version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Sets up the automated releases workflow for all changesets coming into `main` as well. This replicates the same steps as `release-canary.yml`