### PR TITLE
fix(react-email): path resolution done wrong for Windows

### DIFF
--- a/packages/react-email/src/utils/get-preview-server-location.ts
+++ b/packages/react-email/src/utils/get-preview-server-location.ts
@@ -30,8 +30,7 @@ export const getPreviewServerLocation = async () => {
   let previewServerLocation!: string;
   try {
     previewServerLocation = path.dirname(
-      url.parse(usersProject.esmResolve('@react-email/preview-server'), true)
-        .path!,
+      url.fileURLToPath(usersProject.esmResolve('@react-email/preview-server')),
     );
   } catch (_exception) {
     await ensurePreviewServerInstalled(


### PR DESCRIPTION
Closes #2341. The logs from the user were:

```zig
$ email dev
Error: Cannot find module 'next'
Require stack:
- \G:\react-email-starter\node_modules\@react-email\preview-server
    at Function._resolveFilename (node:internal/modules/cjs/loader:1401:15)
    at Function.resolve (node:internal/modules/helpers:145:19)
    at jitiResolve (G:\react-email-starter\node_modules\jiti\dist\jiti.cjs:1:187220)
    at jitiRequire (G:\react-email-starter\node_modules\jiti\dist\jiti.cjs:1:189288)
    at Function.import (G:\react-email-starter\node_modules\jiti\dist\jiti.cjs:1:199778)
    at startDevServer (file:///G:/react-email-starter/node_modules/react-email/dist/index.js:936:55)
    at async Command.dev (file:///G:/react-email-starter/node_modules/react-email/dist/index.js:1135:24) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '\\G:\\react-email-starter\\node_modules\\@react-email\\preview-server'
  ]
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

As you can see, it fails in a `require` corresponding to the following line of code when tracing back to the source code frmo the compiled output:

 https://github.com/resend/react-email/blob/cdff581c8d352076bb2e89febf05adc04eb1f142/packages/react-email/src/utils/preview/start-dev-server.ts#L47-L47
 
 The problem was that, on Windows, the `url.parse(...).path` done to the `file://...` URL coming from `esmResolve` would end up leaving a trailing `/` at the start, which you can also see from the stacktrace. This ended up breaking both the require for `next` as well as breaking the path for when starting the `next` start server later on.
 
 The fix for this was using `url.fileURLToPath` instead of `url.parse(...).path`. I also noted the same problem when using `new URL(...).pathname` and am not quite sure why, but the recommendation for usage seems to be `url.fileURLToPath` so we'll keep that. 

## How to test this

1. Checkout the branch for the pull request
2. Have [email-dev](https://github.com/resend/react-email/tree/canary/packages/react-email/dev) linked globally
3. Run `email-dev dev` on any React Email project on a Windows machine
4. Go to http://localhost:3000 