### PR TITLE
fix: avoid OOM when exporting many email templates

### DIFF
--- a/.changeset/email-export-oom-large-templates.md
+++ b/.changeset/email-export-oom-large-templates.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Avoid OOM when running `email export` on projects with many templates. esbuild builds now run in batches of 10 entry points, and the render phase runs each batch of 25 templates inside a `worker_threads` worker so V8 isolate memory is reclaimed between batches.

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -179,7 +179,6 @@ export const exportTemplates = async (
         const worker = new Worker(renderWorkerSource, {
           eval: true,
           workerData: { templates: batch, options },
-          execArgv: process.execArgv,
         });
         worker.on('message', (msg: RenderWorkerMessage) => {
           if (msg.type === 'progress') {

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -36,21 +36,13 @@ type ExportTemplatesOptions = Options & {
   pretty?: boolean;
 };
 
-// esbuild bundles each entry's full dep graph in-memory, so building all
-// templates in one call OOMs at high counts (#2887). Batching caps peak
-// memory at BUILD_BATCH_SIZE × per-entry cost.
+// Batch so esbuild's Go-side dep graph isn't held for every entry at once.
 const BUILD_BATCH_SIZE = 10;
 
-// Each bundled .cjs is ~1.5MB of self-contained code (inlined react-email,
-// tailwind, css-tree, react). Requiring many in one process accumulates V8
-// state that `delete require.cache[...]` cannot release. Renders run in
-// worker_threads, RENDER_BATCH_SIZE templates per worker, so each batch's
-// V8 isolate is reclaimed when the worker exits.
+// Render each batch in a worker so its V8 isolate is freed on exit;
+// require.cache alone doesn't release the inlined react-email bundles.
 const RENDER_BATCH_SIZE = 25;
 
-// Inlined as a string so we don't need a separate worker file (which would
-// require path/extension juggling between dev source and bundled dist).
-// CommonJS because `new Worker(code, { eval: true })` evaluates as CJS.
 const renderWorkerSource = `
 const { unlinkSync, writeFileSync } = require('node:fs');
 const { parentPort, workerData } = require('node:worker_threads');
@@ -145,8 +137,6 @@ export const exportTemplates = async (
         plugins: [renderingUtilitiesExporter(batch)],
         write: true,
       });
-      // Kill the esbuild service between batches so Go releases its RSS;
-      // the next build() spawns a fresh process.
       await stop();
     }
   } catch (exception) {

--- a/packages/react-email/src/cli/commands/export.ts
+++ b/packages/react-email/src/cli/commands/export.ts
@@ -1,13 +1,11 @@
-import fs, { unlinkSync, writeFileSync } from 'node:fs';
-import { createRequire } from 'node:module';
+import fs from 'node:fs';
 import path from 'node:path';
-import url from 'node:url';
+import { Worker } from 'node:worker_threads';
 import type { Options } from '@react-email/render';
-import { type BuildFailure, build } from 'esbuild';
+import { type BuildFailure, build, stop } from 'esbuild';
 import { glob } from 'glob';
 import logSymbols from 'log-symbols';
 import normalize from 'normalize-path';
-import type React from 'react';
 import { renderingUtilitiesExporter } from '../utils/esbuild/renderring-utilities-exporter.js';
 import {
   type EmailsDirectory,
@@ -38,9 +36,57 @@ type ExportTemplatesOptions = Options & {
   pretty?: boolean;
 };
 
-const filename = url.fileURLToPath(import.meta.url);
+// esbuild bundles each entry's full dep graph in-memory, so building all
+// templates in one call OOMs at high counts (#2887). Batching caps peak
+// memory at BUILD_BATCH_SIZE × per-entry cost.
+const BUILD_BATCH_SIZE = 10;
 
-const require = createRequire(filename);
+// Each bundled .cjs is ~1.5MB of self-contained code (inlined react-email,
+// tailwind, css-tree, react). Requiring many in one process accumulates V8
+// state that `delete require.cache[...]` cannot release. Renders run in
+// worker_threads, RENDER_BATCH_SIZE templates per worker, so each batch's
+// V8 isolate is reclaimed when the worker exits.
+const RENDER_BATCH_SIZE = 25;
+
+// Inlined as a string so we don't need a separate worker file (which would
+// require path/extension juggling between dev source and bundled dist).
+// CommonJS because `new Worker(code, { eval: true })` evaluates as CJS.
+const renderWorkerSource = `
+const { unlinkSync, writeFileSync } = require('node:fs');
+const { parentPort, workerData } = require('node:worker_threads');
+
+const { templates, options } = workerData;
+
+(async () => {
+  for (const template of templates) {
+    try {
+      const emailModule = require(template);
+      const rendered = await emailModule.render(
+        emailModule.reactEmailCreateReactElement(emailModule.default, {}),
+        options,
+      );
+      const htmlPath = template.replace(
+        '.cjs',
+        options.plainText ? '.txt' : '.html',
+      );
+      writeFileSync(htmlPath, rendered);
+      unlinkSync(template);
+      parentPort.postMessage({ type: 'progress', template });
+    } catch (exception) {
+      parentPort.postMessage({
+        type: 'error',
+        template,
+        message: exception && exception.stack ? exception.stack : String(exception),
+      });
+      process.exit(1);
+    }
+  }
+})();
+`;
+
+type RenderWorkerMessage =
+  | { type: 'progress'; template: string }
+  | { type: 'error'; template: string; message: string };
 
 /*
   This first builds all the templates using esbuild and then puts the output in the `.js`
@@ -83,20 +129,26 @@ export const exportTemplates = async (
   const allTemplates = getEmailTemplatesFromDirectory(emailsDirectoryMetadata);
 
   try {
-    await build({
-      bundle: true,
-      entryPoints: allTemplates,
-      external: ['css-tree'],
-      format: 'cjs',
-      jsx: 'automatic',
-      loader: { '.js': 'jsx' },
-      logLevel: 'silent',
-      outExtension: { '.js': '.cjs' },
-      outdir: pathToWhereEmailMarkupShouldBeDumped,
-      platform: 'node',
-      plugins: [renderingUtilitiesExporter(allTemplates)],
-      write: true,
-    });
+    for (let i = 0; i < allTemplates.length; i += BUILD_BATCH_SIZE) {
+      const batch = allTemplates.slice(i, i + BUILD_BATCH_SIZE);
+      await build({
+        bundle: true,
+        entryPoints: batch,
+        external: ['css-tree'],
+        format: 'cjs',
+        jsx: 'automatic',
+        loader: { '.js': 'jsx' },
+        logLevel: 'silent',
+        outExtension: { '.js': '.cjs' },
+        outdir: pathToWhereEmailMarkupShouldBeDumped,
+        platform: 'node',
+        plugins: [renderingUtilitiesExporter(batch)],
+        write: true,
+      });
+      // Kill the esbuild service between batches so Go releases its RSS;
+      // the next build() spawns a fresh process.
+      await stop();
+    }
   } catch (exception) {
     if (spinner) {
       stopSpinnerAndPersist(spinner, {
@@ -127,35 +179,48 @@ export const exportTemplates = async (
     spinner.start();
   }
 
-  for await (const template of allBuiltTemplates) {
+  for (let i = 0; i < allBuiltTemplates.length; i += RENDER_BATCH_SIZE) {
+    const batch = allBuiltTemplates.slice(i, i + RENDER_BATCH_SIZE);
+    let failedTemplate: string | undefined;
+    let failureMessage: string | undefined;
+
     try {
-      if (spinner) {
-        spinner.setText(`rendering ${template.split('/').pop()}`);
-      }
-      delete require.cache[template];
-      const emailModule = require(template) as {
-        default: React.FC;
-        render: (
-          element: React.ReactElement,
-          options: Record<string, unknown>,
-        ) => Promise<string>;
-        reactEmailCreateReactElement: typeof React.createElement;
-      };
-      const rendered = await emailModule.render(
-        emailModule.reactEmailCreateReactElement(emailModule.default, {}),
-        options,
-      );
-      const htmlPath = template.replace(
-        '.cjs',
-        options.plainText ? '.txt' : '.html',
-      );
-      writeFileSync(htmlPath, rendered);
-      unlinkSync(template);
+      await new Promise<void>((resolve, reject) => {
+        const worker = new Worker(renderWorkerSource, {
+          eval: true,
+          workerData: { templates: batch, options },
+          execArgv: process.execArgv,
+        });
+        worker.on('message', (msg: RenderWorkerMessage) => {
+          if (msg.type === 'progress') {
+            if (spinner) {
+              spinner.setText(`rendering ${msg.template.split('/').pop()}`);
+            }
+          } else if (msg.type === 'error') {
+            failedTemplate = msg.template;
+            failureMessage = msg.message;
+          }
+        });
+        worker.on('error', reject);
+        worker.on('exit', (code) => {
+          if (code !== 0) {
+            reject(
+              new Error(
+                failureMessage ?? `Render worker exited with code ${code}`,
+              ),
+            );
+          } else {
+            resolve();
+          }
+        });
+      });
     } catch (exception) {
       if (spinner) {
         stopSpinnerAndPersist(spinner, {
           symbol: logSymbols.error,
-          text: `failed when rendering ${template.split('/').pop()}`,
+          text: failedTemplate
+            ? `failed when rendering ${failedTemplate.split('/').pop()}`
+            : 'failed when rendering',
         });
       }
       console.error(exception);


### PR DESCRIPTION
`email export` crashed with "JavaScript heap out of memory" once a project had a few hundred templates. Two distinct causes, in two distinct phases:

1. Build phase: `esbuild.build()` was called once with every template as an entry point. With `bundle: true`, esbuild expands each entry's full dep graph in-memory (each template pulls ~1.5MB of react-email + transitive). The Go subprocess held all of that simultaneously.

2. Render phase: every bundled `.cjs` is self-contained with its own copy of react-email, tailwind, css-tree, react. Sequentially requiring them accumulates V8 state that `delete require.cache[...]` cannot release; heap grew ~14MB per template and crashed at ~290.

Build phase now runs in batches of 10 entry points with `esbuild.stop()` between batches so the Go subprocess's RSS is released. Render phase runs batches of 25 templates inside `worker_threads.Worker` instances; each worker's V8 isolate is reclaimed on termination, so peak heap stays bounded by one batch's worth.

Closes #2887

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents OOM crashes in `email export` by batching `esbuild` builds and rendering in short‑lived `worker_threads`. Also adds a changeset for a `react-email` patch release.

- **Bug Fixes**
  - Build: batch `esbuild` entry points (10 at a time) and call `esbuild.stop()` between batches.
  - Render: batch templates (25 per worker) in `worker_threads`; each worker exits to reclaim its V8 heap. Do not forward `execArgv` to avoid `ERR_WORKER_INVALID_EXEC_ARGV` with flags like `--max-old-space-size`.
  - Progress and errors: spinner updates per template; errors include the failing template name.
  - Cleanup: remove temporary `.cjs` bundles after rendering.

<sup>Written for commit 4ca81a9eaae2055ef66a3e76e6087785e9779289. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3518?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

