### PR TITLE
feat(docs): new package mention, playground usage, simplified setup

### DIFF
--- a/apps/docs/contributing/codebase-overview.mdx
+++ b/apps/docs/contributing/codebase-overview.mdx
@@ -124,7 +124,7 @@ The CLI is built using [commander](https://www.npmjs.com/package/commander), a C
 parsing of command line arguments and ensuring that the syntax for the command is as expected.
 
 The `build`, `dev`, and `start` commands all depend on the user first installing `@react-email/preview-server`.
-installed on their side. This allows for including required dependencies like `next` as a dev
+Locally installing the preview server also includes all the required dependencies so you can run the necessary commands.
 dependency of the user and not from us.
 
 To actually ensure that `@react-email/preview-server` is installed and to import it into the CLI, we

--- a/apps/docs/contributing/codebase-overview.mdx
+++ b/apps/docs/contributing/codebase-overview.mdx
@@ -100,6 +100,7 @@ Currently, we have the following packages:
   <div>
     - [react-email](https://github.com/resend/react-email/tree/canary/packages/react-email)
       - <span className="text-xs">The package for our [email CLI](/cli)</span>
+    - [@react-email/preview-server](https://github.com/resend/react-email/tree/canary/packages/preview-server)
     - [@react-email/render](https://github.com/resend/react-email/tree/canary/packages/render)
     - [@react-email/row](https://github.com/resend/react-email/tree/canary/packages/row)
     - [@react-email/section](https://github.com/resend/react-email/tree/canary/packages/section)
@@ -119,18 +120,30 @@ you are on as well as the dependent packages. The global installation handles [v
 
 ### The React Email CLI
 
-The CLI (i.e. `packages/react-email`) is key to the best development experience with react.email, but it is complex. Here is a brief overview of the CLI.
+The CLI is built using the awesome [commander](https://www.npmjs.com/package/commander). It handles
+parsing of command line arguments and ensuring that the syntax for the command is as expected.
 
-The CLI includes two components:
-- A Next app for the `email dev` and `email build` commands
-- A [commander.js](https://www.npmjs.com/package/commander) CLI
+The `build`, `dev` and `start` commands all depend on the user having `@react-email/preview-server`
+installed on their side. This allows for including required dependencies like `next` as a dev
+dependency of the user and not from us.
 
-In the NextJS app, we include a `src/cli` directory that is not published but is compiled into a root `cli` directory. This structure provides a good developer experience as we can both share certain functions and communicate between the CLI components.
+To actually ensure that `@react-email/preview-server` is installed and to import it into the CLI, we
+use [nypm](https://www.npmjs.com/package/nypm) and [jiti](https://www.npmjs.com/package/jiti)
+respectively.
 
-We trigger rebuilds of email templates after they have been saved using the
-[chokidar](https://www.npmjs.com/package/chokidar) package
-alongside the [socket.io](https://socket.io/) package to detect file changes and send
-a message to the server to trigger a rebuild.
+Both the Preview Server and the CLI are very closely intertwined — the CLI detects changes to files
+in the user's dependency graph with [chokidar](https://www.npmjs.com/package/chokidar), and send
+that over to the Preview Server using [socket.io](https://socket.io/). Other communication of data
+like the path to the user's emails directory, are done through environment variables for when the
+Preview Server is actually started.
+
+### The Preview Server
+
+The Preview Server is a Next.js app like any other, that uses `esbuild` at runtime to bundle the
+user's email templates and then renders them using [render](/utilities/render).
+
+The Preview Server itself does not detect the changes that the user makes to their emails directory,
+rather it receives that information from the CLI with [socket.io](https://socket.io/).
 
 ## Testing
 

--- a/apps/docs/contributing/codebase-overview.mdx
+++ b/apps/docs/contributing/codebase-overview.mdx
@@ -126,7 +126,7 @@ parsing of command line arguments and ensuring that the syntax for the command i
 The `build`, `dev`, and `start` commands all depend on the user first installing `@react-email/preview-server`.
 Locally installing the preview server also includes all the required dependencies so you can run the necessary commands.
 
-To actually ensure that `@react-email/preview-server` is installed and to import it into the CLI, we
+[nypm](https://www.npmjs.com/package/nypm) and [jiti](https://www.npmjs.com/package/jiti) work together to first ensure `@react-email/preview-server` is installed and then to import it into the CLI.
 use [nypm](https://www.npmjs.com/package/nypm) and [jiti](https://www.npmjs.com/package/jiti)
 respectively.
 

--- a/apps/docs/contributing/codebase-overview.mdx
+++ b/apps/docs/contributing/codebase-overview.mdx
@@ -123,7 +123,7 @@ you are on as well as the dependent packages. The global installation handles [v
 The CLI is built using [commander](https://www.npmjs.com/package/commander), a CLI builder for node. It handles
 parsing of command line arguments and ensuring that the syntax for the command is as expected.
 
-The `build`, `dev` and `start` commands all depend on the user having `@react-email/preview-server`
+The `build`, `dev`, and `start` commands all depend on the user first installing `@react-email/preview-server`.
 installed on their side. This allows for including required dependencies like `next` as a dev
 dependency of the user and not from us.
 

--- a/apps/docs/contributing/codebase-overview.mdx
+++ b/apps/docs/contributing/codebase-overview.mdx
@@ -120,7 +120,7 @@ you are on as well as the dependent packages. The global installation handles [v
 
 ### The React Email CLI
 
-The CLI is built using the awesome [commander](https://www.npmjs.com/package/commander). It handles
+The CLI is built using [commander](https://www.npmjs.com/package/commander), a CLI builder for node. It handles
 parsing of command line arguments and ensuring that the syntax for the command is as expected.
 
 The `build`, `dev` and `start` commands all depend on the user having `@react-email/preview-server`

--- a/apps/docs/contributing/codebase-overview.mdx
+++ b/apps/docs/contributing/codebase-overview.mdx
@@ -125,7 +125,6 @@ parsing of command line arguments and ensuring that the syntax for the command i
 
 The `build`, `dev`, and `start` commands all depend on the user first installing `@react-email/preview-server`.
 Locally installing the preview server also includes all the required dependencies so you can run the necessary commands.
-dependency of the user and not from us.
 
 To actually ensure that `@react-email/preview-server` is installed and to import it into the CLI, we
 use [nypm](https://www.npmjs.com/package/nypm) and [jiti](https://www.npmjs.com/package/jiti)

--- a/apps/docs/contributing/codebase-overview.mdx
+++ b/apps/docs/contributing/codebase-overview.mdx
@@ -127,7 +127,6 @@ The `build`, `dev`, and `start` commands all depend on the user first installing
 Locally installing the preview server also includes all the required dependencies so you can run the necessary commands.
 
 [nypm](https://www.npmjs.com/package/nypm) and [jiti](https://www.npmjs.com/package/jiti) work together to first ensure `@react-email/preview-server` is installed and then to import it into the CLI.
-use [nypm](https://www.npmjs.com/package/nypm) and [jiti](https://www.npmjs.com/package/jiti)
 respectively.
 
 Both the Preview Server and the CLI are very closely intertwined — the CLI detects changes to files

--- a/apps/docs/contributing/codebase-overview.mdx
+++ b/apps/docs/contributing/codebase-overview.mdx
@@ -127,7 +127,6 @@ The `build`, `dev`, and `start` commands all depend on the user first installing
 Locally installing the preview server also includes all the required dependencies so you can run the necessary commands.
 
 [nypm](https://www.npmjs.com/package/nypm) and [jiti](https://www.npmjs.com/package/jiti) work together to first ensure `@react-email/preview-server` is installed and then to import it into the CLI.
-respectively.
 
 Both the Preview Server and the CLI are very closely intertwined — the CLI detects changes to files
 in the user's dependency graph with [chokidar](https://www.npmjs.com/package/chokidar), and send

--- a/apps/docs/contributing/codebase-overview.mdx
+++ b/apps/docs/contributing/codebase-overview.mdx
@@ -128,19 +128,16 @@ Locally installing the preview server also includes all the required dependencie
 
 [nypm](https://www.npmjs.com/package/nypm) and [jiti](https://www.npmjs.com/package/jiti) work together to first ensure `@react-email/preview-server` is installed and then to import it into the CLI.
 
-Both the Preview Server and the CLI are very closely intertwined — the CLI detects changes to files
-in the user's dependency graph with [chokidar](https://www.npmjs.com/package/chokidar), and send
-that over to the Preview Server using [socket.io](https://socket.io/). Other communication of data
-like the path to the user's emails directory, are done through environment variables for when the
-Preview Server is actually started.
+The Preview Server and the CLI work together. The CLI detects changes to files
+in the user's dependency graph with [chokidar](https://www.npmjs.com/package/chokidar) and then sends
+the updated files to the Preview Server using [socket.io](https://socket.io/). Other details, like the path to the user's emails directory, are handled through environment variables.
 
 ### The Preview Server
 
-The Preview Server is a Next.js app like any other, that uses `esbuild` at runtime to bundle the
-user's email templates and then renders them using [render](/utilities/render).
+The Preview Server is a Next.js app that uses `esbuild` at runtime to bundle the
+user's email templates and then renders them using the [render](/utilities/render) utility.
 
-The Preview Server itself does not detect the changes that the user makes to their emails directory,
-rather it receives that information from the CLI with [socket.io](https://socket.io/).
+As changes from the CLI are passed through [socket.io](https://socket.io/) to the Preview Server, the preview updates automatically.
 
 ## Testing
 

--- a/apps/docs/contributing/development-workflow/1-setup.mdx
+++ b/apps/docs/contributing/development-workflow/1-setup.mdx
@@ -33,11 +33,11 @@ To contribute to the project, you must use **Node 18** or higher.
     pnpm link ./packages/react-email/dev -g
     ```
     <Note>
-    This lets you run the CLI without having a need to rebuild the CLI.
+    This lets you run the CLI's source code with `email-dev` avoiding the need to rebuild the CLI.
     </Note>
   </Step>
 </Steps>
 
 If you plan to contribute to the docs, view our [Writing docs](/contributing/development-workflow/5-writing-docs) guide for additional setup.
 
-If you have have any trouble, please [reach out on Discord](https://discord.com/invite/n2pWEjjNnD) or consider [opening up an issue on GitHub](https://github.com/resend/react-email/issues/new?assignees=&labels=Type%3A+Bug&projects=&template=1.bug_report.yml) after reading the [issue guidelines](/contributing/opening-issues).
+If you have any trouble, please [reach out on Discord](https://discord.com/invite/n2pWEjjNnD) or consider [opening up an issue on GitHub](https://github.com/resend/react-email/issues/new?assignees=&labels=Type%3A+Bug&projects=&template=1.bug_report.yml) after reading the [issue guidelines](/contributing/opening-issues).

--- a/apps/docs/contributing/development-workflow/1-setup.mdx
+++ b/apps/docs/contributing/development-workflow/1-setup.mdx
@@ -28,13 +28,12 @@ To contribute to the project, you must use **Node 18** or higher.
     pnpm install
     ```
   </Step>
-  <Step title="Build all the packages">
+  <Step title="Link email-dev CLI globally">
     ```bash inside of react-email
-    pnpm build
+    pnpm link ./packages/react-email/dev -g
     ```
-
     <Note>
-    Building first is crucial because each package may depend on other packages, and pre-building them will ensure that you don't run into issues when developing.
+    This lets you run the CLI without having a need to rebuild the CLI.
     </Note>
   </Step>
 </Steps>

--- a/apps/docs/contributing/development-workflow/1-setup.mdx
+++ b/apps/docs/contributing/development-workflow/1-setup.mdx
@@ -33,7 +33,7 @@ To contribute to the project, you must use **Node 18** or higher.
     pnpm link ./packages/react-email/dev -g
     ```
     <Note>
-    This lets you run the CLI's source code with `email-dev` avoiding the need to rebuild the CLI.
+    Linking the CLI globally runs the CLI's source code when you use the `email-dev` command, avoiding the need to rebuild the CLI.
     </Note>
   </Step>
 </Steps>

--- a/apps/docs/contributing/development-workflow/6-editing-the-components.mdx
+++ b/apps/docs/contributing/development-workflow/6-editing-the-components.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'Using the playground'
-sidebarTitle: '6. Using the playground'
+title: 'Editing the components'
+sidebarTitle: '6. Editing the components'
 'og:image': 'https://react.email/static/covers/react-email.png'
 ---
 
-When making changes to the components, there can be a lot of added friction because of having to rebuild each component every time you want to see the results of your changes at runtime. For that reason we have a [playground](https://github.com/resend/react-email/tree/canary/playground).
+When editing components, we developed a simple [playground](https://github.com/resend/react-email/tree/canary/playground) that lets you create email template free from having to stage them and get hot reloading for when changing the components without having to rebuild any of them.
 
 ## 1. Create an email template
 
@@ -41,5 +41,4 @@ pnpm dev
 ## 3. Open in your browser
 
 Go to http://localhost:3000
-
 

--- a/apps/docs/contributing/development-workflow/6-editing-the-components.mdx
+++ b/apps/docs/contributing/development-workflow/6-editing-the-components.mdx
@@ -4,13 +4,13 @@ sidebarTitle: '6. Editing the components'
 'og:image': 'https://react.email/static/covers/react-email.png'
 ---
 
-When editing components, we developed a simple [playground](https://github.com/resend/react-email/tree/canary/playground) that lets you create email template free from having to stage them and get hot reloading for when changing the components without having to rebuild any of them.
+To facilitate developing components, use the built-in [playground](https://github.com/resend/react-email/tree/canary/playground), which automatically hot reloads when you make changes to the components during development.
 
 ## 1. Create an email template
 
-Create a new file at `playground/emails/testing.tsx` 
+Create a new file at `playground/emails/testing.tsx`
 
-```tsx emails/testing.tsx
+```tsx playground/emails/testing.tsx
 import { Html, Head, Body, Tailwind, Text } from '@react-email/components';
 
 export default function Testing() {
@@ -29,7 +29,7 @@ export default function Testing() {
 ```
 
 <Tip>
-You can use [playground/emails](https://github.com/resend/react-email/tree/canary/playground/emails) as a canvas for you to experiment with component changes, or various user use cases, and git will ignore all email templates there.
+The `.gitignore` file will ignore all changes in [playground/emails](https://github.com/resend/react-email/tree/canary/playground/emails) so you can test component changes and use cases in example templates without committing them to the repository.
 </Tip>
 
 ## 2. Run playground server

--- a/apps/docs/contributing/development-workflow/6-using-the-playground.mdx
+++ b/apps/docs/contributing/development-workflow/6-using-the-playground.mdx
@@ -1,0 +1,45 @@
+---
+title: 'Using the playground'
+sidebarTitle: '6. Using the playground'
+'og:image': 'https://react.email/static/covers/react-email.png'
+---
+
+When making changes to the components, there can be a lot of added friction because of having to rebuild each component every time you want to see the results of your changes at runtime. For that reason we have a [playground](https://github.com/resend/react-email/tree/canary/playground).
+
+## 1. Create an email template
+
+Create a new file at `playground/emails/testing.tsx` 
+
+```tsx emails/testing.tsx
+import { Html, Head, Body, Tailwind, Text } from '@react-email/components';
+
+export default function Testing() {
+  return <Tailwind>
+    <Html>
+      <Head/>
+
+      <Body className="bg-black text-white">
+        <Text className="m-0 my-4 bg-cyan-200 text-slate-800">
+          This is a testing email template.
+        </Text>
+      </Body>
+    </Html>
+  </Tailwind>;
+}
+```
+
+<Tip>
+You can use [playground/emails](https://github.com/resend/react-email/tree/canary/playground/emails) as a canvas for you to experiment with component changes, or various user use cases, and git will ignore all email templates there.
+</Tip>
+
+## 2. Run playground server
+
+```sh
+pnpm dev
+```
+
+## 3. Open in your browser
+
+Go to http://localhost:3000
+
+

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -102,7 +102,7 @@
                   "contributing/development-workflow/3-linting",
                   "contributing/development-workflow/4-building",
                   "contributing/development-workflow/5-writing-docs",
-                  "contributing/development-workflow/6-using-the-playground"
+                  "contributing/development-workflow/6-editing-the-components"
                 ]
               }
             ]

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -101,7 +101,8 @@
                   "contributing/development-workflow/2-running-tests",
                   "contributing/development-workflow/3-linting",
                   "contributing/development-workflow/4-building",
-                  "contributing/development-workflow/5-writing-docs"
+                  "contributing/development-workflow/5-writing-docs",
+                  "contributing/development-workflow/6-using-the-playground"
                 ]
               }
             ]


### PR DESCRIPTION
This updates the contributing guide according to the new changes we made to our development workflows. For starters, it adds a mention to the new `@react-email/preview-server` package and updates the way the CLI is described in the "Codebase overview".

As for the development workflows, I updated the Setup step to include linking the [email-dev](https://github.com/resend/react-email/tree/canary/packages/react-email#setting-up-the-environment) script instead of building all the packages since most of the reasons to build all packages were needing to run the `demo` which isn't really needed anymore with the playground. 

![image](https://github.com/user-attachments/assets/442360d9-3382-4706-bfe0-b361ecfeee15)

I also added in another step to the "Development Workflow" tab called "Editing components" to explain the usage of the playground

![image](https://github.com/user-attachments/assets/7b204148-dc70-4ecb-865e-f15446dd4e2a)

I haven't added any mention to how to run the preview server, and I'm hoping that #2344 would circumvent needing to do that. Open to any ideas on how to include in here without having too many steps on the workflow!