### PR TITLE
fix(react-email): next import breaking when done a second time

### DIFF
--- a/packages/react-email/src/utils/preview/start-dev-server.ts
+++ b/packages/react-email/src/utils/preview/start-dev-server.ts
@@ -43,8 +43,9 @@ export const startDevServer = async (
   const previewServerLocation = await getPreviewServerLocation();
   const previewServer = createJiti(previewServerLocation);
 
-  const { default: next } =
-    await previewServer.import<typeof import('next')>('next');
+  const next = await previewServer.import<typeof import('next')>('next', {
+    default: true,
+  });
 
   devServer = http.createServer((req, res) => {
     if (!req.url) {


### PR DESCRIPTION
For some background, we have a separate package [@react-email/preview-server](https://github.com/resend/react-email/tree/canary/packages/preview-server) for the preview server meant to be installed as `devDependency` by the user and it is built with Next.js. To actually run the preview server, the `next` package is actually required and because of that, for reasons of reducing production dependency sizes, we only have it inside of `@react-email/preview-server`. Because of that, we use [jiti](https://github.com/unjs/jiti) to actually import the `next` package from inside `@react-email/preview-server`.

Closes #2356. After debugging for a moment, I noticed that the jiti import for `next` was coming in as `undefined` when it ran a second time. After taking a look into the documentation from [jiti](https://github.com/unjs/jiti#programmatic):

> If you need the default export of module, you can use `jiti.import(id, { default: true })` as shortcut to `mod?.default ?? mod`.
> ```js
> // shortcut to mod?.default ?? mod
> const modDefault = await jiti.import("./path/to/file.ts", { default: true });
> ```

and after switching to enabling that, it works just fine, without having to destructure to `.default`.

## How to test this

1. Run `pnpm dev` inside `apps/demo` once
2. Run `pnpm dev` inside `apps/demo` again and not error