### PR TITLE
fix: builds errors with esbuild and react-dom@18

### DIFF
--- a/.changeset/shy-moons-smell.md
+++ b/.changeset/shy-moons-smell.md
@@ -1,0 +1,5 @@
+---
+"@react-email/render": patch
+---
+
+fix builds failing with esbuild and react-dom@18

--- a/packages/render/src/edge/import-react-dom.tsx
+++ b/packages/render/src/edge/import-react-dom.tsx
@@ -1,8 +1,11 @@
-export const importReactDOM = async () => {
-  try {
-    return await import('react-dom/server.edge');
-  } catch (_exception) {
-    // This ensures that we still have compatibiltity with React 18, which doesn't have the `edge` conditional export.
-    return await import('react-dom/server');
-  }
+export const importReactDOM = () => {
+  // We don't use async here because tsup converts it to a generator syntax 
+  // that esbuild doesn't understand as dealing with the import failing during
+  // bundling: https://github.com/evanw/esbuild/issues/3216#issuecomment-1628913722
+  return import('react-dom/server.edge').catch(
+    () =>
+      // This ensures that we still have compatibility with React 18, 
+      // which doesn't have the `.edge` export.
+      import('react-dom/server'),
+  );
 };

--- a/packages/render/src/edge/import-react-dom.tsx
+++ b/packages/render/src/edge/import-react-dom.tsx
@@ -1,10 +1,10 @@
 export const importReactDom = () => {
-  // We don't use async here because tsup converts it to a generator syntax 
+  // We don't use async here because tsup converts it to a generator syntax
   // that esbuild doesn't understand as dealing with the import failing during
   // bundling: https://github.com/evanw/esbuild/issues/3216#issuecomment-1628913722
   return import('react-dom/server.edge').catch(
     () =>
-      // This ensures that we still have compatibility with React 18, 
+      // This ensures that we still have compatibility with React 18,
       // which doesn't have the `.edge` export.
       import('react-dom/server'),
   );

--- a/packages/render/src/edge/import-react-dom.tsx
+++ b/packages/render/src/edge/import-react-dom.tsx
@@ -1,4 +1,4 @@
-export const importReactDOM = () => {
+export const importReactDom = () => {
   // We don't use async here because tsup converts it to a generator syntax 
   // that esbuild doesn't understand as dealing with the import failing during
   // bundling: https://github.com/evanw/esbuild/issues/3216#issuecomment-1628913722

--- a/packages/render/src/edge/render.tsx
+++ b/packages/render/src/edge/render.tsx
@@ -3,15 +3,15 @@ import { pretty } from '../node';
 import type { Options } from '../shared/options';
 import { readStream } from '../shared/read-stream.browser';
 import { toPlainText } from '../shared/utils/to-plain-text';
-import { importReactDOM } from './import-react-dom';
+import { importReactDom } from './import-react-dom';
 
 export const render = async (
   element: React.ReactElement,
   options?: Options,
 ) => {
   const suspendedElement = <Suspense>{element}</Suspense>;
-  const reactDOMServer = await importReactDOM().then(
-    // This is beacuse react-dom/server is CJS
+  const reactDOMServer = await importReactDom().then(
+    // This is because react-dom/server is CJS
     (m) => m.default,
   );
 


### PR DESCRIPTION
This is meant to fix an issue similar to https://github.com/resend/resend-node/issues/587. Esbuild bundling always tries to bundle things imported dynamically too, and because of that, it also errors if it doesn't find the thing being imported. This is bad on our side because we rely on it failing, and we treat those cases.

At the same time, esbuild seems to have heuristics (https://github.com/evanw/esbuild/issues/3216#issuecomment-1628913722) to deal with this sort of use case in that it checks for there being a async-try-catch block or a `.catch` function call to not error during bundling. The heuristic doesn't work in our code because `tsup`, after building, uses a different kind of generator syntax to handle async properly, which means that esbuild doesn't detect it.

To avoid this, I just used a `catch` instead of an async-try-catch block.

On a reproduction project I was able to get the error below, and after installing [the preview version](https://github.com/resend/react-email/pull/2436#issuecomment-3258251159), it's started working.

```zig
✘ [ERROR] Could not resolve "react-dom/server.edge"

    node_modules/@react-email/render/dist/edge/index.mjs:160:24:
      160 │     return yield import("react-dom/server.edge");
          ╵                         ~~~~~~~~~~~~~~~~~~~~~~~

  The path "./server.edge" is not exported by package "react-dom":

    node_modules/react-dom/package.json:39:13:
      39 │   "exports": {
         ╵              ^

  You can mark the path "react-dom/server.edge" as external to exclude it from the bundle, which
  will remove this error and leave the unresolved path in the bundle. You can also add ".catch()"
  here to handle this failure at run-time instead of bundle-time.
```

This is also an issue that we had mentioned [on Plain](https://app.plain.com/workspace/w_01GVPAVT3KDHW3F3MWKNBDAYBV/thread/th_01K3ZX0DQ5V4MJC1FDRACYGCR6?entryId=t_01K43DD9JJ8DXYW53XDCHNQ4V8).
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes esbuild build failures with react-dom@18 by updating importReactDOM to use a promise-based dynamic import with a fallback. Avoids async/await so tsup doesn’t emit generator syntax that breaks esbuild, and keeps compatibility by falling back to react-dom/server for React 18.

<!-- End of auto-generated description by cubic. -->

