### PR TITLE
fix(docs): fix broken url in `Codebase Overview` documentation  

### DIFF
--- a/apps/docs/contributing/codebase-overview.mdx
+++ b/apps/docs/contributing/codebase-overview.mdx
@@ -27,7 +27,7 @@ After cloning the [React Email repository](https://github.com/resend/react-email
       <td>
         Here you can find all of the apps related to our online presence, like:
         - this documentation (under [apps/docs](https://github.com/resend/react-email/tree/canary/apps/docs)),
-        - the demo emails we have on [demo.react.email](https://demo.react.email/preview/vercel-invite-user.tsx)
+        - the demo emails we have on [demo.react.email](https://demo.react.email/preview/notifications/vercel-invite-user)
           (under [apps/demo](https://github.com/resend/react-email/tree/canary/apps/demo))
         - the Next app we have for our landing page on [react.email](https://react.email) (under [apps/web](https://github.com/resend/react-email/tree/canary/apps/web))
       </td>


### PR DESCRIPTION
Fixes #2391

Before (broken url) : 


https://github.com/user-attachments/assets/773d1588-c7b1-4061-b8d2-7800f38cbc03


After : 



https://github.com/user-attachments/assets/d775a0bc-926b-4390-b874-73da87de70eb


