### PR TITLE
fix(editor): Convert TableHeader to EmailNode to preserve header cells in email export

### DIFF
--- a/packages/editor/src/extensions/__snapshots__/table.spec.tsx.snap
+++ b/packages/editor/src/extensions/__snapshots__/table.spec.tsx.snap
@@ -31,6 +31,24 @@ exports[`Table Nodes > renders TableCell React Email properly 1`] = `
 "
 `;
 
+exports[`Table Nodes > renders TableHeader React Email properly 1`] = `
+"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--$-->
+<th align="left" scope="col" style="margin:0;padding:0;font-weight:bold">
+  Header content
+</th>
+<!--/$-->
+"
+`;
+
+exports[`Table Nodes > renders TableHeader without scope when not specified 1`] = `
+"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--$-->
+<th style="margin:0;padding:0;font-weight:bold">Header content</th>
+<!--/$-->
+"
+`;
+
 exports[`Table Nodes > renders TableRow React Email properly 1`] = `
 "<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!--$-->

--- a/packages/editor/src/extensions/index.ts
+++ b/packages/editor/src/extensions/index.ts
@@ -64,7 +64,12 @@ import type { StyleAttributeOptions } from './style-attribute';
 import { StyleAttribute } from './style-attribute';
 import type { SupOptions } from './sup';
 import { Sup } from './sup';
-import type { TableCellOptions, TableOptions, TableRowOptions } from './table';
+import type {
+  TableCellOptions,
+  TableHeaderOptions,
+  TableOptions,
+  TableRowOptions,
+} from './table';
 import { Table, TableCell, TableHeader, TableRow } from './table';
 import { Text } from './text';
 import { TrailingNode, type TrailingNodeOptions } from './trailing-node';
@@ -181,7 +186,7 @@ export type StarterKitOptions = {
   Table: Partial<TableOptions> | false;
   TableRow: Partial<TableRowOptions> | false;
   TableCell: Partial<TableCellOptions> | false;
-  TableHeader: Partial<Record<string, any>> | false;
+  TableHeader: Partial<TableHeaderOptions> | false;
   Body: Partial<BodyOptions> | false;
   Container: Partial<ContainerOptions> | false;
   Div: Partial<DivOptions> | false;

--- a/packages/editor/src/extensions/table.spec.tsx
+++ b/packages/editor/src/extensions/table.spec.tsx
@@ -1,10 +1,11 @@
 import { render } from '@react-email/components';
 import { DEFAULT_STYLES } from '../utils/default-styles';
-import { Table, TableCell, TableRow } from './table';
+import { Table, TableCell, TableHeader, TableRow } from './table';
 
 const tableStyle = { ...DEFAULT_STYLES.reset };
 const tableRowStyle = { ...DEFAULT_STYLES.reset };
 const tableCellStyle = { ...DEFAULT_STYLES.reset };
+const tableHeaderStyle = { ...DEFAULT_STYLES.reset };
 
 describe('Table Nodes', () => {
   it('renders Table React Email properly', async () => {
@@ -66,6 +67,48 @@ describe('Table Nodes', () => {
           extension={TableCell}
         >
           Cell content
+        </Component>,
+        { pretty: true },
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('renders TableHeader React Email properly', async () => {
+    const Component = TableHeader.config.renderToReactEmail;
+    expect(Component).toBeDefined();
+    expect(
+      await render(
+        <Component
+          node={{
+            type: 'tableHeader',
+            attrs: {
+              alignment: 'left',
+              scope: 'col',
+            },
+          }}
+          style={tableHeaderStyle}
+          extension={TableHeader}
+        >
+          Header content
+        </Component>,
+        { pretty: true },
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('renders TableHeader without scope when not specified', async () => {
+    const Component = TableHeader.config.renderToReactEmail;
+    expect(
+      await render(
+        <Component
+          node={{
+            type: 'tableHeader',
+            attrs: {},
+          }}
+          style={tableHeaderStyle}
+          extension={TableHeader}
+        >
+          Header content
         </Component>,
         { pretty: true },
       ),

--- a/packages/editor/src/extensions/table.tsx
+++ b/packages/editor/src/extensions/table.tsx
@@ -1,6 +1,6 @@
 import { Column, Section } from '@react-email/components';
 import type { ParentConfig } from '@tiptap/core';
-import { mergeAttributes, Node } from '@tiptap/core';
+import { mergeAttributes } from '@tiptap/core';
 import { EmailNode } from '../core/serializer/email-node';
 import {
   COMMON_HTML_ATTRIBUTES,
@@ -233,7 +233,11 @@ export const TableCell = EmailNode.create<TableCellOptions>({
   },
 });
 
-export const TableHeader = Node.create({
+export interface TableHeaderOptions extends Record<string, unknown> {
+  HTMLAttributes?: Record<string, unknown>;
+}
+
+export const TableHeader = EmailNode.create<TableHeaderOptions>({
   name: 'tableHeader',
 
   group: 'tableCell',
@@ -276,5 +280,23 @@ export const TableHeader = Node.create({
 
   renderHTML({ HTMLAttributes }) {
     return ['th', HTMLAttributes, 0];
+  },
+
+  renderToReactEmail({ children, node, style }) {
+    const inlineStyles = inlineCssToJs(node.attrs?.style);
+    return (
+      <th
+        className={node.attrs?.class || undefined}
+        align={node.attrs?.align || node.attrs?.alignment}
+        scope={node.attrs?.scope || undefined}
+        style={{
+          ...style,
+          ...inlineStyles,
+          fontWeight: 'bold',
+        }}
+      >
+        {children}
+      </th>
+    );
   },
 });


### PR DESCRIPTION

## Summary by cubic
Preserves table header cells in email exports by converting `TableHeader` to an `EmailNode` and rendering `<th>` correctly. Addresses Linear BU-675 by ensuring header text shows up in exported HTML.

- **Bug Fixes**
  - Converted `TableHeader` from TipTap `Node` to `EmailNode` and added `renderToReactEmail` to output `<th>` with `align`, optional `scope`, and bold styling.
  - Introduced `TableHeaderOptions` and updated `StarterKitOptions` to use it.
  - Added snapshot tests for `TableHeader` rendering (with and without `scope`).

<sup>Written for commit c153d0be18e0cb905473fc7777fc9f57c36e06ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

