### PR TITLE
feat(react-email): support custom export extension

### DIFF
--- a/.changeset/custom-extension-cli.md
+++ b/.changeset/custom-extension-cli.md
@@ -1,0 +1,5 @@
+---
+"react-email": minor
+---
+
+Enable custom export extensions via --extension/-e (e.g. .blade.php).

--- a/apps/docs/cli.mdx
+++ b/apps/docs/cli.mdx
@@ -190,6 +190,10 @@ Generates the plain HTML files of your emails into a `out` directory.
 <ResponseField name="--dir" type="string" default="emails">
   Change the directory of your email templates.
 </ResponseField>
+<ResponseField name="--extension" type="string">
+  Set a custom file extension for rendered templates (for example, `blade.php`). When omitted,
+  the extension defaults to `.html`, or `.txt` when `--plainText` is enabled.
+</ResponseField>
 
 ## `email help <cmd>`
 

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -165,7 +165,9 @@ export const exportTemplates = async (
 
   const extension =
     options.extension && options.extension.length > 0
-      ? `.${options.extension}`
+      ? options.extension.startsWith('.')
+        ? options.extension
+        : `.${options.extension}`
       : options.plainText
         ? '.txt'
         : '.html';

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -33,6 +33,7 @@ const getEmailTemplatesFromDirectory = (emailDirectory: EmailsDirectory) => {
 };
 
 type ExportTemplatesOptions = Options & {
+  extension?: string;
   silent?: boolean;
   pretty?: boolean;
 };
@@ -48,7 +49,7 @@ const renderWorkerSource = `
 const { unlinkSync, writeFileSync } = require('node:fs');
 const { parentPort, workerData } = require('node:worker_threads');
 
-const { templates, options } = workerData;
+const { templates, options, extension } = workerData;
 
 (async () => {
   for (const template of templates) {
@@ -58,10 +59,7 @@ const { templates, options } = workerData;
         emailModule.reactEmailCreateReactElement(emailModule.default, {}),
         options,
       );
-      const htmlPath = template.replace(
-        '.cjs',
-        options.plainText ? '.txt' : '.html',
-      );
+      const htmlPath = template.replace('.cjs', extension);
       writeFileSync(htmlPath, rendered);
       unlinkSync(template);
       parentPort.postMessage({ type: 'progress', template });
@@ -165,6 +163,13 @@ export const exportTemplates = async (
     },
   );
 
+  const extension =
+    options.extension && options.extension.length > 0
+      ? `.${options.extension}`
+      : options.plainText
+        ? '.txt'
+        : '.html';
+
   if (spinner && allBuiltTemplates.length > 0) {
     spinner.setText(`rendering ${allBuiltTemplates[0]?.split('/').pop()}`);
     spinner.start();
@@ -179,7 +184,7 @@ export const exportTemplates = async (
       await new Promise<void>((resolve, reject) => {
         const worker = new Worker(renderWorkerSource, {
           eval: true,
-          workerData: { templates: batch, options },
+          workerData: { templates: batch, options, extension },
         });
         worker.on('message', (msg: RenderWorkerMessage) => {
           if (msg.type === 'progress') {

--- a/packages/react-email/src/cli/commands/testing/export.spec.ts
+++ b/packages/react-email/src/cli/commands/testing/export.spec.ts
@@ -215,3 +215,24 @@ test('email export', { retry: 3 }, async () => {
     "
   `);
 });
+
+test('email export with custom extension', { retry: 3 }, async () => {
+  const pathToEmailsDirectory = path.resolve(__dirname, './emails');
+  const pathToDumpMarkup = path.resolve(__dirname, './out');
+
+  await exportTemplates(pathToDumpMarkup, pathToEmailsDirectory, {
+    silent: true,
+    pretty: true,
+    extension: 'blade.php',
+  });
+
+  const outputFile = path.resolve(
+    pathToDumpMarkup,
+    './vercel-invite-user.blade.php',
+  );
+
+  expect(fs.existsSync(outputFile)).toBe(true);
+  expect(await fs.promises.readFile(outputFile, 'utf8')).toContain(
+    '<!DOCTYPE html',
+  );
+});

--- a/packages/react-email/src/cli/index.ts
+++ b/packages/react-email/src/cli/index.ts
@@ -112,12 +112,16 @@ if (!hasRequiredFlags) {
       './emails',
     )
     .option(
+      '-e, --extension <extension>',
+      'Set a custom file extension for rendered emails (e.g. blade.php)',
+    )
+    .option(
       '-s, --silent',
       'To, or not to show a spinner with process information',
       false,
     )
-    .action(({ outDir, pretty, plainText, silent, dir: srcDir }) =>
-      exportTemplates(outDir, srcDir, { silent, plainText, pretty }),
+    .action(({ outDir, pretty, plainText, silent, dir: srcDir, extension }) =>
+      exportTemplates(outDir, srcDir, { silent, plainText, pretty, extension }),
     );
 
   const resend = program.command('resend');


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

Add a `--extension/-e` flag to the CLI export command, document the new option, and add a test.

**Related**

  - https://github.com/resend/react-email/discussions/1885
    

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a --extension/-e flag to the `react-email` export CLI to set a custom output file extension (e.g., blade.php). If omitted, it defaults to .html (or .txt with --plainText) and the flag value is normalized to include a leading dot; docs updated and tests added.

<sup>Written for commit 86f2c4ce4015c9755fac9bbc092c16839eb199e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/2555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

