### PR TITLE
fix(editor): handle doc node in paste handler for multi-block HTML

### DIFF
--- a/packages/editor/src/core/create-paste-handler.ts
+++ b/packages/editor/src/core/create-paste-handler.ts
@@ -1,6 +1,6 @@
 import type { Extensions } from '@tiptap/core';
 import { generateJSON } from '@tiptap/html';
-import type { Slice } from '@tiptap/pm/model';
+import { Slice } from '@tiptap/pm/model';
 import type { EditorView } from '@tiptap/pm/view';
 import { sanitizePastedHtml } from '../utils/paste-sanitizer';
 
@@ -55,11 +55,6 @@ export function createPasteHandler({
       }
     }
 
-    /**
-     * If the coming content has a single child, we can assume
-     * it's a plain text and doesn't need to be parsed and
-     * be introduced in a new line
-     */
     if (slice.content.childCount === 1) {
       return false;
     }
@@ -68,14 +63,15 @@ export function createPasteHandler({
       event.preventDefault();
       const html = event.clipboardData.getData('text/html');
 
-      // Strip visual styles, keep semantic formatting (bold, italic, links, etc.)
       const sanitizedHtml = sanitizePastedHtml(html);
 
       const jsonContent = generateJSON(sanitizedHtml, extensions);
       const node = view.state.schema.nodeFromJSON(jsonContent);
 
-      // Insert the parsed content into the editor at the current selection
-      const transaction = view.state.tr.replaceSelectionWith(node, false);
+      const transaction =
+        node.type.name === 'doc'
+          ? view.state.tr.replaceSelection(new Slice(node.content, 0, 0))
+          : view.state.tr.replaceSelectionWith(node, false);
       view.dispatch(transaction);
 
       return true;

--- a/packages/editor/src/core/paste-drop-handlers.spec.ts
+++ b/packages/editor/src/core/paste-drop-handlers.spec.ts
@@ -1,6 +1,15 @@
+import { Slice } from '@tiptap/pm/model';
 import { describe, expect, it, vi } from 'vitest';
 import { createDropHandler } from './create-drop-handler';
 import { createPasteHandler } from './create-paste-handler';
+
+vi.mock('@tiptap/html', () => ({
+  generateJSON: vi.fn(() => ({ type: 'doc', content: [] })),
+}));
+
+vi.mock('../utils/paste-sanitizer', () => ({
+  sanitizePastedHtml: vi.fn((html: string) => html),
+}));
 
 describe('createDropHandler', () => {
   it('uploads dropped images when auto-import declines synchronously', () => {
@@ -92,5 +101,126 @@ describe('createPasteHandler', () => {
 
     expect(handled).toBe(false);
     expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('inserts doc content as a slice for multi-block HTML paste', async () => {
+    const { generateJSON } = await import('@tiptap/html');
+    const mockedGenerateJSON = vi.mocked(generateJSON);
+
+    const fakeContent = {
+      size: 2,
+      childCount: 2,
+    };
+
+    mockedGenerateJSON.mockReturnValueOnce({
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'One' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Two' }] },
+      ],
+    });
+
+    const replaceSelection = vi
+      .fn()
+      .mockReturnValue({ scrollIntoView: vi.fn() });
+    const replaceSelectionWith = vi.fn();
+    const dispatch = vi.fn();
+    const preventDefault = vi.fn();
+
+    const handler = createPasteHandler({
+      onPaste: () => false,
+      onUploadImage: vi.fn(),
+      extensions: [],
+    });
+
+    const handled = handler(
+      {
+        state: {
+          schema: {
+            nodeFromJSON: vi.fn().mockReturnValue({
+              type: { name: 'doc' },
+              content: fakeContent,
+            }),
+          },
+          tr: { replaceSelection, replaceSelectionWith },
+          selection: { from: 0 },
+        },
+        dispatch,
+      } as never,
+      {
+        clipboardData: {
+          getData: (type: string) =>
+            type === 'text/html'
+              ? '<p>One</p><p>Two</p>'
+              : type === 'text/plain'
+                ? 'One\nTwo'
+                : '',
+          files: [],
+        },
+        preventDefault,
+      } as unknown as ClipboardEvent,
+      { content: { childCount: 2 } } as never,
+    );
+
+    expect(handled).toBe(true);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(replaceSelection).toHaveBeenCalledTimes(1);
+    expect(replaceSelection).toHaveBeenCalledWith(expect.any(Slice));
+    expect(replaceSelectionWith).not.toHaveBeenCalled();
+  });
+
+  it('inserts non-doc node with replaceSelectionWith', async () => {
+    const { generateJSON } = await import('@tiptap/html');
+    const mockedGenerateJSON = vi.mocked(generateJSON);
+
+    mockedGenerateJSON.mockReturnValueOnce({
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'Hello' }],
+    });
+
+    const fakeNode = { type: { name: 'paragraph' } };
+    const replaceSelection = vi.fn();
+    const replaceSelectionWith = vi
+      .fn()
+      .mockReturnValue({ scrollIntoView: vi.fn() });
+    const dispatch = vi.fn();
+    const preventDefault = vi.fn();
+
+    const handler = createPasteHandler({
+      onPaste: () => false,
+      onUploadImage: vi.fn(),
+      extensions: [],
+    });
+
+    const handled = handler(
+      {
+        state: {
+          schema: {
+            nodeFromJSON: vi.fn().mockReturnValue(fakeNode),
+          },
+          tr: { replaceSelection, replaceSelectionWith },
+          selection: { from: 0 },
+        },
+        dispatch,
+      } as never,
+      {
+        clipboardData: {
+          getData: (type: string) =>
+            type === 'text/html'
+              ? '<p>Hello</p>'
+              : type === 'text/plain'
+                ? 'Hello'
+                : '',
+          files: [],
+        },
+        preventDefault,
+      } as unknown as ClipboardEvent,
+      { content: { childCount: 2 } } as never,
+    );
+
+    expect(handled).toBe(true);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(replaceSelectionWith).toHaveBeenCalledWith(fakeNode, false);
+    expect(replaceSelection).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION

## Summary by cubic
Fixes multi-block HTML pasting in the editor by detecting `doc` nodes and inserting their content as a `Slice`. Prevents errors when pasting multiple top-level elements (e.g., `<p>One</p><p>Two</p>`). Aligns with BU-674.

- **Bug Fixes**
  - When the parsed node is `doc`, use `replaceSelection(new Slice(node.content, 0, 0))`; otherwise keep `replaceSelectionWith`.
  - Import `Slice` as a value from `@tiptap/pm/model`.
  - Add tests covering both `doc` (multi-block) and non-`doc` paste paths.

<sup>Written for commit 1667efe2256ff8cd83de45c4d90dec942cc8ee7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

