### PR TITLE
fix(editor): Sanitize unsafe URL schemes in paste and link rendering

### DIFF
--- a/packages/editor/src/extensions/button.tsx
+++ b/packages/editor/src/extensions/button.tsx
@@ -5,6 +5,7 @@ import {
 } from '@react-email/components';
 import { mergeAttributes } from '@tiptap/core';
 import { EmailNode } from '../core/serializer/email-node';
+import { isSafeUrl } from '../utils/is-safe-url';
 import { inlineCssToJs } from '../utils/styles';
 
 export interface EditorButtonOptions {
@@ -52,13 +53,14 @@ export const Button = EmailNode.create<EditorButtonOptions>({
             return false;
           }
           const element = node as HTMLElement;
+          const href = element.getAttribute('href') ?? '';
+          if (!isSafeUrl(href)) {
+            return false;
+          }
           const attrs: Record<string, string> = {};
-
-          // Preserve all attributes
           Array.from(element.attributes).forEach((attr) => {
             attrs[attr.name] = attr.value;
           });
-
           return attrs;
         },
       },
@@ -110,12 +112,14 @@ export const Button = EmailNode.create<EditorButtonOptions>({
 
   renderToReactEmail({ children, node, style }) {
     const inlineStyles = inlineCssToJs(node.attrs?.style);
+    const rawHref = (node.attrs?.href as string) ?? '#';
+    const href = isSafeUrl(rawHref) ? rawHref : '#';
     return (
       <Row>
         <Column align={node.attrs?.align || node.attrs?.alignment}>
           <ReactEmailButton
             className={node.attrs?.class || undefined}
-            href={node.attrs?.href}
+            href={href}
             style={{
               ...style,
               ...inlineStyles,

--- a/packages/editor/src/extensions/link.tsx
+++ b/packages/editor/src/extensions/link.tsx
@@ -6,6 +6,7 @@ export type LinkOptions = TipTapLinkOptions;
 
 import { editorEventBus } from '../core';
 import { EmailMark } from '../core/serializer/email-mark';
+import { isSafeUrl } from '../utils/is-safe-url';
 import { inlineCssToJs } from '../utils/styles';
 import { processStylesForUnlink } from './preserved-style';
 
@@ -16,9 +17,12 @@ export const Link: EmailMark<TipTapLinkOptions, any> = EmailMark.from(
       ? inlineCssToJs(mark.attrs.style)
       : {};
 
+    const rawHref = (mark.attrs?.href as string) ?? '';
+    const href = isSafeUrl(rawHref) ? rawHref : undefined;
+
     return (
       <ReactEmailLink
-        href={mark.attrs?.href ?? undefined}
+        href={href}
         rel={mark.attrs?.rel ?? undefined}
         style={{
           ...style,
@@ -43,13 +47,14 @@ export const Link: EmailMark<TipTapLinkOptions, any> = EmailMark.from(
             return false;
           }
           const element = node as HTMLElement;
+          const href = element.getAttribute('href') ?? '';
+          if (!isSafeUrl(href)) {
+            return false;
+          }
           const attrs: Record<string, string> = {};
-
-          // Preserve all attributes
           Array.from(element.attributes).forEach((attr) => {
             attrs[attr.name] = attr.value;
           });
-
           return attrs;
         },
       },
@@ -60,13 +65,14 @@ export const Link: EmailMark<TipTapLinkOptions, any> = EmailMark.from(
             return false;
           }
           const element = node as HTMLElement;
+          const href = element.getAttribute('href') ?? '';
+          if (!isSafeUrl(href)) {
+            return false;
+          }
           const attrs: Record<string, string> = {};
-
-          // Preserve all attributes
           Array.from(element.attributes).forEach((attr) => {
             attrs[attr.name] = attr.value;
           });
-
           return attrs;
         },
       },

--- a/packages/editor/src/ui/bubble-menu/link-open-link.tsx
+++ b/packages/editor/src/ui/bubble-menu/link-open-link.tsx
@@ -1,5 +1,6 @@
 import { useEditorState } from '@tiptap/react';
 import type * as React from 'react';
+import { isSafeUrl } from '../../utils/is-safe-url';
 import { ExternalLinkIcon } from '../icons';
 import { useBubbleMenuContext } from './context';
 
@@ -19,10 +20,12 @@ export function BubbleMenuLinkOpenLink({
       (e?.getAttributes('link').href as string) ?? '',
   });
 
+  const safeHref = isSafeUrl(linkHref ?? '') ? linkHref : '';
+
   return (
     <a
       {...rest}
-      href={linkHref ?? ''}
+      href={safeHref ?? ''}
       target="_blank"
       rel="noopener noreferrer"
       aria-label="Open link"

--- a/packages/editor/src/utils/is-safe-url.spec.ts
+++ b/packages/editor/src/utils/is-safe-url.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { isSafeUrl } from './is-safe-url';
+
+describe('isSafeUrl', () => {
+  it('allows empty string', () => {
+    expect(isSafeUrl('')).toBe(true);
+  });
+
+  it('allows hash fragment', () => {
+    expect(isSafeUrl('#')).toBe(true);
+  });
+
+  it('allows https URLs', () => {
+    expect(isSafeUrl('https://example.com')).toBe(true);
+  });
+
+  it('allows http URLs', () => {
+    expect(isSafeUrl('http://example.com')).toBe(true);
+  });
+
+  it('allows mailto URLs', () => {
+    expect(isSafeUrl('mailto:user@example.com')).toBe(true);
+  });
+
+  it('allows tel URLs', () => {
+    expect(isSafeUrl('tel:+1234567890')).toBe(true);
+  });
+
+  it('rejects javascript: URLs', () => {
+    expect(isSafeUrl('javascript:alert(1)')).toBe(false);
+  });
+
+  it('rejects javascript: URLs with leading whitespace', () => {
+    expect(isSafeUrl('  javascript:alert(1)')).toBe(false);
+  });
+
+  it('rejects javascript: URLs with mixed case', () => {
+    expect(isSafeUrl('JavaScript:alert(1)')).toBe(false);
+  });
+
+  it('rejects data: URLs', () => {
+    expect(isSafeUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+  });
+
+  it('rejects vbscript: URLs', () => {
+    expect(isSafeUrl('vbscript:msgbox')).toBe(false);
+  });
+
+  it('allows relative paths', () => {
+    expect(isSafeUrl('/page/about')).toBe(true);
+  });
+
+  it('allows anchor-only fragments', () => {
+    expect(isSafeUrl('#section')).toBe(true);
+  });
+});

--- a/packages/editor/src/utils/is-safe-url.ts
+++ b/packages/editor/src/utils/is-safe-url.ts
@@ -1,0 +1,18 @@
+const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+
+export const isSafeUrl = (url: string): boolean => {
+  if (url === '#' || url === '') {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return SAFE_PROTOCOLS.has(parsed.protocol);
+  } catch {
+    return (
+      !url.trimStart().toLowerCase().startsWith('javascript:') &&
+      !url.trimStart().toLowerCase().startsWith('data:') &&
+      !url.trimStart().toLowerCase().startsWith('vbscript:')
+    );
+  }
+};

--- a/packages/editor/src/utils/is-safe-url.ts
+++ b/packages/editor/src/utils/is-safe-url.ts
@@ -1,18 +1,26 @@
 const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
 
+const UNSAFE_SCHEMES = new Set(['javascript:', 'data:', 'vbscript:']);
+
+const extractScheme = (url: string): string | undefined => {
+  const match = /^[\s]*([a-z][a-z0-9+\-.]*:)/i.exec(url);
+  return match?.[1]?.toLowerCase();
+};
+
 export const isSafeUrl = (url: string): boolean => {
   if (url === '#' || url === '') {
     return true;
   }
 
-  try {
-    const parsed = new URL(url);
-    return SAFE_PROTOCOLS.has(parsed.protocol);
-  } catch {
-    return (
-      !url.trimStart().toLowerCase().startsWith('javascript:') &&
-      !url.trimStart().toLowerCase().startsWith('data:') &&
-      !url.trimStart().toLowerCase().startsWith('vbscript:')
-    );
+  const scheme = extractScheme(url);
+
+  if (scheme === undefined) {
+    return true;
   }
+
+  if (UNSAFE_SCHEMES.has(scheme)) {
+    return false;
+  }
+
+  return SAFE_PROTOCOLS.has(scheme);
 };

--- a/packages/editor/src/utils/paste-sanitizer.spec.ts
+++ b/packages/editor/src/utils/paste-sanitizer.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizePastedHtml } from './paste-sanitizer';
+
+describe('sanitizePastedHtml', () => {
+  it('passes through editor content unchanged', () => {
+    const html = '<p class="node-paragraph">Hello</p>';
+    expect(sanitizePastedHtml(html)).toBe(html);
+  });
+
+  it('preserves safe href on links', () => {
+    const html = '<a href="https://example.com">Link</a>';
+    const result = sanitizePastedHtml(html);
+    expect(result).toContain('href="https://example.com"');
+  });
+
+  it('strips javascript: href from links', () => {
+    const html = '<a href="javascript:alert(1)">Click me</a>';
+    const result = sanitizePastedHtml(html);
+    expect(result).not.toContain('javascript:');
+    expect(result).toContain('>Click me</a>');
+  });
+
+  it('strips data: href from links', () => {
+    const html = '<a href="data:text/html,<script>alert(1)</script>">Bad</a>';
+    const result = sanitizePastedHtml(html);
+    expect(result).not.toContain('data:');
+  });
+
+  it('strips vbscript: href from links', () => {
+    const html = '<a href="vbscript:msgbox">Bad</a>';
+    const result = sanitizePastedHtml(html);
+    expect(result).not.toContain('vbscript:');
+  });
+
+  it('strips javascript: src from images', () => {
+    const html = '<img src="javascript:alert(1)" alt="bad">';
+    const result = sanitizePastedHtml(html);
+    expect(result).not.toContain('javascript:');
+    expect(result).toContain('alt="bad"');
+  });
+
+  it('preserves safe src on images', () => {
+    const html = '<img src="https://example.com/img.png" alt="good">';
+    const result = sanitizePastedHtml(html);
+    expect(result).toContain('src="https://example.com/img.png"');
+  });
+
+  it('strips data: src from images', () => {
+    const html = '<img src="data:image/svg+xml,<svg></svg>" alt="bad">';
+    const result = sanitizePastedHtml(html);
+    expect(result).not.toContain('data:');
+  });
+
+  it('preserves mailto: href on links', () => {
+    const html = '<a href="mailto:user@example.com">Email</a>';
+    const result = sanitizePastedHtml(html);
+    expect(result).toContain('href="mailto:user@example.com"');
+  });
+});

--- a/packages/editor/src/utils/paste-sanitizer.ts
+++ b/packages/editor/src/utils/paste-sanitizer.ts
@@ -1,18 +1,7 @@
-/**
- * Sanitizes pasted HTML.
- * - From editor (has node-* classes): pass through as-is
- * - From external: strip all styles/classes, keep only semantic HTML
- */
+import { isSafeUrl } from './is-safe-url';
 
-/**
- * Detects content from the Resend editor by checking for node-* class names.
- */
 const EDITOR_CLASS_PATTERN = /class="[^"]*node-/;
 
-/**
- * Attributes to preserve on specific elements for EXTERNAL content.
- * Only functional attributes - NO style or class.
- */
 const PRESERVED_ATTRIBUTES: Record<string, string[]> = {
   a: ['href', 'target', 'rel'],
   img: ['src', 'alt', 'width', 'height'],
@@ -22,11 +11,11 @@ const PRESERVED_ATTRIBUTES: Record<string, string[]> = {
   '*': ['id'],
 };
 
-function isFromEditor(html: string): boolean {
-  return EDITOR_CLASS_PATTERN.test(html);
-}
+const URL_ATTRIBUTES = new Set(['href', 'src']);
 
-export function sanitizePastedHtml(html: string): string {
+const isFromEditor = (html: string): boolean => EDITOR_CLASS_PATTERN.test(html);
+
+export const sanitizePastedHtml = (html: string): string => {
   if (isFromEditor(html)) {
     return html;
   }
@@ -37,40 +26,41 @@ export function sanitizePastedHtml(html: string): string {
   sanitizeNode(doc.body);
 
   return doc.body.innerHTML;
-}
+};
 
-function sanitizeNode(node: Node): void {
+const sanitizeNode = (node: Node): void => {
   if (node.nodeType === Node.ELEMENT_NODE) {
-    const el = node as HTMLElement;
-    sanitizeElement(el);
+    sanitizeElement(node as HTMLElement);
   }
 
-  for (const child of Array.from(node.childNodes)) {
+  Array.from(node.childNodes).forEach((child) => {
     sanitizeNode(child);
-  }
-}
+  });
+};
 
-function sanitizeElement(el: HTMLElement): void {
+const sanitizeElement = (el: HTMLElement): void => {
   const tagName = el.tagName.toLowerCase();
 
   const allowedForTag = PRESERVED_ATTRIBUTES[tagName] || [];
   const allowedGlobal = PRESERVED_ATTRIBUTES['*'] || [];
   const allowed = new Set([...allowedForTag, ...allowedGlobal]);
 
-  const attributesToRemove: string[] = [];
+  const attributesToRemove = Array.from(el.attributes)
+    .filter((attr) => {
+      if (attr.name.startsWith('data-')) {
+        return true;
+      }
+      if (!allowed.has(attr.name)) {
+        return true;
+      }
+      if (URL_ATTRIBUTES.has(attr.name) && !isSafeUrl(attr.value)) {
+        return true;
+      }
+      return false;
+    })
+    .map((attr) => attr.name);
 
-  for (const attr of Array.from(el.attributes)) {
-    if (attr.name.startsWith('data-')) {
-      attributesToRemove.push(attr.name);
-      continue;
-    }
-
-    if (!allowed.has(attr.name)) {
-      attributesToRemove.push(attr.name);
-    }
-  }
-
-  for (const attr of attributesToRemove) {
+  attributesToRemove.forEach((attr) => {
     el.removeAttribute(attr);
-  }
-}
+  });
+};


### PR DESCRIPTION

## Summary by cubic
Sanitizes URLs in paste and link/button rendering to block unsafe schemes (`javascript:`, `data:`, `vbscript:`) and prevent XSS. Addresses Linear BU-671.

- **Bug Fixes**
  - Added `isSafeUrl` using regex scheme extraction + set checks (CodeQL-safe), with an allowlist (`http:`, `https:`, `mailto:`, `tel:`); handles empty/hash, relative paths, whitespace, and mixed case.
  - Paste sanitization now strips unsafe `href`/`src` values from external HTML.
  - `Link` and `Button` parsing reject unsafe `href`; rendering falls back to safe values.
  - Bubble menu “Open link” only uses validated URLs.
  - Added tests for `isSafeUrl` and the paste sanitizer.

<sup>Written for commit 266d7d7c34cc207aa7bb2aa78f86154eb74c64e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

