### PR TITLE
chore(deps): revert update of changesets/action

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -44,7 +44,7 @@ jobs:
         continue-on-error: true
         run: pnpm canary:enter
       - name: Create "Version packages" PR or publish release
-        uses: changesets/action@04d574e831923498156e0b2b93152878063203a3
+        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc
         with:
           version: pnpm run version
           publish: pnpm run release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         continue-on-error: true
         run: pnpm canary:exit
       - name: Create "Version packages" PR or publish release
-        uses: changesets/action@04d574e831923498156e0b2b93152878063203a3
+        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc
         with:
           version: pnpm run version
           publish: pnpm run release


### PR DESCRIPTION
This reverts commit c85be9f5b38b7b1dc84d30f43479b1c32b5d364c. The new version of the action (#2400) seems to be breaking: 

https://github.com/resend/react-email/actions/runs/16677320246/job/47207463679

