### PR TITLE
fix(preview-server): compatibility checker can't find config when inlining pixel based preset

### DIFF
--- a/.changeset/kind-experts-vanish.md
+++ b/.changeset/kind-experts-vanish.md
@@ -1,0 +1,5 @@
+---
+"@react-email/preview-server": patch
+---
+
+improved method of resolving tailwind configs when checking compatibility

--- a/packages/preview-server/src/utils/caniemail/tailwind/get-tailwind-config.spec.ts
+++ b/packages/preview-server/src/utils/caniemail/tailwind/get-tailwind-config.spec.ts
@@ -1,0 +1,44 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { parse } from '@babel/parser';
+import { pixelBasedPreset } from '@react-email/components';
+import { getTailwindConfig } from './get-tailwind-config';
+
+describe('getTailwindConfig()', () => {
+  it("should work on the demo's Vercel Invite template", async () => {
+    const sourcePath = path.resolve(
+      __dirname,
+      '../../../../../../apps/demo/emails/notifications/vercel-invite-user.tsx',
+    );
+    const sourceCode = await fs.readFile(sourcePath, 'utf8');
+    const ast = parse(sourceCode, {
+      strictMode: false,
+      errorRecovery: true,
+      sourceType: 'unambiguous',
+      plugins: ['jsx', 'typescript', 'decorators'],
+    });
+
+    expect(await getTailwindConfig(sourceCode, ast, sourcePath)).toEqual({
+      presets: [pixelBasedPreset],
+    });
+  });
+
+  it('should work with email templates that import the tailwind config', async () => {
+    const sourcePath = path.resolve(
+      __dirname,
+      './tests/dummy-email-template.tsx',
+    );
+    const sourceCode = await fs.readFile(sourcePath, 'utf8');
+    const ast = parse(sourceCode, {
+      strictMode: false,
+      errorRecovery: true,
+      sourceType: 'unambiguous',
+      plugins: ['jsx', 'typescript', 'decorators'],
+    });
+
+    expect(await getTailwindConfig(sourceCode, ast, sourcePath)).toEqual({
+      theme: {},
+      presets: [pixelBasedPreset],
+    });
+  });
+});

--- a/packages/preview-server/src/utils/caniemail/tailwind/get-tailwind-config.ts
+++ b/packages/preview-server/src/utils/caniemail/tailwind/get-tailwind-config.ts
@@ -2,12 +2,12 @@ import path from 'node:path';
 import type { Node } from '@babel/traverse';
 import traverse from '@babel/traverse';
 import * as esbuild from 'esbuild';
+import type { RawSourceMap } from 'source-map-js';
 import type { Config as TailwindOriginalConfig } from 'tailwindcss';
 import type { AST } from '../../../actions/email-validation/check-compatibility';
+import { improveErrorWithSourceMap } from '../../improve-error-with-sourcemap';
 import { isErr } from '../../result';
 import { runBundledCode } from '../../run-bundled-code';
-import type { RawSourceMap } from 'source-map-js';
-import { improveErrorWithSourceMap } from '../../improve-error-with-sourcemap';
 
 export type TailwindConfig = Pick<
   TailwindOriginalConfig,

--- a/packages/preview-server/src/utils/caniemail/tailwind/get-tailwind-config.ts
+++ b/packages/preview-server/src/utils/caniemail/tailwind/get-tailwind-config.ts
@@ -101,8 +101,6 @@ export { reactEmailTailwindConfigInternal };`,
     sourceMap.sources = sourceMap.sources.map((source) =>
       path.resolve(sourceMapFile.path, '..', source),
     );
-    console.log(sourceMap.sourceRoot);
-    console.log(sourceMap.sources);
     const errorObject = improveErrorWithSourceMap(
       configModule.error as Error,
       filepath,

--- a/packages/preview-server/src/utils/caniemail/tailwind/get-tailwind-config.ts
+++ b/packages/preview-server/src/utils/caniemail/tailwind/get-tailwind-config.ts
@@ -23,8 +23,6 @@ export type TailwindConfig = Pick<
   | 'plugins'
 >;
 
-type ImportDeclaration = Node & { type: 'ImportDeclaration' };
-
 export const getTailwindConfig = async (
   sourceCode: string,
   ast: AST,
@@ -100,7 +98,8 @@ export { reactEmailTailwindConfigInternal };`,
     configModule.value !== null &&
     'reactEmailTailwindConfigInternal' in configModule.value
   ) {
-    return configModule.value.reactEmailTailwindConfigInternal as TailwindConfig;
+    return configModule.value
+      .reactEmailTailwindConfigInternal as TailwindConfig;
   }
 
   throw new Error(
@@ -112,27 +111,6 @@ export { reactEmailTailwindConfigInternal };`,
       },
     },
   );
-};
-
-const getImportWithGivenDefaultSpecifier = (
-  ast: AST,
-  specifierName: string,
-) => {
-  let importNode: ImportDeclaration | undefined;
-  traverse(ast, {
-    ImportDeclaration(nodePath) {
-      if (
-        nodePath.node.specifiers.some(
-          (specifier) =>
-            specifier.type === 'ImportDefaultSpecifier' &&
-            specifier.local.name === specifierName,
-        )
-      ) {
-        importNode = nodePath.node;
-      }
-    },
-  });
-  return importNode;
 };
 
 type JSXAttribute = Node & { type: 'JSXAttribute' };

--- a/packages/preview-server/src/utils/caniemail/tailwind/get-tailwind-config.ts
+++ b/packages/preview-server/src/utils/caniemail/tailwind/get-tailwind-config.ts
@@ -123,7 +123,7 @@ export { reactEmailTailwindConfigInternal };`,
   }
 
   throw new Error(
-    `Could not read Tailwind config at ${filepath} because it doesn't have a default export in it.`,
+    'Could not get the Tailwind config, this is likely a bug, please file an issue.',
     {
       cause: {
         configModule,

--- a/packages/preview-server/src/utils/caniemail/tailwind/get-tailwind-config.ts
+++ b/packages/preview-server/src/utils/caniemail/tailwind/get-tailwind-config.ts
@@ -31,14 +31,14 @@ export const getTailwindConfig = async (
   const configAttribute = getTailwindConfigNode(ast);
 
   if (configAttribute) {
-    const configObjectExpression =
+    const configExpressionValue =
       configAttribute.value?.type === 'JSXExpressionContainer'
         ? configAttribute.value.expression
         : undefined;
-    if (configObjectExpression?.start && configObjectExpression.end) {
+    if (configExpressionValue?.start && configExpressionValue.end) {
       const configSourceValue = sourceCode.slice(
-        configObjectExpression.start,
-        configObjectExpression.end,
+        configExpressionValue.start,
+        configExpressionValue.end,
       );
 
       try {

--- a/packages/preview-server/src/utils/caniemail/tailwind/tests/dummy-email-template.tsx
+++ b/packages/preview-server/src/utils/caniemail/tailwind/tests/dummy-email-template.tsx
@@ -1,0 +1,10 @@
+import { Tailwind } from '@react-email/components';
+import tailwindConfig from './tailwind.config';
+
+export default function EmailTemplate() {
+  return (
+    <Tailwind config={tailwindConfig}>
+      <div className="bg-red-400 w-20" />
+    </Tailwind>
+  );
+}

--- a/packages/preview-server/src/utils/caniemail/tailwind/tests/tailwind.config.ts
+++ b/packages/preview-server/src/utils/caniemail/tailwind/tests/tailwind.config.ts
@@ -1,0 +1,6 @@
+import { pixelBasedPreset, type TailwindConfig } from '@react-email/components';
+
+export default {
+  theme: {},
+  presets: [pixelBasedPreset],
+} satisfies TailwindConfig;


### PR DESCRIPTION
For background, the compatibility checker (caniemail) tries to find and get the Tailwind config defined by the user in the Tailwind element `<Tailwind config={...}>`.

Noticed that the warning from this piece of code:

https://github.com/resend/react-email/blob/b2407a1156d0251cfe466a159306c47d3bcfcfae/packages/preview-server/src/utils/caniemail/tailwind/get-tailwind-config.ts#L66-L69

was happening when building the demo, even if it doesn't fail, and I realized we could just not have this at all by just unifying the methods we have for resolving the tailwind config for the email template into bundling with esbuild.

What this pull request does is simply bundle the source code of the email template while exporting the exact source code in the expression inside the `<Tailwind config={...}>` config property and then just bundle it, run it, and get the exported value. The function to run is the same as it was already for when there's a separate file for the tailwind config, and so it doesn't change much except for making the original function more generic.

The pull request also adds two tests for when the user has inlined their tailwind config, and for when the user has a separate file for it and imports it in.