### PR TITLE
fix: treat paragraphs with inline leaf nodes as non-empty

### DIFF
--- a/packages/editor/src/core/is-document-visually-empty.spec.ts
+++ b/packages/editor/src/core/is-document-visually-empty.spec.ts
@@ -10,6 +10,7 @@ const schema = new Schema({
     globalContent: { group: 'block', atom: true },
     container: { group: 'block', content: 'block+' },
     image: { group: 'block', atom: true },
+    hardBreak: { group: 'inline', inline: true, selectable: false },
   },
 });
 
@@ -62,6 +63,25 @@ describe('isDocumentVisuallyEmpty', () => {
       expect(isDocumentVisuallyEmpty(doc)).toBe(false);
     });
 
+    it('returns false when paragraph contains only a hardBreak', () => {
+      const doc = schema.node('doc', null, [
+        schema.node('paragraph', null, [schema.node('hardBreak')]),
+      ]);
+
+      expect(isDocumentVisuallyEmpty(doc)).toBe(false);
+    });
+
+    it('returns false when paragraph contains a hardBreak alongside text', () => {
+      const doc = schema.node('doc', null, [
+        schema.node('paragraph', null, [
+          schema.text('hello'),
+          schema.node('hardBreak'),
+        ]),
+      ]);
+
+      expect(isDocumentVisuallyEmpty(doc)).toBe(false);
+    });
+
     it('considers just white spaces as not empty', () => {
       const doc = schema.node('doc', null, [
         schema.node('paragraph', null, [schema.text('                 ')]),
@@ -104,6 +124,16 @@ describe('isDocumentVisuallyEmpty', () => {
         schema.node('container', null, [
           schema.node('paragraph'),
           schema.node('paragraph'),
+        ]),
+      ]);
+
+      expect(isDocumentVisuallyEmpty(doc)).toBe(false);
+    });
+
+    it('returns false when container holds a paragraph with only a hardBreak', () => {
+      const doc = schema.node('doc', null, [
+        schema.node('container', null, [
+          schema.node('paragraph', null, [schema.node('hardBreak')]),
         ]),
       ]);
 

--- a/packages/editor/src/core/is-document-visually-empty.ts
+++ b/packages/editor/src/core/is-document-visually-empty.ts
@@ -46,5 +46,5 @@ function hasOnlyEmptyParagraph(node: Node): boolean {
 }
 
 function isEmptyParagraph(node: Node): boolean {
-  return node.type.name === 'paragraph' && node.textContent.length === 0;
+  return node.type.name === 'paragraph' && node.childCount === 0;
 }


### PR DESCRIPTION

## Summary by cubic
Fixes editor empty-state detection by treating paragraphs with inline leaf nodes (e.g., `hardBreak`) as non-empty. Prevents placeholders or disabled actions when the document only has visible line breaks. Resolves BU-669.

- **Bug Fixes**
  - Updated `isEmptyParagraph` to use `node.childCount === 0` instead of `node.textContent.length === 0` (ProseMirror `textContent` ignores inline leaf nodes).
  - Added tests for paragraphs with `hardBreak` (alone, with text, inside `container`); `isEditorEmpty` now stays false when visible breaks exist.

<sup>Written for commit 0874255ab5b4bd500829c89297efa45ff82dac52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

