### PR TITLE
feat(docs): cite `toPlainText` on documentation

### DIFF
--- a/apps/docs/utilities/render.mdx
+++ b/apps/docs/utilities/render.mdx
@@ -104,13 +104,16 @@ This is important because not all email clients and devices can display HTML ema
 
 Here's how to convert a React component into plain text.
 
+<Warning>
+The `plainText` option in the `render` function is deprecated since `@react-email/render@1.2.0`. Use the `toPlainText` function instead.
+</Warning>
+
 ```jsx
 import { MyTemplate } from './email';
-import { render } from '@react-email/render';
+import { toPlainText, render } from '@react-email/render';
 
-const text = await render(<MyTemplate />, {
-  plainText: true,
-});
+const html = await render(<MyTemplate />);
+const text = toPlainText(html);
 
 console.log(text);
 ```
@@ -130,7 +133,7 @@ Click me [https://example.com]
 <ResponseField name="pretty" type="boolean" deprecated>
   Beautify HTML output
 </ResponseField>
-<ResponseField name="plainText" type="boolean">
+<ResponseField name="plainText" type="boolean" deprecated>
   Generate plain text version
 </ResponseField>
 <ResponseField name="htmlToTextOptions" type="HtmlToTextOptions">


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

Following up with the new `toPlainText` utility function for generating plain text versions of HTML (#2412), this PR updates the documentation example to replace the deprecated function in favor of the new one.

I've also added a callout banner mentioning the version of the deprecation instructing users to migrate to the new one.