### PR TITLE
fix(tailwind): convert modern CSS to legacy syntax for email client compatibility

### DIFF
--- a/.changeset/fix-tailwind-media-query-compat.md
+++ b/.changeset/fix-tailwind-media-query-compat.md
@@ -1,0 +1,5 @@
+---
+"@react-email/tailwind": patch
+---
+
+Convert modern CSS range media queries and nesting to legacy syntax for email client compatibility

--- a/packages/tailwind/src/tailwind.spec.tsx
+++ b/packages/tailwind/src/tailwind.spec.tsx
@@ -51,7 +51,7 @@ describe('Tailwind component', () => {
         <meta name="x-apple-disable-message-reformatting" />
         <!--$-->
         <style>
-          .md_p-4{@media (width>=48rem){padding:1rem!important}}
+          @media (min-width:48rem){.md_p-4{padding:1rem!important}}
         </style>
       </head>
       <body>
@@ -352,7 +352,7 @@ describe('Tailwind component', () => {
           <meta name="x-apple-disable-message-reformatting" />
           <!--$-->
           <style>
-            .sm_bg-red-50{@media (width>=40rem){background-color:rgb(254,242,242)!important}}.sm_text-sm{@media (width>=40rem){font-size:0.875rem!important;line-height:1.4285714285714286!important}}.md_text-lg{@media (width>=48rem){font-size:1.125rem!important;line-height:1.5555555555555556!important}}
+            @media (min-width:40rem){.sm_bg-red-50{background-color:rgb(254,242,242)!important}}@media (min-width:40rem){.sm_text-sm{font-size:0.875rem!important;line-height:1.4285714285714286!important}}@media (min-width:48rem){.md_text-lg{font-size:1.125rem!important;line-height:1.5555555555555556!important}}
           </style></head
         ><span
           ><!--[if mso]><i style="letter-spacing: 10px;mso-font-width:-100%;" hidden>&nbsp;</i><![endif]--></span
@@ -390,7 +390,7 @@ describe('Tailwind component', () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html dir="ltr" lang="en"><head><meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/><meta name="x-apple-disable-message-reformatting"/><!--$--><style>.text-body{@media (prefers-color-scheme:dark){color:orange!important}}</style></head><body class="text-body"><table border="0" width="100%" cellPadding="0" cellSpacing="0" role="presentation" align="center"><tbody><tr><td style="color:green">this is the body</td></tr></tbody></table><!--/$--></body></html>"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html dir="ltr" lang="en"><head><meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/><meta name="x-apple-disable-message-reformatting"/><!--$--><style>@media (prefers-color-scheme:dark){.text-body{color:orange!important}}</style></head><body class="text-body"><table border="0" width="100%" cellPadding="0" cellSpacing="0" role="presentation" align="center"><tbody><tr><td style="color:green">this is the body</td></tr></tbody></table><!--/$--></body></html>"`,
     );
   });
 
@@ -425,7 +425,7 @@ describe('Tailwind component', () => {
           <meta name="x-apple-disable-message-reformatting" />
           <!--$-->
           <style>
-            .xl_bg-green-500{@media (width>=1280px){background-color:rgb(0,201,80)!important}}.twoxl_bg-blue-500{@media (width>=1536px){background-color:rgb(43,127,255)!important}}
+            @media (min-width:1280px){.xl_bg-green-500{background-color:rgb(0,201,80)!important}}@media (min-width:1536px){.twoxl_bg-blue-500{background-color:rgb(43,127,255)!important}}
           </style>
         </head>
         <div class="xl_bg-green-500" style="background-color:rgb(255,226,226)">
@@ -453,7 +453,7 @@ describe('Tailwind component', () => {
       <head>
         <!--$-->
         <style>
-          .lg_max-h-calc50pxplus5rem{@media (width>=64rem){max-height:calc(50px + 5rem)!important}}
+          @media (min-width:64rem){.lg_max-h-calc50pxplus5rem{max-height:calc(50px + 5rem)!important}}
         </style>
       </head>
       <div
@@ -496,7 +496,7 @@ describe('Tailwind component', () => {
           <head>
             <!--$-->
             <style>
-              .sm_bg-red-300{@media (width>=40rem){background-color:rgb(255,162,162)!important}}.md_bg-red-400{@media (width>=48rem){background-color:rgb(255,100,103)!important}}.lg_bg-red-500{@media (width>=64rem){background-color:rgb(251,44,54)!important}}
+              @media (min-width:40rem){.sm_bg-red-300{background-color:rgb(255,162,162)!important}}@media (min-width:48rem){.md_bg-red-400{background-color:rgb(255,100,103)!important}}@media (min-width:64rem){.lg_bg-red-500{background-color:rgb(251,44,54)!important}}
             </style>
           </head>
           <body>
@@ -525,7 +525,7 @@ describe('Tailwind component', () => {
           </Tailwind>,
         ),
       ).toMatchInlineSnapshot(
-        `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html lang="en"><head><!--$--><style>.sm_bg-red-300{@media (width>=40rem){background-color:rgb(255,162,162)!important}}.md_bg-red-400{@media (width>=48rem){background-color:rgb(255,100,103)!important}}.lg_bg-red-500{@media (width>=64rem){background-color:rgb(251,44,54)!important}}</style></head><body><div class="sm_bg-red-300 md_bg-red-400 lg_bg-red-500" style="background-color:rgb(255,201,201)"></div><!--/$--></body></html>"`,
+        `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html lang="en"><head><!--$--><style>@media (min-width:40rem){.sm_bg-red-300{background-color:rgb(255,162,162)!important}}@media (min-width:48rem){.md_bg-red-400{background-color:rgb(255,100,103)!important}}@media (min-width:64rem){.lg_bg-red-500{background-color:rgb(251,44,54)!important}}</style></head><body><div class="sm_bg-red-300 md_bg-red-400 lg_bg-red-500" style="background-color:rgb(255,201,201)"></div><!--/$--></body></html>"`,
       );
     });
 
@@ -560,7 +560,7 @@ describe('Tailwind component', () => {
           <head>
             <!--$-->
             <style>
-              .text-body{@media (width>=40rem){color:darkgreen!important}}
+              @media (min-width:40rem){.text-body{color:darkgreen!important}}
             </style>
           </head>
           <body>
@@ -590,7 +590,7 @@ describe('Tailwind component', () => {
           <head>
             <!--$-->
             <style>
-              .hover_bg-red-600{&:hover{@media (hover:hover){background-color:rgb(231,0,11)!important}}}.focus_bg-red-700{&:focus{background-color:rgb(193,0,7)!important}}.sm_bg-red-300{@media (width>=40rem){background-color:rgb(255,162,162)!important}}.sm_hover_bg-red-200{@media (width>=40rem){&:hover{@media (hover:hover){background-color:rgb(255,201,201)!important}}}}.md_bg-red-400{@media (width>=48rem){background-color:rgb(255,100,103)!important}}.lg_bg-red-500{@media (width>=64rem){background-color:rgb(251,44,54)!important}}
+              @media (hover:hover){.hover_bg-red-600:hover{background-color:rgb(231,0,11)!important}}.focus_bg-red-700:focus{background-color:rgb(193,0,7)!important}@media (min-width:40rem){.sm_bg-red-300{background-color:rgb(255,162,162)!important}}@media (min-width:40rem){@media (hover:hover){.sm_hover_bg-red-200:hover{background-color:rgb(255,201,201)!important}}}@media (min-width:48rem){.md_bg-red-400{background-color:rgb(255,100,103)!important}}@media (min-width:64rem){.lg_bg-red-500{background-color:rgb(251,44,54)!important}}
             </style>
           </head>
           <body>
@@ -661,7 +661,7 @@ describe('Tailwind component', () => {
           <meta name="x-apple-disable-message-reformatting" />
           <!--$-->
           <style>
-            .max-sm_text-red-600{@media (width<40rem){color:rgb(231,0,11)!important}}
+            @media (max-width:40rem){.max-sm_text-red-600{color:rgb(231,0,11)!important}}
           </style>
         </head>
         <p class="max-sm_text-red-600" style="color:rgb(20,71,230)">I am some text</p>
@@ -705,7 +705,7 @@ describe('Tailwind component', () => {
           <head>
             <!--$-->
             <style>
-              .sm_bg-red-500{@media (width>=40rem){background-color:rgb(251,44,54)!important}}
+              @media (min-width:40rem){.sm_bg-red-500{background-color:rgb(251,44,54)!important}}
             </style>
             <style></style>
             <link />
@@ -926,7 +926,7 @@ describe('Tailwind component', () => {
           <head>
             <!--$-->
             <style>
-              .sm_border-custom{@media (width>=40rem){border:2px solid!important}}
+              @media (min-width:40rem){.sm_border-custom{border:2px solid!important}}
             </style>
           </head>
           <body>

--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import type { Config } from 'tailwindcss';
 import { useSuspensedPromise } from './hooks/use-suspended-promise';
 import { sanitizeStyleSheet } from './sanitize-stylesheet';
+import { downlevelCss } from './utils/css/downlevel-css';
 import { extractRulesPerClass } from './utils/css/extract-rules-per-class';
 import { getCustomProperties } from './utils/css/get-custom-properties';
 import { sanitizeNonInlinableRules } from './utils/css/sanitize-non-inlinable-rules';
@@ -118,6 +119,7 @@ export function Tailwind({ children, config }: TailwindProps) {
     ),
   };
   sanitizeNonInlinableRules(nonInlineStyles);
+  downlevelCss(nonInlineStyles);
 
   const hasNonInlineStylesToApply = nonInlinableRules.size > 0;
   let appliedNonInlineStyles = false as boolean;

--- a/packages/tailwind/src/utils/css/downlevel-css.spec.ts
+++ b/packages/tailwind/src/utils/css/downlevel-css.spec.ts
@@ -1,0 +1,78 @@
+import { generate, parse, type StyleSheet } from 'css-tree';
+import { downlevelCss } from './downlevel-css';
+
+function transform(css: string): string {
+  const ast = parse(css) as StyleSheet;
+  downlevelCss(ast);
+  return generate(ast);
+}
+
+describe('downlevelCss()', () => {
+  describe('range media feature conversion', () => {
+    it('converts width>= to min-width', () => {
+      expect(transform('@media (width>=40rem){.foo{padding:1rem}}')).toBe(
+        '@media (min-width:40rem){.foo{padding:1rem}}',
+      );
+    });
+
+    it('converts width<= to max-width', () => {
+      expect(transform('@media (width<=40rem){.foo{padding:1rem}}')).toBe(
+        '@media (max-width:40rem){.foo{padding:1rem}}',
+      );
+    });
+
+    it('does not modify non-range media features', () => {
+      expect(transform('@media (hover:hover){.foo{color:red}}')).toBe(
+        '@media (hover:hover){.foo{color:red}}',
+      );
+    });
+  });
+
+  describe('CSS unnesting', () => {
+    it('hoists @media out of rules', () => {
+      expect(
+        transform('.sm_p-4{@media (width>=40rem){padding:1rem!important}}'),
+      ).toBe('@media (min-width:40rem){.sm_p-4{padding:1rem!important}}');
+    });
+
+    it('resolves & nesting selector with pseudo class', () => {
+      expect(transform('.foo{&:hover{color:red}}')).toBe(
+        '.foo:hover{color:red}',
+      );
+    });
+
+    it('handles @media + & combined', () => {
+      expect(
+        transform(
+          '.sm_focus_outline-none{@media (width>=40rem){&:focus{outline-style:none!important}}}',
+        ),
+      ).toBe(
+        '@media (min-width:40rem){.sm_focus_outline-none:focus{outline-style:none!important}}',
+      );
+    });
+
+    it('handles triple nesting: @media > &:hover > @media (hover:hover)', () => {
+      expect(
+        transform(
+          '.sm_hover_bg-red{@media (width>=40rem){&:hover{@media (hover:hover){background-color:red!important}}}}',
+        ),
+      ).toBe(
+        '@media (min-width:40rem){@media (hover:hover){.sm_hover_bg-red:hover{background-color:red!important}}}',
+      );
+    });
+
+    it('leaves plain rules unchanged', () => {
+      expect(transform('.foo{padding:1rem}')).toBe('.foo{padding:1rem}');
+    });
+
+    it('handles multiple rules', () => {
+      expect(
+        transform(
+          '.a{@media (width>=40rem){padding:1rem!important}}.b{@media (width>=48rem){margin:2rem!important}}',
+        ),
+      ).toBe(
+        '@media (min-width:40rem){.a{padding:1rem!important}}@media (min-width:48rem){.b{margin:2rem!important}}',
+      );
+    });
+  });
+});

--- a/packages/tailwind/src/utils/css/downlevel-css.ts
+++ b/packages/tailwind/src/utils/css/downlevel-css.ts
@@ -1,0 +1,242 @@
+import { type CssNode, clone, List, type StyleSheet, walk } from 'css-tree';
+
+/**
+ * Converts modern CSS features (range media queries, CSS nesting) into
+ * legacy-compatible CSS for email client support.
+ *
+ * Transforms:
+ * - `@media (width>=40rem)` → `@media (min-width:40rem)`
+ * - `.cls{@media ...{decls}}` → `@media ...{.cls{decls}}`
+ * - `&:hover` → resolved with parent selector
+ */
+export function downlevelCss(ast: StyleSheet) {
+  convertFeatureRanges(ast);
+  unnestRules(ast);
+}
+
+const rangeToFeatureName: Record<string, string> = {
+  '>=': 'min-',
+  '>': 'min-',
+  '<=': 'max-',
+  '<': 'max-',
+};
+
+/**
+ * Converts FeatureRange nodes (e.g. `width >= 40rem`) into
+ * Feature nodes (e.g. `min-width: 40rem`).
+ */
+function convertFeatureRanges(ast: CssNode) {
+  walk(ast, {
+    enter(node, item, list) {
+      if (node.type !== 'FeatureRange' || !list) return;
+
+      const prefix = rangeToFeatureName[node.leftComparison];
+      if (!prefix) return;
+
+      const featureName = node.left.type === 'Identifier' ? node.left.name : '';
+      if (!featureName) return;
+
+      const feature: CssNode = {
+        type: 'Feature',
+        kind: node.kind,
+        name: `${prefix}${featureName}`,
+        value: node.middle,
+      } as CssNode;
+
+      list.replace(item, list.createItem(feature));
+    },
+  });
+}
+
+interface RuleNode {
+  type: 'Rule';
+  prelude: CssNode;
+  block: { type: 'Block'; children: List<CssNode> };
+}
+
+interface AtruleNode {
+  type: 'Atrule';
+  name: string;
+  prelude: CssNode;
+  block: { type: 'Block'; children: List<CssNode> };
+}
+
+/**
+ * Flattens CSS nesting: hoists @media out of rules and resolves `&`.
+ *
+ * Input:  `.cls { @media (...) { &:hover { color: red } } }`
+ * Output: `@media (...) { .cls:hover { color: red } }`
+ */
+function unnestRules(ast: StyleSheet) {
+  const newChildren = new List<CssNode>();
+
+  for (const node of ast.children.toArray()) {
+    if (node.type === 'Rule') {
+      const flattened = flattenRule(node as RuleNode);
+      for (const flatNode of flattened) {
+        newChildren.appendData(flatNode);
+      }
+    } else {
+      newChildren.appendData(node);
+    }
+  }
+
+  ast.children = newChildren;
+}
+
+/**
+ * Recursively flattens a rule's block, producing top-level nodes.
+ * Declarations stay in a rule with the parent selector.
+ * Nested @media and rules with & are hoisted.
+ */
+function flattenRule(rule: RuleNode): CssNode[] {
+  const result: CssNode[] = [];
+  const declarations: CssNode[] = [];
+
+  for (const child of rule.block.children.toArray()) {
+    if (child.type === 'Declaration') {
+      declarations.push(child);
+    } else if (child.type === 'Atrule') {
+      const atrule = child as unknown as AtruleNode;
+      const innerNodes = flattenBlockWithSelector(
+        rule.prelude,
+        atrule.block.children,
+      );
+      for (const inner of innerNodes) {
+        result.push({
+          type: 'Atrule',
+          name: atrule.name,
+          prelude: clone(atrule.prelude),
+          block: {
+            type: 'Block',
+            children: new List<CssNode>().fromArray([inner]),
+          },
+        } as CssNode);
+      }
+    } else if (child.type === 'Rule') {
+      const nestedRule = child as unknown as RuleNode;
+      const resolvedPrelude = resolveNesting(rule.prelude, nestedRule.prelude);
+      const innerFlattened = flattenRule({
+        ...nestedRule,
+        prelude: resolvedPrelude,
+      } as RuleNode);
+      result.push(...innerFlattened);
+    }
+  }
+
+  if (declarations.length > 0) {
+    result.unshift({
+      type: 'Rule',
+      prelude: clone(rule.prelude),
+      block: {
+        type: 'Block',
+        children: new List<CssNode>().fromArray(declarations),
+      },
+    } as CssNode);
+  }
+
+  return result;
+}
+
+/**
+ * Processes children of an @media block, wrapping declarations/rules
+ * with the parent selector.
+ */
+function flattenBlockWithSelector(
+  parentPrelude: CssNode,
+  children: List<CssNode>,
+): CssNode[] {
+  const result: CssNode[] = [];
+  const declarations: CssNode[] = [];
+
+  for (const child of children.toArray()) {
+    if (child.type === 'Declaration') {
+      declarations.push(child);
+    } else if (child.type === 'Rule') {
+      const nestedRule = child as unknown as RuleNode;
+      const resolvedPrelude = resolveNesting(parentPrelude, nestedRule.prelude);
+      const innerFlattened = flattenRule({
+        ...nestedRule,
+        prelude: resolvedPrelude,
+      } as RuleNode);
+      result.push(...innerFlattened);
+    } else if (child.type === 'Atrule') {
+      const atrule = child as unknown as AtruleNode;
+      const innerNodes = flattenBlockWithSelector(
+        parentPrelude,
+        atrule.block.children,
+      );
+      for (const inner of innerNodes) {
+        result.push({
+          type: 'Atrule',
+          name: atrule.name,
+          prelude: clone(atrule.prelude),
+          block: {
+            type: 'Block',
+            children: new List<CssNode>().fromArray([inner]),
+          },
+        } as CssNode);
+      }
+    }
+  }
+
+  if (declarations.length > 0) {
+    result.unshift({
+      type: 'Rule',
+      prelude: clone(parentPrelude),
+      block: {
+        type: 'Block',
+        children: new List<CssNode>().fromArray(declarations),
+      },
+    } as CssNode);
+  }
+
+  return result;
+}
+
+/**
+ * Resolves `&` (NestingSelector) in a nested selector by replacing it
+ * with the parent selector's content.
+ */
+function resolveNesting(
+  parentPrelude: CssNode,
+  nestedPrelude: CssNode,
+): CssNode {
+  const resolved = clone(nestedPrelude);
+
+  walk(resolved, {
+    enter(node, item, list) {
+      if (node.type !== 'NestingSelector' || !list) return;
+
+      const parentSelectors = getFirstSelectorChildren(parentPrelude);
+      if (!parentSelectors) return;
+
+      const clonedParent = parentSelectors.map((n) => clone(n));
+
+      let current = item;
+      for (const parentNode of clonedParent) {
+        list.insertData(parentNode, current);
+        current = current.prev!;
+      }
+      list.remove(item);
+    },
+  });
+
+  return resolved;
+}
+
+/**
+ * Gets the children of the first Selector in a SelectorList prelude.
+ */
+function getFirstSelectorChildren(prelude: CssNode): CssNode[] | null {
+  if (prelude.type === 'SelectorList') {
+    const first = prelude.children.first;
+    if (first?.type === 'Selector') {
+      return first.children.toArray();
+    }
+  }
+  if (prelude.type === 'Selector') {
+    return prelude.children.toArray();
+  }
+  return null;
+}

--- a/packages/tailwind/src/utils/css/downlevel-css.ts
+++ b/packages/tailwind/src/utils/css/downlevel-css.ts
@@ -1,4 +1,48 @@
-import { type CssNode, clone, List, type StyleSheet, walk } from 'css-tree';
+import {
+  type CssNode,
+  type CssNodeCommon,
+  type List as CssTreeList,
+  clone,
+  type Identifier,
+  List,
+  type ListItem,
+  type StyleSheet,
+  walk,
+} from 'css-tree';
+
+/**
+ * css-tree v3 node types not yet in @types/css-tree@2.3.x.
+ * These match the runtime AST shape produced by css-tree 3.1.0.
+ */
+interface FeatureRange extends CssNodeCommon {
+  type: 'FeatureRange';
+  kind: string;
+  left: CssNode;
+  leftComparison: '>=' | '<=' | '>' | '<';
+  middle: CssNode;
+  rightComparison: string | null;
+  right: CssNode | null;
+}
+
+interface Feature extends CssNodeCommon {
+  type: 'Feature';
+  kind: string;
+  name: string;
+  value: CssNode;
+}
+
+interface RuleNode {
+  type: 'Rule';
+  prelude: CssNode;
+  block: { type: 'Block'; children: CssTreeList<CssNode> };
+}
+
+interface AtruleNode {
+  type: 'Atrule';
+  name: string;
+  prelude: CssNode;
+  block: { type: 'Block'; children: CssTreeList<CssNode> };
+}
 
 /**
  * Converts modern CSS features (range media queries, CSS nesting) into
@@ -27,38 +71,29 @@ const rangeToFeatureName: Record<string, string> = {
  */
 function convertFeatureRanges(ast: CssNode) {
   walk(ast, {
-    enter(node, item, list) {
-      if (node.type !== 'FeatureRange' || !list) return;
+    enter(node: CssNode, item: ListItem<CssNode>, list: CssTreeList<CssNode>) {
+      if (node.type !== ('FeatureRange' as CssNode['type']) || !list) return;
 
-      const prefix = rangeToFeatureName[node.leftComparison];
+      const rangeNode = node as unknown as FeatureRange;
+      const prefix = rangeToFeatureName[rangeNode.leftComparison];
       if (!prefix) return;
 
-      const featureName = node.left.type === 'Identifier' ? node.left.name : '';
+      const featureName =
+        rangeNode.left.type === 'Identifier'
+          ? (rangeNode.left as Identifier).name
+          : '';
       if (!featureName) return;
 
-      const feature: CssNode = {
+      const feature: Feature = {
         type: 'Feature',
-        kind: node.kind,
+        kind: rangeNode.kind,
         name: `${prefix}${featureName}`,
-        value: node.middle,
-      } as CssNode;
+        value: rangeNode.middle,
+      };
 
-      list.replace(item, list.createItem(feature));
+      list.replace(item, list.createItem(feature as unknown as CssNode));
     },
   });
-}
-
-interface RuleNode {
-  type: 'Rule';
-  prelude: CssNode;
-  block: { type: 'Block'; children: List<CssNode> };
-}
-
-interface AtruleNode {
-  type: 'Atrule';
-  name: string;
-  prelude: CssNode;
-  block: { type: 'Block'; children: List<CssNode> };
 }
 
 /**
@@ -72,7 +107,7 @@ function unnestRules(ast: StyleSheet) {
 
   for (const node of ast.children.toArray()) {
     if (node.type === 'Rule') {
-      const flattened = flattenRule(node as RuleNode);
+      const flattened = flattenRule(node as unknown as RuleNode);
       for (const flatNode of flattened) {
         newChildren.appendData(flatNode);
       }
@@ -119,7 +154,7 @@ function flattenRule(rule: RuleNode): CssNode[] {
       const innerFlattened = flattenRule({
         ...nestedRule,
         prelude: resolvedPrelude,
-      } as RuleNode);
+      });
       result.push(...innerFlattened);
     }
   }
@@ -144,7 +179,7 @@ function flattenRule(rule: RuleNode): CssNode[] {
  */
 function flattenBlockWithSelector(
   parentPrelude: CssNode,
-  children: List<CssNode>,
+  children: CssTreeList<CssNode>,
 ): CssNode[] {
   const result: CssNode[] = [];
   const declarations: CssNode[] = [];
@@ -158,7 +193,7 @@ function flattenBlockWithSelector(
       const innerFlattened = flattenRule({
         ...nestedRule,
         prelude: resolvedPrelude,
-      } as RuleNode);
+      });
       result.push(...innerFlattened);
     } else if (child.type === 'Atrule') {
       const atrule = child as unknown as AtruleNode;
@@ -205,7 +240,7 @@ function resolveNesting(
   const resolved = clone(nestedPrelude);
 
   walk(resolved, {
-    enter(node, item, list) {
+    enter(node: CssNode, item: ListItem<CssNode>, list: CssTreeList<CssNode>) {
       if (node.type !== 'NestingSelector' || !list) return;
 
       const parentSelectors = getFirstSelectorChildren(parentPrelude);
@@ -213,10 +248,9 @@ function resolveNesting(
 
       const clonedParent = parentSelectors.map((n) => clone(n));
 
-      let current = item;
+      // Insert each parent token before the `&` node, keeping original order.
       for (const parentNode of clonedParent) {
-        list.insertData(parentNode, current);
-        current = current.prev!;
+        list.insertData(parentNode, item);
       }
       list.remove(item);
     },


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

## Summary

- Tailwind v4 outputs CSS with range media queries (`width>=40rem`) and CSS nesting that email clients like Gmail on Android don't support
- Adds a `downlevelCss` transformation step that converts range syntax to `min-width`/`max-width` and unnests rules to top-level `@media` blocks
- Fixes the CSS output to use legacy-compatible syntax that works across all email clients

Closes #3009

### Before

```css
.sm_p-4{@media (width>=48rem){padding:1rem!important}}
.hover_bg-red-600{&:hover{@media (hover:hover){background-color:red!important}}}
```

### After

```css
@media (min-width:48rem){.sm_p-4{padding:1rem!important}}
@media (hover:hover){.hover_bg-red-600:hover{background-color:red!important}}
```

## Test plan

- [x] New unit tests for `downlevelCss()` covering range conversion, unnesting, `&` resolution, triple nesting, and passthrough (9 tests)
- [x] All existing tailwind tests pass (12 snapshots updated)
- [x] Build succeeds
- [x] Lint passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downlevels Tailwind v4 CSS to legacy syntax for email clients by converting range media queries and unnesting rules. Adds a `downlevelCss` step so styles render correctly in Gmail on Android and similar clients.

- **Bug Fixes**
  - Added `downlevelCss` to `@react-email/tailwind` to convert range media features to `min-width`/`max-width`.
  - Hoists nested `@media` and resolves `&` into top-level rules, preserving selector token order.
  - Added unit tests for range conversion, unnesting, and complex nesting; updated snapshots.
  - Declared local css-tree v3 node interfaces and typed walk callbacks to satisfy TypeScript.

<sup>Written for commit c958bed6591d7964ab7c894414d6a5bf86c9220b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

