### PR TITLE
fix(preview-server): range rounded borders, tearing when selecting different lines

### DIFF
--- a/packages/preview-server/src/components/code.tsx
+++ b/packages/preview-server/src/components/code.tsx
@@ -105,78 +105,82 @@ export const Code: React.FC<Readonly<CodeProps>> = ({
           />
           <div
             ref={scrollerRef}
-            className="flex max-h-[650px] h-full p-4 after:w-full after:static after:block after:h-4 after:content-[''] overflow-auto"
+            className="max-h-[650px] h-full p-4 after:w-full after:static after:block after:h-4 after:content-[''] overflow-auto"
           >
-            <div className="text-[#49494f] text-[13px] font-light font-[MonoLisa,_Menlo,_monospace]">
-              {tokens.map((_, i) => (
-                <Link
-                  id={`L${i + 1}`}
-                  key={i}
-                  href={{
-                    hash: `#L${i + 1}`,
-                    search: searchParams.toString(),
-                  }}
-                  scroll={false}
-                  className={cn(
-                    'align-middle block scroll-mt-[325px] rounded-l-sm select-none pr-3 cursor-pointer hover:text-slate-12',
-                    isHighlighting(i + 1) &&
-                      'text-cyan-11 hover:text-cyan-11 bg-cyan-5',
-                  )}
-                  type="button"
-                >
-                  {i + 1}
-                </Link>
-              ))}
-            </div>
-            <pre>
+            <div className="grid grid-cols-[auto_1fr] w-full">
               {tokens.map((line, i) => {
                 const lineProps = getLineProps({
                   line,
                   key: i,
                 });
-                return (
-                  <div
-                    {...lineProps}
-                    className={cn(
-                      'whitespace-pre flex transition-colors rounded-r-sm',
-                      isHighlighting(i + 1) && 'bg-cyan-5',
-                      {
-                        "before:mr-2 before:text-slate-11 before:content-['$']":
-                          language === 'bash' && tokens.length === 1,
-                      },
-                    )}
-                    key={i}
-                  >
-                    {line.map((token, key) => {
-                      const tokenProps = getTokenProps({
-                        token,
-                      });
-                      const isException =
-                        token.content === 'from' &&
-                        line[key + 1]?.content === ':';
-                      const newTypes = isException
-                        ? [...token.types, 'key-white']
-                        : token.types;
-                      token.types = newTypes;
+                const isHighlighted = isHighlighting(i + 1);
+                const isHighlightStart = highlight && highlight[0] === i + 1;
+                const isHighlightEnd = highlight && highlight[1] === i + 1;
 
-                      return (
-                        <Fragment key={key}>
-                          <span {...tokenProps} />
-                        </Fragment>
-                      );
-                    })}
-                  </div>
+                return (
+                  <Fragment key={i}>
+                    {/* Line number cell */}
+                    <Link
+                      id={`L${i + 1}`}
+                      href={{
+                        hash: `#L${i + 1}`,
+                        search: searchParams.toString(),
+                      }}
+                      scroll={false}
+                      aria-selected={isHighlighted}
+                      className={cn(
+                        'text-[#49494f] relative text-[13px] font-light font-[MonoLisa,_Menlo,_monospace] align-middle scroll-mt-[325px] select-none pr-3 cursor-pointer hover:text-slate-12 transition-colors',
+                        'aria-selected:text-cyan-11 aria-selected:hover:text-cyan-11 aria-selected:bg-cyan-5 [&+*]:aria-selected:bg-cyan-5',
+                        isHighlightStart && 'rounded-tl-sm',
+                        isHighlightEnd && 'rounded-bl-sm',
+                      )}
+                      type="button"
+                    >
+                      {i + 1}
+                    </Link>
+
+                    {/* Code content cell */}
+                    <div
+                      {...lineProps}
+                      className={cn(
+                        'whitespace-pre transition-colors',
+                        {
+                          "before:mr-2 before:text-slate-11 before:content-['$']":
+                            language === 'bash' && tokens.length === 1,
+                        },
+                      )}
+                    >
+                      {line.map((token, key) => {
+                        const tokenProps = getTokenProps({
+                          token,
+                        });
+                        const isException =
+                          token.content === 'from' &&
+                          line[key + 1]?.content === ':';
+                        const newTypes = isException
+                          ? [...token.types, 'key-white']
+                          : token.types;
+                        token.types = newTypes;
+
+                        return (
+                          <Fragment key={key}>
+                            <span {...tokenProps} />
+                          </Fragment>
+                        );
+                      })}
+                    </div>
+                  </Fragment>
                 );
               })}
-            </pre>
-            <div
-              className="absolute bottom-0 left-0 h-px w-[200px]"
-              style={{
-                background:
-                  'linear-gradient(90deg, rgba(56, 189, 248, 0) 0%, rgba(56, 189, 248, 0) 0%, rgba(232, 232, 232, 0.2) 33.02%, rgba(143, 143, 143, 0.6719) 64.41%, rgba(236, 72, 153, 0) 98.93%)',
-              }}
-            />
+            </div>
           </div>
+          <div
+            className="absolute bottom-0 left-0 h-px w-[200px]"
+            style={{
+              background:
+                'linear-gradient(90deg, rgba(56, 189, 248, 0) 0%, rgba(56, 189, 248, 0) 0%, rgba(232, 232, 232, 0.2) 33.02%, rgba(143, 143, 143, 0.6719) 64.41%, rgba(236, 72, 153, 0) 98.93%)',
+            }}
+          />
         </>
       )}
     </Highlight>


### PR DESCRIPTION
This changes the code block to use grids to align the elements properly, while using the fact that the line numbers and line contents are siblings to color them using classes. It also modifies the rounded borders to only be applied at the start and end of highlighted lines.

The reason for these changes is to fix the tearing that was happening when highlighting quickly various lines:

https://github.com/user-attachments/assets/c790120e-8b34-4068-8486-a0a5ccf144a4

This was happening because we were enabling the Tailwind classes from the Javascript in two different places, and React was re-rendering them with a sufficient delay to cause tearing. After this pull request it looks like this:

https://github.com/user-attachments/assets/2f711e24-792b-4a8c-8544-5d1ef75addc9

As for the rounded borders, this is the old version:

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/edab6dc8-7ad5-4c50-b7eb-073c7c6da5f7) | ![image](https://github.com/user-attachments/assets/25554110-aea0-4ced-bcee-2f8ca41c05af) | 
