### PR TITLE
chore(preview-server): use unformatted markup for sending and preview

### DIFF
--- a/packages/preview-server/src/actions/render-email-by-path.tsx
+++ b/packages/preview-server/src/actions/render-email-by-path.tsx
@@ -31,8 +31,8 @@ export interface RenderedEmailMetadata {
 export type EmailRenderingResult =
   | RenderedEmailMetadata
   | {
-      error: ErrorObject;
-    };
+    error: ErrorObject;
+  };
 
 const cache = new Map<string, EmailRenderingResult>();
 
@@ -86,18 +86,21 @@ export const renderEmailByPath = async (
   const EmailComponent = Email as React.FC;
   try {
     const element = createElement(EmailComponent, previewProps);
-    const markupWithReferences = await renderWithReferences(element, {
-      pretty: true,
-    });
-    const prettyMarkup = await render(element, {
-      pretty: true,
-    });
-    const markup = await render(element, {
-      pretty: false,
-    });
-    const plainText = await render(element, {
-      plainText: true,
-    });
+    const [markupWithReferences, prettyMarkup, markup, plainText] =
+      await Promise.all([
+        renderWithReferences(element, {
+          pretty: true,
+        }),
+        render(element, {
+          pretty: true,
+        }),
+        render(element, {
+          pretty: false,
+        }),
+        render(element, {
+          plainText: true,
+        }),
+      ]);
 
     const reactMarkup = await fs.promises.readFile(emailPath, 'utf-8');
 

--- a/packages/preview-server/src/actions/render-email-by-path.tsx
+++ b/packages/preview-server/src/actions/render-email-by-path.tsx
@@ -31,8 +31,8 @@ export interface RenderedEmailMetadata {
 export type EmailRenderingResult =
   | RenderedEmailMetadata
   | {
-    error: ErrorObject;
-  };
+      error: ErrorObject;
+    };
 
 const cache = new Map<string, EmailRenderingResult>();
 

--- a/packages/preview-server/src/actions/render-email-by-path.tsx
+++ b/packages/preview-server/src/actions/render-email-by-path.tsx
@@ -17,6 +17,7 @@ import { registerSpinnerAutostopping } from '../utils/register-spinner-autostopp
 import type { ErrorObject } from '../utils/types/error-object';
 
 export interface RenderedEmailMetadata {
+  prettyMarkup: string;
   markup: string;
   /**
    * HTML markup with `data-source-file` and `data-source-line` attributes pointing to the original
@@ -88,8 +89,11 @@ export const renderEmailByPath = async (
     const markupWithReferences = await renderWithReferences(element, {
       pretty: true,
     });
-    const markup = await render(element, {
+    const prettyMarkup = await render(element, {
       pretty: true,
+    });
+    const markup = await render(element, {
+      pretty: false,
     });
     const plainText = await render(element, {
       plainText: true,
@@ -112,6 +116,7 @@ export const renderEmailByPath = async (
     });
 
     const renderingResult: RenderedEmailMetadata = {
+      prettyMarkup,
       // This ensures that no null byte character ends up in the rendered
       // markup making users suspect of any issues. These null byte characters
       // only seem to happen with React 18, as it has no similar incident with React 19.

--- a/packages/preview-server/src/app/preview/[...slug]/page.tsx
+++ b/packages/preview-server/src/app/preview/[...slug]/page.tsx
@@ -71,7 +71,7 @@ This is most likely not an issue with the preview server. Maybe there was a typo
       });
     }
     const lintingSources = getLintingSources(
-      serverEmailRenderingResult.markup,
+      serverEmailRenderingResult.prettyMarkup,
       '',
     );
     lintingRows = [];
@@ -103,7 +103,7 @@ This is most likely not an issue with the preview server. Maybe there was a typo
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        html: serverEmailRenderingResult.markup,
+        html: serverEmailRenderingResult.prettyMarkup,
         plainText: serverEmailRenderingResult.plainText,
       }),
     });

--- a/packages/preview-server/src/app/preview/[...slug]/preview.tsx
+++ b/packages/preview-server/src/app/preview/[...slug]/preview.tsx
@@ -191,7 +191,7 @@ const Preview = ({ emailTitle, className, ...props }: PreviewProps) => {
                         },
                         {
                           language: 'markup',
-                          content: renderedEmailMetadata.markup,
+                          content: renderedEmailMetadata.prettyMarkup,
                         },
                         {
                           language: 'markdown',

--- a/packages/preview-server/src/components/toolbar.tsx
+++ b/packages/preview-server/src/components/toolbar.tsx
@@ -41,13 +41,13 @@ const ToolbarInner = ({
   serverSpamCheckingResult,
   serverCompatibilityResults,
 
-  markup,
+  prettyMarkup,
   reactMarkup,
   plainText,
   emailPath,
   emailSlug,
 }: ToolbarProps & {
-  markup: string;
+  prettyMarkup: string;
   reactMarkup: string;
   plainText: string;
   emailSlug: string;
@@ -75,7 +75,7 @@ const ToolbarInner = ({
     );
   const [spamCheckingResult, { load: loadSpamChecking, loading: spamLoading }] =
     useSpamAssassin({
-      markup,
+      markup: prettyMarkup,
       plainText,
 
       initialResult: serverSpamCheckingResult ?? cachedSpamCheckingResult,
@@ -85,7 +85,7 @@ const ToolbarInner = ({
     LintingRow[]
   >(`linter-${emailSlug.replaceAll('/', '-')}`);
   const [lintingRows, { load: loadLinting, loading: lintLoading }] = useLinter({
-    markup,
+    markup: prettyMarkup,
 
     initialRows: serverLintingRows ?? cachedLintingRows,
   });
@@ -336,13 +336,13 @@ export const Toolbar = ({
     React.use(PreviewContext)!;
 
   if (renderedEmailMetadata === undefined) return null;
-  const { markup, plainText, reactMarkup } = renderedEmailMetadata;
+  const { prettyMarkup, plainText, reactMarkup } = renderedEmailMetadata;
 
   return (
     <ToolbarInner
       emailPath={emailPath}
       emailSlug={emailSlug}
-      markup={markup}
+      prettyMarkup={prettyMarkup}
       reactMarkup={reactMarkup}
       plainText={plainText}
       serverLintingRows={serverLintingRows}


### PR DESCRIPTION
After considering #1847 carefully, we've decided we're going to not provide a way to format templates anymore in the future, which will mean we'll only format the HTML for viewing in the preview server, and probably also for `email export`.

To actually deal with #1847, this changed it so that the markup used for the iframe, and for sending the email template are not formatted at all. This does fix the issue, and users should not format if they don't really need to, especially if they're sending emails which means there's going to be unnecessary overhead.

Closes #1847 