### PR TITLE
fix(ui): possible security issue

### DIFF
--- a/.changeset/secure-emails-dir-action.md
+++ b/.changeset/secure-emails-dir-action.md
@@ -1,0 +1,12 @@
+---
+"@react-email/ui": patch
+---
+
+stop accepting the emails directory path as a server-action argument
+
+The `getEmailsDirectoryMetadataAction` server action used to take an
+absolute filesystem path from the client and walk that directory on the
+server, which allowed any caller of the endpoint to enumerate arbitrary
+directories on the host. The action now reads the path from the server-only
+`REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH` env variable and ignores
+client input.

--- a/packages/ui/src/actions/get-emails-directory-metadata-action.ts
+++ b/packages/ui/src/actions/get-emails-directory-metadata-action.ts
@@ -1,19 +1,11 @@
 'use server';
 
+import { emailsDirectoryAbsolutePath } from '../app/env';
 import type { EmailsDirectory } from '../utils/get-emails-directory-metadata';
 import { getEmailsDirectoryMetadata } from '../utils/get-emails-directory-metadata';
 
-export const getEmailsDirectoryMetadataAction = async (
-  absolutePathToEmailsDirectory: string,
-  keepFileExtensions = false,
-  isSubDirectory = false,
-
-  baseDirectoryPath = absolutePathToEmailsDirectory,
-): Promise<EmailsDirectory | undefined> => {
-  return getEmailsDirectoryMetadata(
-    absolutePathToEmailsDirectory,
-    keepFileExtensions,
-    isSubDirectory,
-    baseDirectoryPath,
-  );
+export const getEmailsDirectoryMetadataAction = async (): Promise<
+  EmailsDirectory | undefined
+> => {
+  return getEmailsDirectoryMetadata(emailsDirectoryAbsolutePath);
 };

--- a/packages/ui/src/contexts/emails.tsx
+++ b/packages/ui/src/contexts/emails.tsx
@@ -34,9 +34,7 @@ export const EmailsProvider = (props: {
 
   if (!isBuilding && !isPreviewDevelopment) {
     useHotreload(async () => {
-      const metadata = await getEmailsDirectoryMetadataAction(
-        props.initialEmailsDirectoryMetadata.absolutePath,
-      );
+      const metadata = await getEmailsDirectoryMetadataAction();
       if (metadata) {
         setEmailsDirectoryMetadata(metadata);
       } else {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a path injection risk by removing client-controlled paths from the emails directory server action. The action now reads the absolute path from a server-only env var, addressing CodeQL alert #288 (DEV-797).

- **Bug Fixes**
  - `getEmailsDirectoryMetadataAction` no longer accepts a path argument; uses `emailsDirectoryAbsolutePath` from `REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH`.
  - `EmailsProvider` updated to call the action with no args; hot-reload flow unchanged.
  - Changeset added to publish a patch for `@react-email/ui`.

- **Migration**
  - Update any direct calls to `getEmailsDirectoryMetadataAction()` to pass no arguments.
  - Ensure `REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH` is set on the server.

<sup>Written for commit ee132bd604e96ebdd5fdaa6b4c8dd67306a1fdd1. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3531?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

