### PR TITLE
fix(editor): possible prototype pollution in theming

### DIFF
--- a/.changeset/email-theming-proto-pollution.md
+++ b/.changeset/email-theming-proto-pollution.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+prevent prototype pollution in the email-theming plugin by building `cssJS` and merged theme objects from `Object.create(null)` so attacker-controlled `__proto__`, `constructor`, or `prototype` keys in panel-style input become regular own properties instead of mutating `Object.prototype`

--- a/packages/editor/src/plugins/email-theming/css-transforms.spec.ts
+++ b/packages/editor/src/plugins/email-theming/css-transforms.spec.ts
@@ -518,32 +518,31 @@ describe('prototype pollution resistance', () => {
     ];
   });
 
-  it.each(POISON_KEYS)(
-    'transformToCssJs does not pollute Object.prototype via classReference="%s"',
-    (poisonKey) => {
-      const styles = [
-        {
-          title: 'attack',
-          inputs: [
-            {
-              classReference: poisonKey,
-              prop: POLLUTION_MARKER,
-              value: 'pwned',
-            },
-          ],
-        },
-      ] as unknown as PanelGroup[];
-
-      transformToCssJs(styles, DEFAULT_INBOX_FONT_SIZE_PX);
-
-      expect(({} as Record<string, unknown>)[POLLUTION_MARKER]).toBeUndefined();
-      expect(
-        (Object.prototype as unknown as Record<string, unknown>)[
-          POLLUTION_MARKER
+  it.each(
+    POISON_KEYS,
+  )('transformToCssJs does not pollute Object.prototype via classReference="%s"', (poisonKey) => {
+    const styles = [
+      {
+        title: 'attack',
+        inputs: [
+          {
+            classReference: poisonKey,
+            prop: POLLUTION_MARKER,
+            value: 'pwned',
+          },
         ],
-      ).toBeUndefined();
-    },
-  );
+      },
+    ] as unknown as PanelGroup[];
+
+    transformToCssJs(styles, DEFAULT_INBOX_FONT_SIZE_PX);
+
+    expect(({} as Record<string, unknown>)[POLLUTION_MARKER]).toBeUndefined();
+    expect(
+      (Object.prototype as unknown as Record<string, unknown>)[
+        POLLUTION_MARKER
+      ],
+    ).toBeUndefined();
+  });
 
   it('transformToCssJs stores poison keys as own properties on a prototype-less root', () => {
     const styles = [

--- a/packages/editor/src/plugins/email-theming/css-transforms.spec.ts
+++ b/packages/editor/src/plugins/email-theming/css-transforms.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   injectGlobalPlainCss,
   injectThemeCss,
+  mergeCssJs,
   transformToCssJs,
 } from './css-transforms';
 import { DEFAULT_INBOX_FONT_SIZE_PX } from './themes';
@@ -499,5 +500,97 @@ describe('injectGlobalPlainCss', () => {
     injectGlobalPlainCss('', { styleId: STYLE_ID, scopeSelector: SCOPE });
 
     expect(document.getElementById(STYLE_ID)).toBeNull();
+  });
+});
+
+describe('prototype pollution resistance', () => {
+  const POISON_KEYS = ['__proto__', 'constructor', 'prototype'] as const;
+  const POLLUTION_MARKER = 'polluted_marker_8b9c1f';
+
+  afterEach(() => {
+    // Belt-and-braces: scrub any pollution that may have leaked so a
+    // failing assertion doesn't bleed into the rest of the suite.
+    delete (Object.prototype as unknown as Record<string, unknown>)[
+      POLLUTION_MARKER
+    ];
+    delete (Array.prototype as unknown as Record<string, unknown>)[
+      POLLUTION_MARKER
+    ];
+  });
+
+  it.each(POISON_KEYS)(
+    'transformToCssJs does not pollute Object.prototype via classReference="%s"',
+    (poisonKey) => {
+      const styles = [
+        {
+          title: 'attack',
+          inputs: [
+            {
+              classReference: poisonKey,
+              prop: POLLUTION_MARKER,
+              value: 'pwned',
+            },
+          ],
+        },
+      ] as unknown as PanelGroup[];
+
+      transformToCssJs(styles, DEFAULT_INBOX_FONT_SIZE_PX);
+
+      expect(({} as Record<string, unknown>)[POLLUTION_MARKER]).toBeUndefined();
+      expect(
+        (Object.prototype as unknown as Record<string, unknown>)[
+          POLLUTION_MARKER
+        ],
+      ).toBeUndefined();
+    },
+  );
+
+  it('transformToCssJs stores poison keys as own properties on a prototype-less root', () => {
+    const styles = [
+      {
+        title: 'attack',
+        inputs: [
+          {
+            classReference: '__proto__',
+            prop: 'color',
+            value: 'red',
+          },
+        ],
+      },
+    ] as unknown as PanelGroup[];
+
+    const result = transformToCssJs(styles, DEFAULT_INBOX_FONT_SIZE_PX);
+
+    expect(Object.getPrototypeOf(result)).toBeNull();
+    expect(Object.hasOwn(result, '__proto__')).toBe(true);
+  });
+
+  it('mergeCssJs does not mutate Object.prototype when fed a hostile __proto__ key', () => {
+    // JSON.parse is the realistic vector: a payload with "__proto__" becomes
+    // an own enumerable property on the parsed object, which `for...in` then
+    // exposes.
+    const hostile = JSON.parse(
+      `{"__proto__":{"${POLLUTION_MARKER}":"pwned"}}`,
+    ) as CssJs;
+
+    const original = { body: { color: 'black' } } as unknown as CssJs;
+    const merged = mergeCssJs(original, hostile);
+
+    expect(
+      (Object.prototype as unknown as Record<string, unknown>)[
+        POLLUTION_MARKER
+      ],
+    ).toBeUndefined();
+    expect(({} as Record<string, unknown>)[POLLUTION_MARKER]).toBeUndefined();
+    expect(Object.getPrototypeOf(merged)).toBeNull();
+  });
+
+  it('mergeCssJs preserves legitimate keys when input contains a poison key', () => {
+    const hostile = JSON.parse(
+      `{"__proto__":{"x":1},"body":{"color":"blue"}}`,
+    ) as CssJs;
+    const merged = mergeCssJs({} as CssJs, hostile);
+
+    expect(merged.body).toEqual({ color: 'blue' });
   });
 });

--- a/packages/editor/src/plugins/email-theming/css-transforms.ts
+++ b/packages/editor/src/plugins/email-theming/css-transforms.ts
@@ -6,7 +6,11 @@ export function transformToCssJs(
   styleArray: PanelGroup[],
   baseFontSize: number,
 ): CssJs {
-  const cssJS = {} as CssJs;
+  // Use prototype-less objects so attacker-supplied keys like `__proto__`,
+  // `constructor`, or `prototype` are stored as plain own properties instead
+  // of routing through the Object.prototype setter, which would mutate the
+  // global prototype.
+  const cssJS = Object.create(null) as CssJs;
 
   if (!Array.isArray(styleArray)) {
     return cssJS;
@@ -31,7 +35,7 @@ export function transformToCssJs(
       }
 
       if (!cssJS[input.classReference]) {
-        cssJS[input.classReference] = {};
+        cssJS[input.classReference] = Object.create(null);
       }
 
       // @ts-expect-error -- backward compatibility: 'h-padding' is a legacy prop not in KnownCssProperties
@@ -57,7 +61,10 @@ export function transformToCssJs(
 }
 
 export function mergeCssJs(original: CssJs, newCssJs: CssJs) {
-  const merged = { ...original };
+  // Same defensive pattern as `transformToCssJs`: a prototype-less root keeps
+  // a hostile `__proto__` key in the input from triggering the
+  // Object.prototype setter during assignment.
+  const merged = Object.assign(Object.create(null), original) as CssJs;
 
   for (const key in newCssJs) {
     const keyType = key as keyof CssJs;
@@ -67,10 +74,11 @@ export function mergeCssJs(original: CssJs, newCssJs: CssJs) {
       typeof merged[keyType] === 'object' &&
       !Array.isArray(merged[keyType])
     ) {
-      merged[keyType] = {
-        ...merged[keyType],
-        ...newCssJs[keyType],
-      };
+      merged[keyType] = Object.assign(
+        Object.create(null),
+        merged[keyType],
+        newCssJs[keyType],
+      );
     } else {
       merged[keyType] = newCssJs[keyType];
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevented prototype pollution in the email-theming plugin of `@react-email/editor` by using prototype-less objects and safe merges. Addresses Linear DEV-791 (CodeQL js/prototype-polluting-assignment).

- **Bug Fixes**
  - Build `cssJS` roots and class maps with `Object.create(null)` in `transformToCssJs`.
  - Merge theme objects via `Object.assign` into prototype-less targets in `mergeCssJs` to neutralize `__proto__`/`constructor`/`prototype` payloads.
  - Added tests to ensure no `Object.prototype` mutation and that valid styles still merge correctly.
  - Changeset: patch release for `@react-email/editor`.

<sup>Written for commit 09b1885b32148cd2c5968ebc85d716def53f159b. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3536?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

