### PR TITLE
fix: pull-requests write permission for sync-prs-to-linear

### DIFF
--- a/.github/workflows/sync-prs-to-linear.yml
+++ b/.github/workflows/sync-prs-to-linear.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      pull-requests: read
+      pull-requests: write
       issues: write
 
     steps:

--- a/.github/workflows/sync-prs-to-linear.yml
+++ b/.github/workflows/sync-prs-to-linear.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@3eb5c6b385a32cbef0551f50f4b6b01651cf1644
+      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@8e1157bc66378899c7e80a49b45b1a0a0067f7a5
         with:
           linear-api-key: ${{ secrets.LINEAR_API_KEY }}
           linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}


### PR DESCRIPTION
Adding labels to PRs via the issues API requires `pull-requests: write`. Was set to `read` which caused the action to fail with 'Resource not accessible by integration'.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grant `pull-requests: write` in the `sync-prs-to-linear` workflow so it can add PR labels via the Issues API and stop “Resource not accessible by integration” failures. Also bump the `resend/public-shared-workflows` action reference.

<sup>Written for commit 744cbd38153c62f927a97c3004425ed5d58e886c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

