### PR TITLE
fix(react-email): broken paths on `email build` output for Windows

### DIFF
--- a/.changeset/plenty-wasps-walk.md
+++ b/.changeset/plenty-wasps-walk.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Normalize Windows paths in generated Next.js config

--- a/packages/react-email/src/commands/build.ts
+++ b/packages/react-email/src/commands/build.ts
@@ -78,14 +78,14 @@ const setNextEnvironmentVariablesForBuild = async (
   const nextConfigContents = `
 const path = require('path');
 const emailsDirRelativePath = path.normalize('${emailsDirRelativePath}');
-const userProjectLocation = '${process.cwd()}';
+const userProjectLocation = '${process.cwd().replace(/\\/g, '/')}';
 /** @type {import('next').NextConfig} */
 module.exports = {
   env: {
     NEXT_PUBLIC_IS_BUILDING: 'true',
     EMAILS_DIR_RELATIVE_PATH: emailsDirRelativePath,
     EMAILS_DIR_ABSOLUTE_PATH: path.resolve(userProjectLocation, emailsDirRelativePath),
-    PREVIEW_SERVER_LOCATION: '${builtPreviewAppPath}',
+    PREVIEW_SERVER_LOCATION: '${builtPreviewAppPath.replace(/\\/g, '/')}',
     USER_PROJECT_LOCATION: userProjectLocation
   },
   // this is needed so that the code for building emails works properly


### PR DESCRIPTION
Fixes #2420.

@MrMaxie's intuition was right on—replacing backslashes with forward slashes in absolute paths in the `next.config.js` template fixes Windows builds on my end.

Before this change, if I run the following on Windows:

```
pnpm create email
cd react-email-starter
pnpm i
pnpm build
```

it fails during the Next.js build, citing a very mangled version of the project path in the error message.

After this change, if I [Yalc](https://github.com/wclr/yalc) my local `react-email` package into my react-email-starter project, the build succeeds!

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Normalizes Windows paths in the generated Next.js config to fix build failures on Windows. Replaces backslashes with forward slashes in absolute paths used during react-email builds.

- **Bug Fixes**
  - Convert backslashes in process.cwd() and builtPreviewAppPath before writing next.config.js.
  - Prevents mangled path errors during Next.js build on Windows (react-email-starter).

<!-- End of auto-generated description by cubic. -->

