### PR TITLE
feat(ci): low-hanging fruit performance wins

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,10 @@ on:
       - main
       - canary
   pull_request:
-permissions: 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
   contents: read
   pull-requests: read
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,9 @@ permissions:
   pull-requests: read
 jobs:
   lint:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: buildjet-2vcpu-ubuntu-2204
     container:
-      image: node:22
+      image: node:22-slim
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -5,7 +5,10 @@ on:
       - main
       - canary
   pull_request:
-permissions: 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
   contents: read
   pull-requests: read
 jobs:

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -13,9 +13,9 @@ permissions:
   pull-requests: read
 jobs:
   pin-dependencies-check:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: buildjet-2vcpu-ubuntu-2204
     container:
-      image: node:22
+      image: node:22-slim
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request-title-check.yml
+++ b/.github/workflows/pull-request-title-check.yml
@@ -9,9 +9,9 @@ permissions:
   pull-requests: read
 jobs:
   pull-request-title-check:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: buildjet-2vcpu-ubuntu-2204
     container:
-      image: node:22
+      image: node:22-slim
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request-title-check.yml
+++ b/.github/workflows/pull-request-title-check.yml
@@ -2,7 +2,10 @@ name: Pull Request Title Check
 on:
   pull_request:
     types: [opened, edited, synchronize]
-permissions: 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
   pull-requests: read
 jobs:
   pull-request-title-check:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
       - main
       - canary
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions: 
   contents: read
   pull-requests: read


### PR DESCRIPTION
This adds a few quick wins to try make CI take up less resources and not be clogged as requested by @gabrielmfern. It:

* Uses smaller buildjet instances for small tasks
* Cancels workflows when pushing to a branch with previous executions (useful to avoid useless runs in PRs)
* Uses a smaller node image

Note that these are just simple quick-wins, what will really help with CI is changing the runners, which we'll do separately.

Also note that release workflows are mostly unchanged to avoid canceling releases in the middle or using smaller machines for building.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reduce CI resource usage and queue times by canceling redundant runs and using smaller runners/images for lightweight workflows. Release pipelines remain unchanged.

- **Refactors**
  - Added concurrency groups to cancel in-progress runs on new pushes (lint, pin-dependencies, PR title check, tests).
  - Switched small jobs to buildjet-2vcpu runners.
  - Changed container to node:22-slim for lighter images.
  - Left release workflows untouched to avoid mid-run cancellations.

<!-- End of auto-generated description by cubic. -->

