### PR TITLE
fix(editor): Prevent section Backspace from deleting sections with non-text content

### DIFF
--- a/packages/editor/src/extensions/section.tsx
+++ b/packages/editor/src/extensions/section.tsx
@@ -1,14 +1,10 @@
 import { Section as ReactEmailSection } from '@react-email/components';
 import { mergeAttributes } from '@tiptap/core';
-import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
 import type * as React from 'react';
 import { EmailNode } from '../core/serializer/email-node';
 import { getTextAlignment } from '../utils/get-text-alignment';
+import { isSectionEmpty } from '../utils/is-section-empty';
 import { inlineCssToJs } from '../utils/styles';
-
-function isSectionEmpty(node: ProseMirrorNode): boolean {
-  return node.textContent === '' && node.content.size <= node.childCount * 2;
-}
 
 export interface SectionOptions {
   HTMLAttributes: Record<string, unknown>;

--- a/packages/editor/src/utils/is-section-empty.spec.ts
+++ b/packages/editor/src/utils/is-section-empty.spec.ts
@@ -1,0 +1,65 @@
+import { Schema } from '@tiptap/pm/model';
+import { describe, expect, it } from 'vitest';
+import { isSectionEmpty } from './is-section-empty';
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    section: { group: 'block', content: 'block+' },
+    paragraph: { group: 'block', content: 'inline*' },
+    text: { group: 'inline' },
+    horizontalRule: { group: 'block' },
+    image: { group: 'block', atom: true },
+  },
+});
+
+const section = (children: Parameters<typeof schema.node>[2]) =>
+  schema.node('section', null, children);
+
+describe('isSectionEmpty', () => {
+  it('returns true for a section with a single empty paragraph', () => {
+    const node = section([schema.node('paragraph')]);
+    expect(isSectionEmpty(node)).toBe(true);
+  });
+
+  it('returns true for a section with multiple empty paragraphs', () => {
+    const node = section([
+      schema.node('paragraph'),
+      schema.node('paragraph'),
+    ]);
+    expect(isSectionEmpty(node)).toBe(true);
+  });
+
+  it('returns false for a section with a paragraph containing text', () => {
+    const node = section([
+      schema.node('paragraph', null, [schema.text('hello')]),
+    ]);
+    expect(isSectionEmpty(node)).toBe(false);
+  });
+
+  it('returns false for a section containing a horizontal rule', () => {
+    const node = section([schema.node('horizontalRule')]);
+    expect(isSectionEmpty(node)).toBe(false);
+  });
+
+  it('returns false for a section containing an atom node', () => {
+    const node = section([schema.node('image')]);
+    expect(isSectionEmpty(node)).toBe(false);
+  });
+
+  it('returns false for a section with a horizontal rule and an empty paragraph', () => {
+    const node = section([
+      schema.node('horizontalRule'),
+      schema.node('paragraph'),
+    ]);
+    expect(isSectionEmpty(node)).toBe(false);
+  });
+
+  it('returns false for a section with an atom node and text', () => {
+    const node = section([
+      schema.node('image'),
+      schema.node('paragraph', null, [schema.text('caption')]),
+    ]);
+    expect(isSectionEmpty(node)).toBe(false);
+  });
+});

--- a/packages/editor/src/utils/is-section-empty.ts
+++ b/packages/editor/src/utils/is-section-empty.ts
@@ -1,0 +1,15 @@
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+
+const isSectionEmpty = (node: ProseMirrorNode): boolean => {
+  if (node.textContent !== '') return false;
+
+  const children = Array.from(
+    { length: node.childCount },
+    (_, i) => node.child(i),
+  );
+  if (children.some((child) => child.isLeaf)) return false;
+
+  return node.content.size <= node.childCount * 2;
+};
+
+export { isSectionEmpty };


### PR DESCRIPTION

## Summary by cubic
Prevents Backspace from deleting sections that contain dividers, images, or other leaf/atom blocks. Addresses Linear BU-667.

- **Bug Fixes**
  - Updated `isSectionEmpty` to return false if any child is a leaf node (`isLeaf`), including `horizontalRule` and atom nodes.
  - Moved `isSectionEmpty` to `packages/editor/src/utils/is-section-empty.ts` and wired it into the section extension.
  - Added unit tests for empty paragraphs, text, `horizontalRule`, atom nodes, and mixed content.

<sup>Written for commit 7e77dea278a87fdffc35f15aa604c97fb2abb74c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

