### PR TITLE
fix(preview-server): detect hsl/hsla colors in compatibility checker

### DIFF
--- a/.changeset/detect-hsl-colors.md
+++ b/.changeset/detect-hsl-colors.md
@@ -1,0 +1,5 @@
+---
+"@react-email/preview-server": patch
+---
+
+detect hsl and hsla color functions in the email compatibility checker


### PR DESCRIPTION
## Summary

The email compatibility checker now flags `hsl()` and `hsla()` color values as unsupported in Microsoft Outlook on Windows.

Previously, these color functions were invisible to the checker because [caniemail.com](https://caniemail.com) does not track hsl/hsla support data. Users would unknowingly use hsl colors that render correctly in the preview but fail silently in Outlook (Word rendering engine).

Fixes #2947

## Changes

- **New file:** `caniemail-supplemental-data.ts` - Contains manually curated support entries for `hsl()` and `hsla()` with Outlook Windows marked as unsupported (`"n"`). Kept separate from the auto-generated `caniemail-data.ts` so entries survive re-runs of `fill-caniemail-data.mts`.
- **Modified:** `check-compatibility.ts` - Merges supplemental entries with the caniemail data so the existing CSS function matching logic picks up hsl/hsla automatically.

## Why a separate file?

The `caniemail-data.ts` file is auto-generated from caniemail.com's API via `fill-caniemail-data.mts`. Adding entries directly would get wiped on the next refresh. The supplemental file can be removed once caniemail.com adds official hsl/hsla tracking.

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flags `hsl()` and `hsla()` colors as unsupported in Outlook on Windows in the email compatibility checker to prevent silent rendering failures. Fixes Linear issue #2947 and publishes a patch to `@react-email/preview-server`.

- **Bug Fixes**
  - Added supplemental `hsl()`/`hsla()` support data and merged it with `caniemail` so the existing CSS function detection flags these colors for Outlook on Windows.
  - Added a changeset to release this as a patch.

<sup>Written for commit f27e60b0171ada949c233dad11c0774ad86af43d. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3061?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

