### PR TITLE
feat(docs): danger callout for running `render` on the browser

### DIFF
--- a/apps/docs/utilities/render.mdx
+++ b/apps/docs/utilities/render.mdx
@@ -84,6 +84,18 @@ This will generate the following output:
 </html>
 ```
 
+<Danger>
+    When running on the browser, to properly support Safari and browsers running on iOS, you will
+    need to polyfill the [ReadableByteStreamController API](https://developer.mozilla.org/en-US/docs/Web/API/ReadableByteStreamController#browser_compatibility).
+
+    We recommend [npm i web-streams-polyfill](https://www.npmjs.com/package/web-streams-polyfill),
+    and it can be applied as follows in some sort of root file for your website:
+
+    ```jsx
+    import "web-streams-polyfill/polyfill";
+    ```
+</Danger>
+
 ## 4. Convert to Plain Text
 
 Plain text versions of emails are important because they ensure that the message can be read by the recipient even if they are unable to view the HTML version of the email.


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e686cdae-bbae-4192-bc0d-a5a31ce7109a)

Closes #1732. I'd say that it's much better for us to recommend users to polyfill this, instead of us doing it, to avoid having the package larger for the minority of use cases, since React Email is mainly meant for running in the server for sending the email templates themselves. The use of the API is also done by `react-dom`, and they themselves do not polyfill this.