### PR TITLE
chore: stub REDIS_URL in preview-release workflow

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -40,6 +40,7 @@ jobs:
           SPAM_ASSASSIN_PORT: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.SPAM_ASSASSIN_PORT || '' }}
           TURBO_TOKEN: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.TURBO_TOKEN || '' }}
           TURBO_TEAM: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.TURBO_TEAM || '' }}
+          REDIS_URL: redis://localhost:6379
       - name: Publish changed packages to pkg.pr.new
         if: steps.changed_packages.outputs.all_changed_and_modified_files != ''
         run: pnpm pkg-pr-new publish ${{ steps.changed_packages.outputs.all_changed_and_modified_files }} --pnpm


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stubs `REDIS_URL` in the `preview-release` workflow to prevent `apps/web` from failing during `next build` page-data collection. This unblocks preview releases when `turbo` marks `apps/web` as affected; no Redis connection is made.

<sup>Written for commit 9417ade84dababbf0cd1c7107698acdbc00dbfa0. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3520?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

