### PR TITLE
fix: titles for version bump pull requests

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -43,12 +43,12 @@ jobs:
         # This step errors if it is already in prerelease mode
         continue-on-error: true
         run: pnpm canary:enter
-      - name: Create "Version packages" PR or publish release
+      - name: Create "version packages" pull request or publish release
         uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc
         with:
           version: pnpm run version
           publish: pnpm run release
-          title: "chore(root): Version packages"
+          title: "chore(root): version packages (canary)"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,12 @@ jobs:
         # This step errors if it is not in prerelease mode
         continue-on-error: true
         run: pnpm canary:exit
-      - name: Create "Version packages" PR or publish release
+      - name: Create "version packages" pull request or publish release
         uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc
         with:
           version: pnpm run version
           publish: pnpm run release
-          title: "chore(root): Version packages"
+          title: "chore(root): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Standardized version bump pull request titles in release and canary workflows for consistency. Titles now use "chore(root): version packages" (and "(canary)" for canary), and the step label spells out "pull request."

<!-- End of auto-generated description by cubic. -->

