### PR TITLE
feat(react-email): optimize Tailwind rendering pipeline with caching

### DIFF
--- a/packages/react-email/src/components/tailwind/hooks/use-suspended-promise.ts
+++ b/packages/react-email/src/components/tailwind/hooks/use-suspended-promise.ts
@@ -5,6 +5,7 @@ interface PromiseState {
 }
 
 const promiseStates = new Map<string, PromiseState>();
+const MAX_CACHE_SIZE = 50;
 
 export function useSuspensedPromise<Result>(
   promiseFn: () => Promise<Result>,
@@ -12,6 +13,10 @@ export function useSuspensedPromise<Result>(
 ) {
   const previousState = promiseStates.get(key);
   if (previousState) {
+    // LRU: move to end of insertion order
+    promiseStates.delete(key);
+    promiseStates.set(key, previousState);
+
     if ('error' in previousState) {
       throw previousState.error;
     }
@@ -21,6 +26,12 @@ export function useSuspensedPromise<Result>(
     }
 
     throw previousState.promise;
+  }
+
+  // Evict oldest entry when at capacity
+  if (promiseStates.size >= MAX_CACHE_SIZE) {
+    const oldestKey = promiseStates.keys().next().value;
+    if (oldestKey !== undefined) promiseStates.delete(oldestKey);
   }
 
   const state: PromiseState = {

--- a/packages/react-email/src/components/tailwind/tailwind.tsx
+++ b/packages/react-email/src/components/tailwind/tailwind.tsx
@@ -100,18 +100,20 @@ export function Tailwind({ children, config, theme, utility }: TailwindProps) {
     ),
   );
 
-  let classesUsed: string[] = [];
+  const classesUsed: string[] = [];
   let mappedChildren: React.ReactNode = mapReactTree(children, (node) => {
     if (React.isValidElement<EmailElementProps>(node)) {
       if (node.props.className) {
         const classes = node.props.className?.split(/\s+/);
-        classesUsed = [...classesUsed, ...classes];
-        tailwindSetup.addUtilities(classes);
+        classesUsed.push(...classes);
       }
     }
 
     return node;
   });
+
+  const uniqueClasses = [...new Set(classesUsed)];
+  tailwindSetup.addUtilities(uniqueClasses);
 
   const styleSheet = tailwindSetup.getStyleSheet();
   sanitizeStyleSheet(styleSheet);

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
@@ -11,22 +11,25 @@ export function extractRulesPerClass(root: CssNode, classes: string[]) {
     visit: 'Rule',
     enter(rule) {
       const selectorClasses: string[] = [];
-      walk(rule, {
-        visit: 'ClassSelector',
-        enter(classSelector) {
-          selectorClasses.push(string.decode(classSelector.name));
-        },
-      });
+      if (rule.prelude) {
+        walk(rule.prelude, {
+          visit: 'ClassSelector',
+          enter(classSelector) {
+            selectorClasses.push(string.decode(classSelector.name));
+          },
+        });
+      }
+
+      const matchingClasses = selectorClasses.filter((c) => classSet.has(c));
+      if (matchingClasses.length === 0) return;
+
       if (isRuleInlinable(rule)) {
-        for (const className of selectorClasses) {
-          if (classSet.has(className)) {
-            inlinableRules.set(className, rule);
-          }
+        for (const className of matchingClasses) {
+          inlinableRules.set(className, rule);
         }
       } else {
         const { inlinablePart, nonInlinablePart } = splitMixedRule(rule);
-        for (const className of selectorClasses) {
-          if (!classSet.has(className)) continue;
+        for (const className of matchingClasses) {
           if (inlinablePart) {
             inlinableRules.set(className, inlinablePart);
           }

--- a/packages/react-email/src/components/tailwind/utils/tailwindcss/setup-tailwind.ts
+++ b/packages/react-email/src/components/tailwind/utils/tailwindcss/setup-tailwind.ts
@@ -1,4 +1,4 @@
-import { parse, type StyleSheet } from 'css-tree';
+import { clone, parse, type StyleSheet } from 'css-tree';
 import { compile } from 'tailwindcss';
 import type { TailwindConfig } from '../../tailwind.js';
 import indexCss from './tailwind-stylesheets/index.js';
@@ -109,13 +109,19 @@ ${cssConfigs?.utility ? '@import "custom-utilities.css" layer(utilities);' : ''}
   });
 
   let css: string = baseCss;
+  let cachedCss: string | undefined;
+  let cachedAst: StyleSheet | undefined;
 
   return {
     addUtilities: function addUtilities(candidates: string[]): void {
       css = compiler.build(candidates);
     },
     getStyleSheet: function getCss() {
-      return parse(css) as StyleSheet;
+      if (css !== cachedCss) {
+        cachedCss = css;
+        cachedAst = parse(css) as StyleSheet;
+      }
+      return clone(cachedAst!) as StyleSheet;
     },
   };
 }


### PR DESCRIPTION
Optimize the Tailwind rendering pipeline without changing
  public API.

  - Batch class collection with `Set` dedup, call `addUtilities` once (N `compiler.build()`
   → 1)
  - Cache parsed CSS AST with `clone()` on read to skip redundant `parse()` calls
  - Walk `rule.prelude` instead of entire rule subtree, early exit for non-matching rules
  - Add LRU eviction (max 50) to `useSuspensedPromise` to cap memory on long-running
  servers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized the Tailwind rendering pipeline to remove redundant builds and CSS parsing, and added an LRU cache for suspended promises to reduce memory on long-running servers. No public API changes.

- **Refactors**
  - Batch and dedupe class names, then call `addUtilities` once per render.
  - Cache parsed CSS AST in `setupTailwind` and return a clone to avoid extra `parse()` calls.
  - Walk `rule.prelude` only in `extractRulesPerClass` with early exit for non-matching rules.
  - Add LRU (max 50) to `useSuspensedPromise` to cap memory usage.

<sup>Written for commit fba0aafbfb80cd92ae379d74fdfb44b7693a9f47. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/2970?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

