### PR TITLE
fix(web): reduce nested scrollbars in editor examples

### DIFF
--- a/apps/web/src/app/editor/email-export/example.tsx
+++ b/apps/web/src/app/editor/email-export/example.tsx
@@ -65,11 +65,9 @@ function ExportPanel() {
         {exporting ? 'Exporting...' : 'Export HTML'}
       </button>
       {html && (
-        <textarea
-          readOnly
-          value={html}
-          className="mt-3 w-full h-64 p-3 font-mono text-xs bg-(--re-bg) text-(--re-text) border border-(--re-border) rounded-lg resize-y"
-        />
+        <pre className="mt-3 w-full p-3 font-mono text-xs bg-(--re-bg) text-(--re-text) border border-(--re-border) rounded-lg whitespace-pre-wrap break-all select-all">
+          {html}
+        </pre>
       )}
     </div>
   );

--- a/apps/web/src/app/editor/email-export/example.tsx
+++ b/apps/web/src/app/editor/email-export/example.tsx
@@ -65,7 +65,7 @@ function ExportPanel() {
         {exporting ? 'Exporting...' : 'Export HTML'}
       </button>
       {html && (
-        <pre className="mt-3 w-full p-3 font-mono text-xs bg-(--re-bg) text-(--re-text) border border-(--re-border) rounded-lg whitespace-pre-wrap break-all select-all">
+        <pre className="mt-3 w-full p-3 font-mono text-xs bg-(--re-bg) text-(--re-text) border border-(--re-border) rounded-lg whitespace-pre-wrap break-words select-all">
           {html}
         </pre>
       )}

--- a/apps/web/src/app/editor/full-email-builder/example.tsx
+++ b/apps/web/src/app/editor/full-email-builder/example.tsx
@@ -30,7 +30,7 @@ const content = `
 
 function Sidebar() {
   return (
-    <aside className="w-56 shrink-0 border-l border-(--re-border) p-3 flex flex-col gap-3 overflow-y-auto text-xs">
+    <aside className="w-56 shrink-0 border-l border-(--re-border) p-3 flex flex-col gap-3 text-xs">
       <Inspector.Root>
         <nav>
           <ol className="flex items-center gap-1 list-none m-0 p-0 mb-4">
@@ -104,11 +104,9 @@ function ExportPanel() {
         {exporting ? 'Exporting...' : 'Export HTML'}
       </button>
       {html && (
-        <textarea
-          readOnly
-          value={html}
-          className="mt-3 w-full h-64 p-3 font-mono text-xs bg-(--re-bg) text-(--re-text) border border-(--re-border) rounded-lg resize-y"
-        />
+        <pre className="mt-3 w-full p-3 font-mono text-xs bg-(--re-bg) text-(--re-text) border border-(--re-border) rounded-lg whitespace-pre-wrap break-all select-all">
+          {html}
+        </pre>
       )}
     </div>
   );
@@ -158,11 +156,8 @@ export function FullEmailBuilder() {
         </button>
       </div>
       <EditorContext.Provider value={{ editor }}>
-        <div
-          className="flex overflow-hidden -mx-4 -mb-4 border-t border-(--re-border)"
-          style={{ height: '32rem' }}
-        >
-          <div className="flex-1 min-w-0 m-4 mt-0 overflow-y-auto">
+        <div className="flex -mx-4 -mb-4 border-t border-(--re-border) min-h-0">
+          <div className="flex-1 min-w-0 m-4 mt-0">
             <EditorContent
               className="p-4 pt-0 bg-white rounded-md"
               editor={editor}

--- a/apps/web/src/app/editor/full-email-builder/example.tsx
+++ b/apps/web/src/app/editor/full-email-builder/example.tsx
@@ -104,7 +104,7 @@ function ExportPanel() {
         {exporting ? 'Exporting...' : 'Export HTML'}
       </button>
       {html && (
-        <pre className="mt-3 w-full p-3 font-mono text-xs bg-(--re-bg) text-(--re-text) border border-(--re-border) rounded-lg whitespace-pre-wrap break-all select-all">
+        <pre className="mt-3 w-full p-3 font-mono text-xs bg-(--re-bg) text-(--re-text) border border-(--re-border) rounded-lg whitespace-pre-wrap break-words select-all">
           {html}
         </pre>
       )}

--- a/apps/web/src/app/editor/inspector-composed/example.tsx
+++ b/apps/web/src/app/editor/inspector-composed/example.tsx
@@ -30,15 +30,15 @@ export function InspectorComposed() {
       description="Cherry-pick which sections render, control collapse state, and mix in custom sections alongside built-in ones."
     >
       <EditorContext.Provider value={{ editor }}>
-        <div className="flex flex-1 min-h-0 overflow-hidden -m-4">
-          <div className="flex-1 min-w-0 m-4 mt-0 overflow-y-auto">
+        <div className="flex -m-4">
+          <div className="flex-1 min-w-0 m-4 mt-0">
             <EditorContent
               className="p-4 pt-0 bg-white rounded-md"
               editor={editor}
             />
           </div>
 
-          <aside className="w-60 shrink-0 border-l border-(--re-border) p-4 flex flex-col gap-4 overflow-y-auto text-xs">
+          <aside className="w-60 shrink-0 border-l border-(--re-border) p-4 flex flex-col gap-4 text-xs">
             <Inspector.Root>
               <Breadcrumb />
 

--- a/apps/web/src/app/editor/inspector-custom/example.tsx
+++ b/apps/web/src/app/editor/inspector-custom/example.tsx
@@ -30,14 +30,14 @@ export function InspectorCustom() {
       description="Build the entire inspector UI from scratch using only render-props data and plain HTML. No primitives or section components."
     >
       <EditorContext.Provider value={{ editor }}>
-        <div className="flex flex-1 min-h-0 overflow-hidden -m-4">
-          <div className="flex-1 min-w-0 m-4 mt-0 overflow-y-auto">
+        <div className="flex -m-4">
+          <div className="flex-1 min-w-0 m-4 mt-0">
             <EditorContent
               className="p-4 pt-0 bg-white rounded-md"
               editor={editor}
             />
           </div>
-          <aside className="w-60 shrink-0 border-l border-(--re-border) p-4 flex flex-col gap-3 overflow-y-auto text-xs">
+          <aside className="w-60 shrink-0 border-l border-(--re-border) p-4 flex flex-col gap-3 text-xs">
             <Inspector.Root>
               <Inspector.Document>
                 {({ findStyleValue, setGlobalStyle }) => (

--- a/apps/web/src/app/editor/inspector-defaults/example.tsx
+++ b/apps/web/src/app/editor/inspector-defaults/example.tsx
@@ -31,15 +31,15 @@ export function InspectorDefaults() {
       description="Zero-config inspector sidebar. All three inspectors (Document, Node, Text) render sensible defaults when no children are passed."
     >
       <EditorContext.Provider value={{ editor }}>
-        <div className="flex flex-1 min-h-0 overflow-hidden -m-4">
-          <div className="flex-1 min-w-0 m-4 overflow-y-auto">
+        <div className="flex -m-4">
+          <div className="flex-1 min-w-0 m-4">
             <EditorContent
               className="p-4 pt-0 bg-white rounded-md"
               editor={editor}
             />
           </div>
 
-          <aside className="w-60 shrink-0 border-l border-(--re-border) p-4 flex flex-col gap-4 overflow-y-auto text-xs">
+          <aside className="w-60 shrink-0 border-l border-(--re-border) p-4 flex flex-col gap-4 text-xs">
             <Inspector.Root>
               <Breadcrumb />
               <Inspector.Document />

--- a/apps/web/src/app/editor/standalone-editor-full/example.tsx
+++ b/apps/web/src/app/editor/standalone-editor-full/example.tsx
@@ -77,11 +77,9 @@ export function StandaloneEditorFull() {
       />
 
       {output && (
-        <textarea
-          readOnly
-          value={output}
-          className="mt-4 w-full h-64 p-3 font-mono text-xs bg-(--re-bg) text-(--re-text) border border-(--re-border) rounded-lg resize-y"
-        />
+        <pre className="mt-4 w-full p-3 font-mono text-xs bg-(--re-bg) text-(--re-text) border border-(--re-border) rounded-lg whitespace-pre-wrap break-all select-all">
+          {output}
+        </pre>
       )}
     </ExampleShell>
   );

--- a/apps/web/src/app/editor/standalone-editor-full/example.tsx
+++ b/apps/web/src/app/editor/standalone-editor-full/example.tsx
@@ -77,7 +77,7 @@ export function StandaloneEditorFull() {
       />
 
       {output && (
-        <pre className="mt-4 w-full p-3 font-mono text-xs bg-(--re-bg) text-(--re-text) border border-(--re-border) rounded-lg whitespace-pre-wrap break-all select-all">
+        <pre className="mt-4 w-full p-3 font-mono text-xs bg-(--re-bg) text-(--re-text) border border-(--re-border) rounded-lg whitespace-pre-wrap break-words select-all">
           {output}
         </pre>
       )}

--- a/apps/web/src/app/editor/standalone-editor-inspector/example.tsx
+++ b/apps/web/src/app/editor/standalone-editor-inspector/example.tsx
@@ -18,13 +18,10 @@ export function StandaloneEditorInspector() {
       title="Standalone editor — inspector"
       description="Add an inspector sidebar alongside the standalone EmailEditor — no manual EditorProvider setup needed."
     >
-      <div
-        className="flex flex-1 min-h-0 overflow-hidden"
-        style={{ height: '32rem' }}
-      >
+      <div className="flex">
         <EmailEditor
           content={content}
-          className="flex-1 min-w-0 overflow-y-auto mr-4 p-4 bg-white rounded-md"
+          className="flex-1 min-w-0 mr-4 p-4 bg-white rounded-md"
         >
           <Sidebar />
         </EmailEditor>
@@ -35,7 +32,7 @@ export function StandaloneEditorInspector() {
 
 function Sidebar() {
   return (
-    <Inspector.Root className="w-60 shrink-0 border-l border-(--re-border) pt-8 p-4 flex flex-col overflow-y-auto text-xs">
+    <Inspector.Root className="w-60 shrink-0 border-l border-(--re-border) pt-8 p-4 flex flex-col text-xs">
       <Breadcrumb />
       <Inspector.Document />
       <Inspector.Node />


### PR DESCRIPTION
Drop fixed-height containers and unnecessary overflow-y-auto wrappers across the editor example pages so each page scrolls with a single viewport-level scrollbar. Replace readonly textareas used for HTML export with non-scrolling `<pre>` blocks for the same reason.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies scrolling in editor examples by using a single viewport scrollbar and removing inner scroll areas. Switches export previews to `<pre>` blocks with readable wrapping for easier viewing and copying.

- **Bug Fixes**
  - Dropped fixed heights and `overflow-y-auto` from editor panes and sidebars.
  - Replaced readonly `textarea` exports with `<pre>` using `whitespace-pre-wrap` and `select-all`.
  - Switched to `break-words` in export previews to avoid breaking inside HTML tags and attributes.

<sup>Written for commit ecc9808ceeb25af9101ce8aea3d3d5090be126a8. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3521?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

