### PR TITLE
fix(preview-server): symlinked email templates wrongly handled

### DIFF
--- a/packages/preview-server/src/utils/esbuild/renderring-utilities-exporter.ts
+++ b/packages/preview-server/src/utils/esbuild/renderring-utilities-exporter.ts
@@ -16,14 +16,15 @@ import { escapeStringForRegex } from './escape-string-for-regex';
  */
 export const renderingUtilitiesExporter = (emailTemplates: string[]) => ({
   name: 'rendering-utilities-exporter',
-  setup: (b: PluginBuild) => {
+  setup: async (b: PluginBuild) => {
+    const filterOptions = await Promise.all(
+      emailTemplates.map(async (emailPath) =>
+        escapeStringForRegex(await fs.realpath(emailPath)),
+      ),
+    );
     b.onLoad(
       {
-        filter: new RegExp(
-          emailTemplates
-            .map((emailPath) => escapeStringForRegex(emailPath))
-            .join('|'),
-        ),
+        filter: new RegExp(filterOptions.join('|')),
       },
       async ({ path: pathToFile }) => {
         return {


### PR DESCRIPTION
Closes #1865. The original problem there was something else that seems to not be present anymore, but there was still an error when trying to render an email template that was a symlink.

<img width="1894" height="1359" alt="Image" src="https://github.com/user-attachments/assets/93b06b2c-80be-40db-b59a-28fa3db17861" />

The problem was that esbuild itself resolves the symlinks properly, and the filter Regex for our plugin was still filtering out for the link file instead of for the target. This pull request fixes that by using `fs.realpath` before actually using the value into the email template.

## How to test

> Recommend giving a read to https://github.com/resend/react-email/blob/canary/playground/README.md

1. Create a new email template at `packages/preview-server/emails/target.tsx`
	```jsx
	export default function EmailTemplate() {
	  return <h1>this is a test</h1>;
	}
    ```
2. Create a symlink to the target `ln -Ts packages/preview-server/emails/target.tsx link.tsx`
3. Run `pnpm dev` in `packages/preview-server`
4. Open http://localhost:3000/preview/link and http://localhost:3000/preview/target and have no errors
