### PR TITLE
chore: bump public-shared-workflows hash

### DIFF
--- a/.github/workflows/sync-prs-to-linear.yml
+++ b/.github/workflows/sync-prs-to-linear.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@987719e552691473bfd4aa8a105d63277d8709df
+      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@6adbbae7541681ead204faab5d4e5ea9bebca4da
         with:
           linear-api-key: ${{ secrets.LINEAR_API_KEY }}
           linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}


### PR DESCRIPTION
Pins to `6adbbae7541681ead204faab5d4e5ea9bebca4da` which includes debug logging for PR author associations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `resend/public-shared-workflows/.github/actions/sync_prs_to_linear` to a version with debug logs for PR author associations. Improves troubleshooting of PR-to-Linear sync.

<sup>Written for commit 8c9baaeadb509af55fa41ecf97bb3805dce05465. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

