### PR TITLE
chore: bump public-shared-workflows hash

### DIFF
--- a/.github/workflows/sync-prs-to-linear.yml
+++ b/.github/workflows/sync-prs-to-linear.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@8e1157bc66378899c7e80a49b45b1a0a0067f7a5
+      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@987719e552691473bfd4aa8a105d63277d8709df
         with:
           linear-api-key: ${{ secrets.LINEAR_API_KEY }}
           linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}


### PR DESCRIPTION
Pins to `987719e552691473bfd4aa8a105d63277d8709df` which adds bot and internal member filtering to the linear sync action.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `resend/public-shared-workflows/.github/actions/sync_prs_to_linear` to `987719e552691473bfd4aa8a105d63277d8709df` to add bot and internal member filtering. This reduces noise in Linear by skipping PRs from bots and internal contributors.

<sup>Written for commit 89a61e690e75a59c3716c25417b3d9846a305d7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

