### PR TITLE
fix: data-source-* attributes in HTML code view

### DIFF
--- a/.changeset/open-queens-sniff.md
+++ b/.changeset/open-queens-sniff.md
@@ -1,0 +1,5 @@
+---
+"@react-email/preview-server": patch
+---
+
+fix data-source-\* attributes in the html code view

--- a/packages/preview-server/src/actions/render-email-by-path.tsx
+++ b/packages/preview-server/src/actions/render-email-by-path.tsx
@@ -31,8 +31,8 @@ export interface RenderedEmailMetadata {
 export type EmailRenderingResult =
   | RenderedEmailMetadata
   | {
-      error: ErrorObject;
-    };
+    error: ErrorObject;
+  };
 
 const cache = new Map<string, EmailRenderingResult>();
 
@@ -86,21 +86,18 @@ export const renderEmailByPath = async (
   const EmailComponent = Email as React.FC;
   try {
     const element = createElement(EmailComponent, previewProps);
-    const [markupWithReferences, prettyMarkup, markup, plainText] =
-      await Promise.all([
-        renderWithReferences(element, {
-          pretty: true,
-        }),
-        render(element, {
-          pretty: true,
-        }),
-        render(element, {
-          pretty: false,
-        }),
-        render(element, {
-          plainText: true,
-        }),
-      ]);
+    const markupWithReferences = await renderWithReferences(element, {
+      pretty: true,
+    });
+    const prettyMarkup = await render(element, {
+      pretty: true,
+    });
+    const markup = await render(element, {
+      pretty: false,
+    });
+    const plainText = await render(element, {
+      plainText: true,
+    });
 
     const reactMarkup = await fs.promises.readFile(emailPath, 'utf-8');
 


### PR DESCRIPTION
For background, we use a custom JSX runtime that, if there is a certain boolean as true in the `globalThis`, it then adds in those properties. We render multiple times, once with this just to be able to interpolate where errors happen, and another time without.

The issues were being caused by the fact that we were rendering in “parallel” with `Promise.all`, which made that global value be enabled when it shouldn't. To fix this I've just changed it to not use `Promise.all`, which didn't have as much of a performance impact as I expected.