### PR TITLE
fix(ui): possible security issue with email file access

### DIFF
--- a/.changeset/contain-render-email-path.md
+++ b/.changeset/contain-render-email-path.md
@@ -1,0 +1,5 @@
+---
+"@react-email/ui": patch
+---
+
+reject paths that resolve outside the configured emails directory in `renderEmailByPath` and `getEmailPathFromSlug` to close a path-traversal vector in the preview server

--- a/packages/ui/src/actions/get-email-path-from-slug.ts
+++ b/packages/ui/src/actions/get-email-path-from-slug.ts
@@ -4,27 +4,32 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { cache } from 'react';
 import { emailsDirectoryAbsolutePath } from '../app/env';
+import { isPathWithinEmailsDirectory } from '../utils/is-path-within-emails-directory';
+
+const safeReturn = (candidate: string): string | undefined => {
+  return isPathWithinEmailsDirectory(candidate) ? candidate : undefined;
+};
 
 export const getEmailPathFromSlug = cache(async (slug: string) => {
   if (['.tsx', '.jsx', '.ts', '.js', '.html'].includes(path.extname(slug)))
-    return path.join(emailsDirectoryAbsolutePath, slug);
+    return safeReturn(path.join(emailsDirectoryAbsolutePath, slug));
 
   const pathWithoutExtension = path.join(emailsDirectoryAbsolutePath, slug);
 
   if (fs.existsSync(`${pathWithoutExtension}.tsx`)) {
-    return `${pathWithoutExtension}.tsx`;
+    return safeReturn(`${pathWithoutExtension}.tsx`);
   }
   if (fs.existsSync(`${pathWithoutExtension}.jsx`)) {
-    return `${pathWithoutExtension}.jsx`;
+    return safeReturn(`${pathWithoutExtension}.jsx`);
   }
   if (fs.existsSync(`${pathWithoutExtension}.ts`)) {
-    return `${pathWithoutExtension}.ts`;
+    return safeReturn(`${pathWithoutExtension}.ts`);
   }
   if (fs.existsSync(`${pathWithoutExtension}.js`)) {
-    return `${pathWithoutExtension}.js`;
+    return safeReturn(`${pathWithoutExtension}.js`);
   }
   if (fs.existsSync(`${pathWithoutExtension}.html`)) {
-    return `${pathWithoutExtension}.html`;
+    return safeReturn(`${pathWithoutExtension}.html`);
   }
 
   return undefined;

--- a/packages/ui/src/actions/render-email-by-path.spec.ts
+++ b/packages/ui/src/actions/render-email-by-path.spec.ts
@@ -1,11 +1,27 @@
 import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { renderEmailByPath } from './render-email-by-path';
 
 describe('renderEmailByPath() with raw .html templates', () => {
-  const htmlPath = path.resolve(
-    __dirname,
-    '../utils/testing/raw-html-email.html',
-  );
+  const emailsRoot = path.resolve(__dirname, '../utils/testing');
+  const htmlPath = path.join(emailsRoot, 'raw-html-email.html');
+
+  let previousEnvValue: string | undefined;
+
+  beforeAll(() => {
+    previousEnvValue =
+      process.env.REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH;
+    process.env.REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH = emailsRoot;
+  });
+
+  afterAll(() => {
+    if (previousEnvValue === undefined) {
+      delete process.env.REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH;
+    } else {
+      process.env.REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH =
+        previousEnvValue;
+    }
+  });
 
   it('renders raw HTML without bundling a React component', async () => {
     const result = await renderEmailByPath(htmlPath, true);
@@ -32,5 +48,22 @@ describe('renderEmailByPath() with raw .html templates', () => {
     expect(result.plainText).toContain(
       'This template has no JavaScript exports.',
     );
+  });
+
+  it('refuses to render a path outside the configured emails directory', async () => {
+    const result = await renderEmailByPath('/etc/passwd', true);
+
+    expect('error' in result).toBe(true);
+    if (!('error' in result)) return;
+    expect(result.error.message).toMatch(/outside of the configured emails/);
+  });
+
+  it('refuses to escape via traversal segments', async () => {
+    const result = await renderEmailByPath(
+      path.join(emailsRoot, '..', '..', '..', 'etc', 'passwd'),
+      true,
+    );
+
+    expect('error' in result).toBe(true);
   });
 });

--- a/packages/ui/src/actions/render-email-by-path.tsx
+++ b/packages/ui/src/actions/render-email-by-path.tsx
@@ -14,6 +14,7 @@ import {
 import { convertStackWithSourceMap } from '../utils/convert-stack-with-sourcemap';
 import { createJsxRuntime } from '../utils/create-jsx-runtime';
 import { getEmailComponent } from '../utils/get-email-component';
+import { isPathWithinEmailsDirectory } from '../utils/is-path-within-emails-directory';
 import { registerSpinnerAutostopping } from '../utils/register-spinner-autostopping';
 import {
   createSpinner,
@@ -95,6 +96,16 @@ export const renderEmailByPath = async (
   emailPath: string,
   invalidatingCache = false,
 ): Promise<EmailRenderingResult> => {
+  if (!isPathWithinEmailsDirectory(emailPath)) {
+    return {
+      error: {
+        name: 'Error',
+        message: `Refusing to render ${path.basename(emailPath)} because it resolves outside of the configured emails directory.`,
+        stack: undefined,
+      },
+    };
+  }
+
   if (invalidatingCache) {
     cache.delete(emailPath);
   }

--- a/packages/ui/src/utils/is-path-within-emails-directory.spec.ts
+++ b/packages/ui/src/utils/is-path-within-emails-directory.spec.ts
@@ -55,9 +55,7 @@ describe('isPathWithinEmailsDirectory()', () => {
     expect(isPathWithinEmailsDirectory('../secret.txt')).toBe(false);
     expect(isPathWithinEmailsDirectory('../../etc/passwd')).toBe(false);
     expect(
-      isPathWithinEmailsDirectory(
-        path.join(emailsRoot, '..', 'secret.txt'),
-      ),
+      isPathWithinEmailsDirectory(path.join(emailsRoot, '..', 'secret.txt')),
     ).toBe(false);
   });
 

--- a/packages/ui/src/utils/is-path-within-emails-directory.spec.ts
+++ b/packages/ui/src/utils/is-path-within-emails-directory.spec.ts
@@ -1,0 +1,102 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { isPathWithinEmailsDirectory } from './is-path-within-emails-directory';
+
+describe('isPathWithinEmailsDirectory()', () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rxe-path-guard-'));
+  const emailsRoot = path.join(tmpRoot, 'emails');
+  const outsideFile = path.join(tmpRoot, 'secret.txt');
+
+  let previousEnvValue: string | undefined;
+
+  beforeAll(() => {
+    fs.mkdirSync(emailsRoot, { recursive: true });
+    fs.writeFileSync(path.join(emailsRoot, 'welcome.tsx'), '// fixture');
+    fs.writeFileSync(outsideFile, 'top secret');
+
+    previousEnvValue =
+      process.env.REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH;
+    process.env.REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH = emailsRoot;
+  });
+
+  afterAll(() => {
+    if (previousEnvValue === undefined) {
+      delete process.env.REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH;
+    } else {
+      process.env.REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH =
+        previousEnvValue;
+    }
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('accepts a file directly inside the emails directory', () => {
+    expect(
+      isPathWithinEmailsDirectory(path.join(emailsRoot, 'welcome.tsx')),
+    ).toBe(true);
+  });
+
+  it('accepts the emails directory itself', () => {
+    expect(isPathWithinEmailsDirectory(emailsRoot)).toBe(true);
+  });
+
+  it('accepts a relative path that resolves inside the emails directory', () => {
+    expect(isPathWithinEmailsDirectory('welcome.tsx')).toBe(true);
+    expect(isPathWithinEmailsDirectory('./welcome.tsx')).toBe(true);
+  });
+
+  it('rejects absolute paths outside the emails directory', () => {
+    expect(isPathWithinEmailsDirectory(outsideFile)).toBe(false);
+    expect(isPathWithinEmailsDirectory('/etc/passwd')).toBe(false);
+  });
+
+  it('rejects traversal attempts via ../', () => {
+    expect(isPathWithinEmailsDirectory('../secret.txt')).toBe(false);
+    expect(isPathWithinEmailsDirectory('../../etc/passwd')).toBe(false);
+    expect(
+      isPathWithinEmailsDirectory(
+        path.join(emailsRoot, '..', 'secret.txt'),
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects sibling directories with a shared prefix', () => {
+    const sibling = `${emailsRoot}-other`;
+    fs.mkdirSync(sibling, { recursive: true });
+    try {
+      expect(isPathWithinEmailsDirectory(path.join(sibling, 'evil.tsx'))).toBe(
+        false,
+      );
+    } finally {
+      fs.rmSync(sibling, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects symlinks that escape the emails directory', () => {
+    const symlinkPath = path.join(emailsRoot, 'escape.txt');
+    try {
+      fs.symlinkSync(outsideFile, symlinkPath);
+    } catch {
+      // Some CI environments may forbid symlink creation; skip in that case.
+      return;
+    }
+    try {
+      expect(isPathWithinEmailsDirectory(symlinkPath)).toBe(false);
+    } finally {
+      fs.rmSync(symlinkPath, { force: true });
+    }
+  });
+
+  it('rejects everything when the env var is unset (fail closed)', () => {
+    const saved = process.env.REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH;
+    delete process.env.REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH;
+    try {
+      expect(
+        isPathWithinEmailsDirectory(path.join(emailsRoot, 'welcome.tsx')),
+      ).toBe(false);
+    } finally {
+      process.env.REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH = saved;
+    }
+  });
+});

--- a/packages/ui/src/utils/is-path-within-emails-directory.ts
+++ b/packages/ui/src/utils/is-path-within-emails-directory.ts
@@ -1,0 +1,31 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const safeRealpath = (target: string): string => {
+  try {
+    return fs.realpathSync(target);
+  } catch {
+    return path.resolve(target);
+  }
+};
+
+/**
+ * Returns true when `emailPath` resolves to a location inside the emails
+ * directory configured via REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH.
+ *
+ * Server actions accept arbitrary strings from the client, so any path that
+ * eventually reaches the filesystem must be checked against this boundary to
+ * prevent traversal (`../../etc/passwd`) and absolute-path escapes.
+ */
+export const isPathWithinEmailsDirectory = (emailPath: string): boolean => {
+  const root = process.env.REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH;
+  if (!root) return false;
+
+  const resolvedRoot = safeRealpath(path.resolve(root));
+  const resolvedTarget = safeRealpath(path.resolve(resolvedRoot, emailPath));
+
+  return (
+    resolvedTarget === resolvedRoot ||
+    resolvedTarget.startsWith(resolvedRoot + path.sep)
+  );
+};


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Blocks path traversal in the preview server by rejecting email paths that resolve outside the configured emails directory. Addresses Linear DEV-794 and the CodeQL `js/path-injection` alert.

- **Bug Fixes**
  - Added `isPathWithinEmailsDirectory` to validate paths using `realpath`; blocks `../` escapes, absolute paths, symlink escapes; fails closed if `REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH` is unset.
  - Guarded `renderEmailByPath` to return an error when the path is outside the emails directory.
  - Wrapped returns in `getEmailPathFromSlug` so only in-root files are returned; otherwise `undefined`.
  - Expanded tests for traversal, symlink, and env-var cases; added checks that paths outside the configured directory are rejected.

<sup>Written for commit 03bea3c51bf241ecbc62e72cebd42d432641cff8. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3534?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

