### PR TITLE
chore: remove engineering from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*                     @resend/engineering


### PR DESCRIPTION
Removing engineering from code owners so that there's no auto assign happenings for contributions coming in from the community.

For new pull requests that we want auto assign to happen, we can just ask for a review from Engineering.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed @resend/engineering from CODEOWNERS to stop auto-assigning the team on all pull requests, especially from the community. Request Engineering reviews manually when needed.

<!-- End of auto-generated description by cubic. -->

