### PR TITLE
fix(ui): update existing Resend templates instead of creating duplicates

### DIFF
--- a/.changeset/four-zebras-hear.md
+++ b/.changeset/four-zebras-hear.md
@@ -1,0 +1,5 @@
+---
+"@react-email/preview-server": patch
+---
+
+fix(preview-server): update existing Resend templates instead of creating duplicates

--- a/.changeset/four-zebras-hear.md
+++ b/.changeset/four-zebras-hear.md
@@ -2,4 +2,4 @@
 "@react-email/preview-server": patch
 ---
 
-fix(preview-server): update existing Resend templates instead of creating duplicates
+update existing Resend templates instead of creating duplicates

--- a/.changeset/four-zebras-hear.md
+++ b/.changeset/four-zebras-hear.md
@@ -1,5 +1,5 @@
 ---
-"@react-email/preview-server": patch
+"@react-email/ui": patch
 ---
 
 update existing Resend templates instead of creating duplicates

--- a/packages/ui/src/actions/export-single-template.ts
+++ b/packages/ui/src/actions/export-single-template.ts
@@ -1,14 +1,14 @@
-"use server";
+'use server';
 
-import { Resend } from "resend";
-import { z } from "zod";
-import { resendApiKey } from "../app/env";
-import { upsertResendTemplate } from "../utils/resend-template-upsert";
-import { baseActionClient } from "./safe-action";
+import { Resend } from 'resend';
+import { z } from 'zod';
+import { resendApiKey } from '../app/env';
+import { upsertResendTemplate } from '../utils/resend-template-upsert';
+import { baseActionClient } from './safe-action';
 
 export const exportSingleTemplate = baseActionClient
   .metadata({
-    actionName: "exportSingleTemplate",
+    actionName: 'exportSingleTemplate',
   })
   .inputSchema(
     z.object({
@@ -27,14 +27,14 @@ export const exportSingleTemplate = baseActionClient
       html: parsedInput.html,
     });
 
-    if ("error" in response) {
-      console.error("Error syncing single template", response.error);
-      return { name: parsedInput.name, status: "failed" as const };
+    if ('error' in response) {
+      console.error('Error syncing single template', response.error);
+      return { name: parsedInput.name, status: 'failed' as const };
     }
 
     return {
       name: parsedInput.name,
-      status: "succeeded" as const,
+      status: 'succeeded' as const,
       id: response.id,
       operation: response.operation,
     };

--- a/packages/ui/src/actions/export-single-template.ts
+++ b/packages/ui/src/actions/export-single-template.ts
@@ -1,36 +1,41 @@
-'use server';
+"use server";
 
-import { Resend } from 'resend';
-import { z } from 'zod';
-import { resendApiKey } from '../app/env';
-import { baseActionClient } from './safe-action';
+import { Resend } from "resend";
+import { z } from "zod";
+import { resendApiKey } from "../app/env";
+import { upsertResendTemplate } from "../utils/resend-template-upsert";
+import { baseActionClient } from "./safe-action";
 
 export const exportSingleTemplate = baseActionClient
   .metadata({
-    actionName: 'exportSingleTemplate',
+    actionName: "exportSingleTemplate",
   })
   .inputSchema(
     z.object({
       name: z.string(),
+      legacyName: z.string().optional(),
       html: z.string(),
     }),
   )
   .action(async ({ parsedInput }) => {
     const resend = new Resend(resendApiKey);
 
-    const response = await resend.templates.create({
+    const response = await upsertResendTemplate({
+      resend,
       name: parsedInput.name,
+      legacyName: parsedInput.legacyName,
       html: parsedInput.html,
     });
 
-    if (response.error) {
-      console.error('Error creating single template', response.error);
-      return { name: parsedInput.name, status: 'failed' as const };
+    if ("error" in response) {
+      console.error("Error syncing single template", response.error);
+      return { name: parsedInput.name, status: "failed" as const };
     }
 
     return {
       name: parsedInput.name,
-      status: 'succeeded' as const,
-      id: response.data.id,
+      status: "succeeded" as const,
+      id: response.id,
+      operation: response.operation,
     };
   });

--- a/packages/ui/src/components/toolbar/resend.tsx
+++ b/packages/ui/src/components/toolbar/resend.tsx
@@ -4,7 +4,9 @@ import { exportSingleTemplate } from '../../actions/export-single-template';
 import { getEmailPathFromSlug } from '../../actions/get-email-path-from-slug';
 import { renderEmailByPath } from '../../actions/render-email-by-path';
 import { useEmails } from '../../contexts/emails';
+import { removeFilenameExtension } from '../../utils/contains-email-template';
 import type { EmailsDirectory } from '../../utils/get-emails-directory-metadata';
+import type { ResendTemplateSyncOperation } from '../../utils/resend-template-upsert';
 import { sleep } from '../../utils/sleep';
 import { Button } from '../button';
 import { IconCloudAlert } from '../icons/icon-cloud-alert';
@@ -18,6 +20,7 @@ export interface ResendStatus {
 }
 
 interface ResendItem {
+  operation?: ResendTemplateSyncOperation;
   status: 'uploading' | 'failed' | 'succeeded';
   name: string;
   id?: string;
@@ -54,6 +57,7 @@ export function ResendIntegration({
   };
 
   const loading = isExportSinglePending || isBulkProcessing;
+  const templateName = removeFilenameExtension(emailSlug);
 
   if (items.length === 0 && !loading) {
     return (
@@ -70,12 +74,13 @@ export function ResendIntegration({
               setItems([
                 {
                   status: 'uploading',
-                  name: emailSlug,
+                  name: templateName,
                 },
               ]);
 
               exportSingle({
-                name: emailSlug,
+                name: templateName,
+                legacyName: emailSlug,
                 html: htmlMarkup,
               });
             }}
@@ -108,7 +113,7 @@ export function ResendIntegration({
 
                 const emailSlug = emailItem.name;
                 // Remove file extension, keeping the directory structure
-                const templateName = emailSlug.replace(/\.[^/.]+$/, '');
+                const templateName = removeFilenameExtension(emailSlug);
 
                 try {
                   const emailPath = await getEmailPathFromSlug(emailSlug);
@@ -132,6 +137,7 @@ export function ResendIntegration({
 
                   const exportResult = await exportSingleAsync({
                     name: templateName,
+                    legacyName: emailSlug,
                     html: renderResult.markup,
                   });
 
@@ -143,6 +149,7 @@ export function ResendIntegration({
                               ...item,
                               status: 'succeeded',
                               id: exportResult.data!.id,
+                              operation: exportResult.data!.operation,
                             }
                           : item,
                       ),
@@ -210,7 +217,9 @@ export function ResendIntegration({
               ? 'Uploading...'
               : item.status === 'failed'
                 ? 'Failed to upload. Try again.'
-                : 'Template uploaded successfully.'}
+                : item.operation === 'updated'
+                  ? 'Template updated successfully.'
+                  : 'Template created successfully.'}
           </Results.Column>
           <Results.Column>
             {item.status === 'succeeded' && (

--- a/packages/ui/src/utils/resend-template-upsert.spec.ts
+++ b/packages/ui/src/utils/resend-template-upsert.spec.ts
@@ -35,6 +35,12 @@ describe('upsertResendTemplate()', () => {
     };
   };
 
+  const notFoundError = {
+    message: 'Template not found',
+    name: 'not_found',
+    statusCode: 404,
+  } as const;
+
   it('updates the template directly when the alias already exists', async () => {
     const resend = createResendMock();
     const alias = getResendTemplateAlias('welcome');
@@ -73,11 +79,7 @@ describe('upsertResendTemplate()', () => {
 
     resend.templates.get.mockResolvedValue({
       data: null,
-      error: {
-        message: 'Template not found',
-        name: 'not_found',
-        statusCode: 404,
-      },
+      error: notFoundError,
     });
     resend.templates.list.mockResolvedValue({
       data: {
@@ -95,6 +97,7 @@ describe('upsertResendTemplate()', () => {
             name: 'welcome',
           },
         ],
+        has_more: false,
       },
       error: null,
     });
@@ -127,11 +130,7 @@ describe('upsertResendTemplate()', () => {
 
     resend.templates.get.mockResolvedValue({
       data: null,
-      error: {
-        message: 'Template not found',
-        name: 'not_found',
-        statusCode: 404,
-      },
+      error: notFoundError,
     });
     resend.templates.list.mockResolvedValue({
       data: {
@@ -143,6 +142,7 @@ describe('upsertResendTemplate()', () => {
             name: 'welcome.tsx',
           },
         ],
+        has_more: false,
       },
       error: null,
     });
@@ -169,20 +169,114 @@ describe('upsertResendTemplate()', () => {
     });
   });
 
+  it('keeps searching later template pages before creating a new template', async () => {
+    const resend = createResendMock();
+    const alias = getResendTemplateAlias('welcome');
+
+    resend.templates.get.mockResolvedValue({
+      data: null,
+      error: notFoundError,
+    });
+    resend.templates.list
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              alias: null,
+              created_at: '2026-04-01T00:00:00.000Z',
+              id: 'tmpl_page_1',
+              name: 'other-template',
+            },
+          ],
+          has_more: true,
+        },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              alias: null,
+              created_at: '2026-04-02T00:00:00.000Z',
+              id: 'tmpl_page_2',
+              name: 'welcome',
+            },
+          ],
+          has_more: false,
+        },
+        error: null,
+      });
+    resend.templates.update.mockResolvedValue({
+      data: { id: 'tmpl_page_2' },
+      error: null,
+    });
+
+    const result = await upsertResendTemplate({
+      resend,
+      name: 'welcome',
+      html: '<p>Hello</p>',
+    });
+
+    expect(result).toEqual({
+      id: 'tmpl_page_2',
+      operation: 'updated',
+    });
+    expect(resend.templates.list).toHaveBeenNthCalledWith(1, {
+      after: undefined,
+      limit: 100,
+    });
+    expect(resend.templates.list).toHaveBeenNthCalledWith(2, {
+      after: 'tmpl_page_1',
+      limit: 100,
+    });
+    expect(resend.templates.update).toHaveBeenCalledWith('tmpl_page_2', {
+      alias,
+      html: '<p>Hello</p>',
+      name: 'welcome',
+    });
+    expect(resend.templates.create).not.toHaveBeenCalled();
+  });
+
+  it('returns the lookup error when fetching an existing alias fails unexpectedly', async () => {
+    const resend = createResendMock();
+    const permissionError = {
+      message: 'Missing permissions',
+      name: 'invalid_access',
+      statusCode: 403,
+    } as const;
+
+    resend.templates.get.mockResolvedValue({
+      data: null,
+      error: permissionError,
+    });
+
+    const result = await upsertResendTemplate({
+      resend,
+      name: 'welcome',
+      html: '<p>Hello</p>',
+    });
+
+    expect(result).toEqual({
+      error: permissionError,
+    });
+    expect(resend.templates.list).not.toHaveBeenCalled();
+    expect(resend.templates.update).not.toHaveBeenCalled();
+    expect(resend.templates.create).not.toHaveBeenCalled();
+  });
+
   it('creates a new template when no existing match is found', async () => {
     const resend = createResendMock();
     const alias = getResendTemplateAlias('welcome');
 
     resend.templates.get.mockResolvedValue({
       data: null,
-      error: {
-        message: 'Template not found',
-        name: 'not_found',
-        statusCode: 404,
-      },
+      error: notFoundError,
     });
     resend.templates.list.mockResolvedValue({
-      data: { data: [] },
+      data: {
+        data: [],
+        has_more: false,
+      },
       error: null,
     });
     resend.templates.create.mockResolvedValue({

--- a/packages/ui/src/utils/resend-template-upsert.spec.ts
+++ b/packages/ui/src/utils/resend-template-upsert.spec.ts
@@ -1,0 +1,209 @@
+import {
+  getResendTemplateAlias,
+  upsertResendTemplate,
+} from './resend-template-upsert';
+
+describe('getResendTemplateAlias()', () => {
+  it('creates a stable alias from the template name', () => {
+    expect(getResendTemplateAlias('welcome-email')).toBe(
+      getResendTemplateAlias('welcome-email'),
+    );
+  });
+
+  it('normalizes the template name and strips the extension', () => {
+    expect(getResendTemplateAlias('Néwsletters/welcome-email.tsx')).toMatch(
+      /^react-email-newsletters-welcome-email-[a-f0-9]{8}$/,
+    );
+  });
+
+  it('avoids collisions when different names sanitize to the same slug', () => {
+    expect(getResendTemplateAlias('welcome/email')).not.toBe(
+      getResendTemplateAlias('welcome-email'),
+    );
+  });
+});
+
+describe('upsertResendTemplate()', () => {
+  const createResendMock = () => {
+    return {
+      templates: {
+        create: vi.fn(),
+        get: vi.fn(),
+        list: vi.fn(),
+        update: vi.fn(),
+      },
+    };
+  };
+
+  it('updates the template directly when the alias already exists', async () => {
+    const resend = createResendMock();
+    const alias = getResendTemplateAlias('welcome');
+
+    resend.templates.get.mockResolvedValue({
+      data: { id: 'tmpl_alias' },
+      error: null,
+    });
+    resend.templates.update.mockResolvedValue({
+      data: { id: 'tmpl_alias' },
+      error: null,
+    });
+
+    const result = await upsertResendTemplate({
+      resend,
+      name: 'welcome',
+      html: '<p>Hello</p>',
+    });
+
+    expect(result).toEqual({
+      id: 'tmpl_alias',
+      operation: 'updated',
+    });
+    expect(resend.templates.update).toHaveBeenCalledWith(alias, {
+      alias,
+      html: '<p>Hello</p>',
+      name: 'welcome',
+    });
+    expect(resend.templates.list).not.toHaveBeenCalled();
+    expect(resend.templates.create).not.toHaveBeenCalled();
+  });
+
+  it('updates the oldest exact name match and assigns the alias', async () => {
+    const resend = createResendMock();
+    const alias = getResendTemplateAlias('welcome');
+
+    resend.templates.get.mockResolvedValue({
+      data: null,
+      error: {
+        message: 'Template not found',
+        name: 'not_found',
+        statusCode: 404,
+      },
+    });
+    resend.templates.list.mockResolvedValue({
+      data: {
+        data: [
+          {
+            alias: null,
+            created_at: '2026-04-10T00:00:00.000Z',
+            id: 'tmpl_newer',
+            name: 'welcome',
+          },
+          {
+            alias: null,
+            created_at: '2026-04-01T00:00:00.000Z',
+            id: 'tmpl_original',
+            name: 'welcome',
+          },
+        ],
+      },
+      error: null,
+    });
+    resend.templates.update.mockResolvedValue({
+      data: { id: 'tmpl_original' },
+      error: null,
+    });
+
+    const result = await upsertResendTemplate({
+      resend,
+      name: 'welcome',
+      html: '<p>Hello</p>',
+    });
+
+    expect(result).toEqual({
+      id: 'tmpl_original',
+      operation: 'updated',
+    });
+    expect(resend.templates.update).toHaveBeenCalledWith('tmpl_original', {
+      alias,
+      html: '<p>Hello</p>',
+      name: 'welcome',
+    });
+    expect(resend.templates.create).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the legacy single-upload name when migrating old templates', async () => {
+    const resend = createResendMock();
+    const alias = getResendTemplateAlias('welcome');
+
+    resend.templates.get.mockResolvedValue({
+      data: null,
+      error: {
+        message: 'Template not found',
+        name: 'not_found',
+        statusCode: 404,
+      },
+    });
+    resend.templates.list.mockResolvedValue({
+      data: {
+        data: [
+          {
+            alias: null,
+            created_at: '2026-04-01T00:00:00.000Z',
+            id: 'tmpl_legacy',
+            name: 'welcome.tsx',
+          },
+        ],
+      },
+      error: null,
+    });
+    resend.templates.update.mockResolvedValue({
+      data: { id: 'tmpl_legacy' },
+      error: null,
+    });
+
+    const result = await upsertResendTemplate({
+      resend,
+      name: 'welcome',
+      legacyName: 'welcome.tsx',
+      html: '<p>Hello</p>',
+    });
+
+    expect(result).toEqual({
+      id: 'tmpl_legacy',
+      operation: 'updated',
+    });
+    expect(resend.templates.update).toHaveBeenCalledWith('tmpl_legacy', {
+      alias,
+      html: '<p>Hello</p>',
+      name: 'welcome',
+    });
+  });
+
+  it('creates a new template when no existing match is found', async () => {
+    const resend = createResendMock();
+    const alias = getResendTemplateAlias('welcome');
+
+    resend.templates.get.mockResolvedValue({
+      data: null,
+      error: {
+        message: 'Template not found',
+        name: 'not_found',
+        statusCode: 404,
+      },
+    });
+    resend.templates.list.mockResolvedValue({
+      data: { data: [] },
+      error: null,
+    });
+    resend.templates.create.mockResolvedValue({
+      data: { id: 'tmpl_created' },
+      error: null,
+    });
+
+    const result = await upsertResendTemplate({
+      resend,
+      name: 'welcome',
+      html: '<p>Hello</p>',
+    });
+
+    expect(result).toEqual({
+      id: 'tmpl_created',
+      operation: 'created',
+    });
+    expect(resend.templates.create).toHaveBeenCalledWith({
+      alias,
+      html: '<p>Hello</p>',
+      name: 'welcome',
+    });
+  });
+});

--- a/packages/ui/src/utils/resend-template-upsert.ts
+++ b/packages/ui/src/utils/resend-template-upsert.ts
@@ -34,9 +34,10 @@ interface ResendTemplatesApi {
     name: string;
   }): PromiseLike<ResendResponse<ResendTemplateIdentifier>>;
   get(identifier: string): Promise<ResendResponse<ResendTemplateIdentifier>>;
-  list(options: { limit: number }): Promise<
+  list(options: { after?: string; limit: number }): Promise<
     ResendResponse<{
       data: ResendTemplateSummary[];
+      has_more: boolean;
     }>
   >;
   update(
@@ -152,6 +153,69 @@ const createMissingTemplateResponse = (message: string): ResendError => ({
   statusCode: null,
 });
 
+const isMissingTemplateError = (error: ResendError | null) => {
+  return error?.statusCode === 404 || error?.name === 'not_found';
+};
+
+const findExistingTemplate = async ({
+  alias,
+  legacyName,
+  name,
+  resend,
+}: {
+  alias: string;
+  legacyName?: string;
+  name: string;
+  resend: ResendApi;
+}) => {
+  let after: string | undefined;
+
+  while (true) {
+    const listResponse = await resend.templates.list({
+      after,
+      limit: RESEND_TEMPLATE_SEARCH_LIMIT,
+    });
+
+    if (listResponse.error || !listResponse.data?.data) {
+      return {
+        error:
+          listResponse.error ??
+          createMissingTemplateResponse(
+            `Failed listing templates before syncing ${name}.`,
+          ),
+      };
+    }
+
+    const templateToUpdate = getTemplateToUpdate(listResponse.data.data, {
+      alias,
+      legacyName,
+      name,
+    });
+
+    if (templateToUpdate) {
+      return {
+        template: templateToUpdate,
+      };
+    }
+
+    if (!listResponse.data.has_more || listResponse.data.data.length === 0) {
+      return {
+        template: undefined,
+      };
+    }
+
+    after = listResponse.data.data.at(-1)?.id;
+
+    if (!after) {
+      return {
+        error: createMissingTemplateResponse(
+          `Failed paginating templates before syncing ${name}.`,
+        ),
+      };
+    }
+  }
+};
+
 export const upsertResendTemplate = async ({
   html,
   legacyName,
@@ -184,32 +248,35 @@ export const upsertResendTemplate = async ({
     };
   }
 
-  const listResponse = await resend.templates.list({
-    limit: RESEND_TEMPLATE_SEARCH_LIMIT,
-  });
-
-  if (listResponse.error || !listResponse.data?.data) {
+  if (
+    existingTemplateResponse.error &&
+    !isMissingTemplateError(existingTemplateResponse.error)
+  ) {
     return {
-      error:
-        listResponse.error ??
-        createMissingTemplateResponse(
-          `Failed listing templates before syncing ${name}.`,
-        ),
+      error: existingTemplateResponse.error,
     };
   }
 
-  const templateToUpdate = getTemplateToUpdate(listResponse.data.data, {
+  const existingTemplateLookup = await findExistingTemplate({
     alias,
     legacyName,
     name,
+    resend,
   });
 
-  if (templateToUpdate) {
-    const updateResponse = await resend.templates.update(templateToUpdate.id, {
-      alias,
-      html,
-      name,
-    });
+  if ('error' in existingTemplateLookup) {
+    return existingTemplateLookup;
+  }
+
+  if (existingTemplateLookup.template) {
+    const updateResponse = await resend.templates.update(
+      existingTemplateLookup.template.id,
+      {
+        alias,
+        html,
+        name,
+      },
+    );
 
     if (updateResponse.error || !updateResponse.data?.id) {
       return {

--- a/packages/ui/src/utils/resend-template-upsert.ts
+++ b/packages/ui/src/utils/resend-template-upsert.ts
@@ -157,6 +157,19 @@ const isMissingTemplateError = (error: ResendError | null) => {
   return error?.statusCode === 404 || error?.name === 'not_found';
 };
 
+type ExistingTemplateLookupResult =
+  | {
+      error: ResendError;
+      status: 'error';
+    }
+  | {
+      status: 'found';
+      template: ResendTemplateSummary;
+    }
+  | {
+      status: 'missing';
+    };
+
 const findExistingTemplate = async ({
   alias,
   legacyName,
@@ -167,7 +180,7 @@ const findExistingTemplate = async ({
   legacyName?: string;
   name: string;
   resend: ResendApi;
-}) => {
+}): Promise<ExistingTemplateLookupResult> => {
   let after: string | undefined;
 
   while (true) {
@@ -183,6 +196,7 @@ const findExistingTemplate = async ({
           createMissingTemplateResponse(
             `Failed listing templates before syncing ${name}.`,
           ),
+        status: 'error',
       };
     }
 
@@ -194,13 +208,14 @@ const findExistingTemplate = async ({
 
     if (templateToUpdate) {
       return {
+        status: 'found',
         template: templateToUpdate,
       };
     }
 
     if (!listResponse.data.has_more || listResponse.data.data.length === 0) {
       return {
-        template: undefined,
+        status: 'missing',
       };
     }
 
@@ -211,6 +226,7 @@ const findExistingTemplate = async ({
         error: createMissingTemplateResponse(
           `Failed paginating templates before syncing ${name}.`,
         ),
+        status: 'error',
       };
     }
   }
@@ -264,11 +280,13 @@ export const upsertResendTemplate = async ({
     resend,
   });
 
-  if ('error' in existingTemplateLookup) {
-    return existingTemplateLookup;
+  if (existingTemplateLookup.status === 'error') {
+    return {
+      error: existingTemplateLookup.error,
+    };
   }
 
-  if (existingTemplateLookup.template) {
+  if (existingTemplateLookup.status === 'found') {
     const updateResponse = await resend.templates.update(
       existingTemplateLookup.template.id,
       {

--- a/packages/ui/src/utils/resend-template-upsert.ts
+++ b/packages/ui/src/utils/resend-template-upsert.ts
@@ -1,0 +1,250 @@
+import { createHash } from 'node:crypto';
+import { removeFilenameExtension } from './contains-email-template';
+
+const RESEND_TEMPLATE_ALIAS_PREFIX = 'react-email';
+const RESEND_TEMPLATE_ALIAS_NAME_MAX_LENGTH = 32;
+const RESEND_TEMPLATE_SEARCH_LIMIT = 100;
+
+interface ResendError {
+  message: string;
+  name: string;
+  statusCode: number | null;
+}
+
+interface ResendResponse<Data> {
+  data: Data | null;
+  error: ResendError | null;
+}
+
+interface ResendTemplateIdentifier {
+  id: string;
+}
+
+interface ResendTemplateSummary {
+  alias: string | null;
+  created_at: string;
+  id: string;
+  name: string;
+}
+
+interface ResendTemplatesApi {
+  create(payload: {
+    alias: string;
+    html: string;
+    name: string;
+  }): PromiseLike<ResendResponse<ResendTemplateIdentifier>>;
+  get(identifier: string): Promise<ResendResponse<ResendTemplateIdentifier>>;
+  list(options: { limit: number }): Promise<
+    ResendResponse<{
+      data: ResendTemplateSummary[];
+    }>
+  >;
+  update(
+    identifier: string,
+    payload: {
+      alias: string;
+      html: string;
+      name: string;
+    },
+  ): Promise<ResendResponse<ResendTemplateIdentifier>>;
+}
+
+interface ResendApi {
+  templates: ResendTemplatesApi;
+}
+
+interface UpsertResendTemplateOptions {
+  html: string;
+  legacyName?: string;
+  name: string;
+  resend: ResendApi;
+}
+
+export type ResendTemplateSyncOperation = 'created' | 'updated';
+
+export type UpsertResendTemplateResult =
+  | {
+      id: string;
+      operation: ResendTemplateSyncOperation;
+    }
+  | {
+      error: ResendError;
+    };
+
+const sanitizeTemplateAliasName = (templateName: string) => {
+  const sanitized = removeFilenameExtension(templateName)
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, RESEND_TEMPLATE_ALIAS_NAME_MAX_LENGTH);
+
+  if (sanitized.length === 0) {
+    return 'template';
+  }
+
+  return sanitized;
+};
+
+export const getResendTemplateAlias = (templateName: string) => {
+  const sanitizedName = sanitizeTemplateAliasName(templateName);
+  const templateHash = createHash('sha256')
+    .update(removeFilenameExtension(templateName))
+    .digest('hex')
+    .slice(0, 8);
+
+  return `${RESEND_TEMPLATE_ALIAS_PREFIX}-${sanitizedName}-${templateHash}`;
+};
+
+const chooseOldestTemplate = (templates: ResendTemplateSummary[]) => {
+  return [...templates].sort((leftTemplate, rightTemplate) => {
+    return (
+      new Date(leftTemplate.created_at).getTime() -
+      new Date(rightTemplate.created_at).getTime()
+    );
+  })[0];
+};
+
+const getTemplateToUpdate = (
+  templates: ResendTemplateSummary[],
+  {
+    alias,
+    legacyName,
+    name,
+  }: {
+    alias: string;
+    legacyName?: string;
+    name: string;
+  },
+) => {
+  const exactAliasMatch = templates.find(
+    (template) => template.alias === alias,
+  );
+
+  if (exactAliasMatch) {
+    return exactAliasMatch;
+  }
+
+  const exactNameMatches = templates.filter(
+    (template) => template.name === name,
+  );
+  if (exactNameMatches.length > 0) {
+    return chooseOldestTemplate(exactNameMatches);
+  }
+
+  if (legacyName) {
+    const legacyNameMatches = templates.filter(
+      (template) => template.name === legacyName,
+    );
+
+    if (legacyNameMatches.length > 0) {
+      return chooseOldestTemplate(legacyNameMatches);
+    }
+  }
+
+  return undefined;
+};
+
+const createMissingTemplateResponse = (message: string): ResendError => ({
+  message,
+  name: 'application_error',
+  statusCode: null,
+});
+
+export const upsertResendTemplate = async ({
+  html,
+  legacyName,
+  name,
+  resend,
+}: UpsertResendTemplateOptions): Promise<UpsertResendTemplateResult> => {
+  const alias = getResendTemplateAlias(name);
+  const existingTemplateResponse = await resend.templates.get(alias);
+
+  if (existingTemplateResponse.data?.id) {
+    const updateResponse = await resend.templates.update(alias, {
+      alias,
+      html,
+      name,
+    });
+
+    if (updateResponse.error || !updateResponse.data?.id) {
+      return {
+        error:
+          updateResponse.error ??
+          createMissingTemplateResponse(
+            `Failed updating the template for ${name}.`,
+          ),
+      };
+    }
+
+    return {
+      id: updateResponse.data.id,
+      operation: 'updated',
+    };
+  }
+
+  const listResponse = await resend.templates.list({
+    limit: RESEND_TEMPLATE_SEARCH_LIMIT,
+  });
+
+  if (listResponse.error || !listResponse.data?.data) {
+    return {
+      error:
+        listResponse.error ??
+        createMissingTemplateResponse(
+          `Failed listing templates before syncing ${name}.`,
+        ),
+    };
+  }
+
+  const templateToUpdate = getTemplateToUpdate(listResponse.data.data, {
+    alias,
+    legacyName,
+    name,
+  });
+
+  if (templateToUpdate) {
+    const updateResponse = await resend.templates.update(templateToUpdate.id, {
+      alias,
+      html,
+      name,
+    });
+
+    if (updateResponse.error || !updateResponse.data?.id) {
+      return {
+        error:
+          updateResponse.error ??
+          createMissingTemplateResponse(
+            `Failed updating the template for ${name}.`,
+          ),
+      };
+    }
+
+    return {
+      id: updateResponse.data.id,
+      operation: 'updated',
+    };
+  }
+
+  const createResponse = await resend.templates.create({
+    alias,
+    html,
+    name,
+  });
+
+  if (createResponse.error || !createResponse.data?.id) {
+    return {
+      error:
+        createResponse.error ??
+        createMissingTemplateResponse(
+          `Failed creating the template for ${name}.`,
+        ),
+    };
+  }
+
+  return {
+    id: createResponse.data.id,
+    operation: 'created',
+  };
+};


### PR DESCRIPTION
## Summary

Fixes #3194.

The Resend integration in the preview server always created a new template on every upload. That made repeated uploads produce duplicate templates instead of updating the original one.

This PR changes the upload flow to behave like an upsert:
- use a deterministic Resend alias per template
- update an existing template when a match is found
- only create a new template when no existing template can be matched

## Changes

- added a dedicated Resend template upsert helper in `packages/preview-server/src/utils/resend-template-upsert.ts`
- added focused tests for alias generation and matching behavior in `packages/preview-server/src/utils/resend-template-upsert.spec.ts`
- updated `packages/preview-server/src/actions/export-single-template.ts` to use the upsert flow instead of calling `resend.templates.create()` directly
- updated `packages/preview-server/src/components/toolbar/resend.tsx` so both single upload and bulk upload use the same normalized template identity
- updated the toolbar messaging so the UI distinguishes between template creation and template update

## Why

Previously the preview server always called `resend.templates.create()`, so every upload created a new dashboard template.

This implementation introduces a stable alias for each template and uses it to find and update the same template on future uploads. It also includes a fallback for older templates created before aliases were used, including older single-upload names that included the file extension.

That keeps new uploads stable while still allowing existing templates to be migrated into the new flow.

## Verification

Ran:
- `pnpm --filter @react-email/preview-server exec vitest run src/utils/resend-template-upsert.spec.ts`
- `pnpm exec biome check packages/preview-server/src/utils/resend-template-upsert.ts packages/preview-server/src/utils/resend-template-upsert.spec.ts packages/preview-server/src/actions/export-single-template.ts packages/preview-server/src/components/toolbar/resend.tsx`

Results:
- focused tests passed
- formatting and lint checks passed on touched files

Note:
- `pnpm --filter @react-email/preview-server exec tsc --noEmit` still reports existing package-wide type resolution issues unrelated to this patch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate Resend templates by upserting on upload in `@react-email/ui`. Uses a stable alias and a paginated lookup to update existing templates, and updates the toolbar to show when a template was created vs updated.

- **Bug Fixes**
  - Added `upsertResendTemplate` to generate a deterministic alias and update existing templates; only creates when no match is found (with fallback to legacy names, including those with extensions).
  - Implemented paginated template lookup and selected the oldest exact name match when the alias isn’t present; tightened result narrowing for CI.
  - Switched single and bulk uploads to use normalized template names via `removeFilenameExtension` and the upsert flow; pass `legacyName` for migration.
  - Updated UI messaging to distinguish “created” vs “updated” and return/display the `operation` in results; added focused tests for alias generation, matching, and pagination.

<sup>Written for commit 355eaa45536f87a9c348966cdcd32e70066fc9e8. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3278?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

