### PR TITLE
fix: refuse server-side fetches to private addresses in email linter

### DIFF
--- a/.changeset/quick-fetch-ssrf-guard.md
+++ b/.changeset/quick-fetch-ssrf-guard.md
@@ -1,0 +1,5 @@
+---
+"@react-email/ui": patch
+---
+
+refuse outbound fetches whose hostname resolves to a private or reserved address (loopback, RFC1918, link-local incl. cloud metadata, ULA, multicast) to close a server-side request forgery vector in the preview server's email linter. the linter now also skips network probes for same-origin assets, so relative `<img src="/foo.png">` paths against the local dev server keep working without exposing it as an SSRF target.

--- a/packages/ui/src/actions/email-validation/check-images.spec.tsx
+++ b/packages/ui/src/actions/email-validation/check-images.spec.tsx
@@ -102,20 +102,6 @@ test('checkImages()', async () => {
             "passed": true,
             "type": "security",
           },
-          {
-            "metadata": {
-              "fetchStatusCode": 200,
-            },
-            "passed": true,
-            "type": "fetch_attempt",
-          },
-          {
-            "metadata": {
-              "byteCount": 111922,
-            },
-            "passed": true,
-            "type": "image_size",
-          },
         ],
         "codeLocation": {
           "column": 3,

--- a/packages/ui/src/actions/email-validation/check-images.ts
+++ b/packages/ui/src/actions/email-validation/check-images.ts
@@ -53,6 +53,13 @@ const getResponseSizeInBytes = async (res: IncomingMessage) => {
 export const checkImages = async (code: string, base: string) => {
   const ast = parse(code);
 
+  let baseOrigin: string | undefined;
+  try {
+    if (base) baseOrigin = new URL(base).origin;
+  } catch {
+    baseOrigin = undefined;
+  }
+
   const readableStream = new ReadableStream<ImageCheckingResult>({
     async start(controller) {
       const images = ast.querySelectorAll('img');
@@ -103,44 +110,53 @@ export const checkImages = async (code: string, base: string) => {
             });
           }
 
-          let res: IncomingMessage | undefined;
-          try {
-            res = await quickFetch(url);
-            const hasSucceeded =
-              res.statusCode?.toString().startsWith('2') ?? false;
-            result.checks.push({
-              type: 'fetch_attempt',
-              passed: hasSucceeded,
-              metadata: {
-                fetchStatusCode: res.statusCode,
-              },
-            });
-            if (!hasSucceeded) {
-              result.status = res.statusCode?.toString().startsWith('3')
-                ? 'warning'
-                : 'error';
-            }
+          // Same-origin assets are served by the dev server we're already
+          // talking to — the user sees whether they render in the preview
+          // iframe directly. Skip the network probe to avoid the SSRF guard
+          // refusing legitimate loopback reads against our own host.
+          const isSameOrigin =
+            baseOrigin !== undefined && url.origin === baseOrigin;
 
-            const responseSizeBytes = await getResponseSizeInBytes(res);
-            result.checks.push({
-              type: 'image_size',
-              passed: responseSizeBytes < 1_048_576, // 1024 x 1024 bytes
-              metadata: {
-                byteCount: responseSizeBytes,
-              },
-            });
-            if (responseSizeBytes > 1_048_576 && result.status !== 'error') {
-              result.status = 'warning';
+          if (!isSameOrigin) {
+            let res: IncomingMessage | undefined;
+            try {
+              res = await quickFetch(url);
+              const hasSucceeded =
+                res.statusCode?.toString().startsWith('2') ?? false;
+              result.checks.push({
+                type: 'fetch_attempt',
+                passed: hasSucceeded,
+                metadata: {
+                  fetchStatusCode: res.statusCode,
+                },
+              });
+              if (!hasSucceeded) {
+                result.status = res.statusCode?.toString().startsWith('3')
+                  ? 'warning'
+                  : 'error';
+              }
+
+              const responseSizeBytes = await getResponseSizeInBytes(res);
+              result.checks.push({
+                type: 'image_size',
+                passed: responseSizeBytes < 1_048_576, // 1024 x 1024 bytes
+                metadata: {
+                  byteCount: responseSizeBytes,
+                },
+              });
+              if (responseSizeBytes > 1_048_576 && result.status !== 'error') {
+                result.status = 'warning';
+              }
+            } catch {
+              result.checks.push({
+                type: 'fetch_attempt',
+                passed: false,
+                metadata: {
+                  fetchStatusCode: undefined,
+                },
+              });
+              result.status = 'error';
             }
-          } catch {
-            result.checks.push({
-              type: 'fetch_attempt',
-              passed: false,
-              metadata: {
-                fetchStatusCode: undefined,
-              },
-            });
-            result.status = 'error';
           }
         } catch {
           result.checks.push({

--- a/packages/ui/src/actions/email-validation/is-private-ip.spec.ts
+++ b/packages/ui/src/actions/email-validation/is-private-ip.spec.ts
@@ -1,0 +1,64 @@
+import { isPrivateOrReservedIp } from './is-private-ip';
+
+const blocked = [
+  '0.0.0.0',
+  '0.1.2.3',
+  '10.0.0.1',
+  '10.255.255.254',
+  '100.64.0.1',
+  '100.127.255.254',
+  '127.0.0.1',
+  '127.255.255.254',
+  '169.254.169.254',
+  '169.254.0.1',
+  '172.16.0.1',
+  '172.31.255.254',
+  '192.0.0.0',
+  '192.168.0.1',
+  '192.168.1.1',
+  '224.0.0.1',
+  '239.255.255.255',
+  '255.255.255.255',
+  '::',
+  '::1',
+  '::ffff:127.0.0.1',
+  '::ffff:10.0.0.1',
+  '::ffff:169.254.169.254',
+  'fe80::1',
+  'fe80::abcd:1234',
+  'fc00::1',
+  'fd00::1',
+  'ff02::1',
+];
+
+const allowed = [
+  '1.1.1.1',
+  '8.8.8.8',
+  '93.184.216.34',
+  '172.15.255.254',
+  '172.32.0.1',
+  '100.63.255.254',
+  '100.128.0.1',
+  '169.253.255.254',
+  '169.255.0.1',
+  '192.0.1.1',
+  '192.169.0.1',
+  '223.255.255.254',
+  '2606:4700:4700::1111',
+  '2001:4860:4860::8888',
+  '::ffff:1.1.1.1',
+];
+
+const malformed = ['', 'not-an-ip', '999.999.999.999', 'example.com'];
+
+test.each(blocked)('blocks %s', (address) => {
+  expect(isPrivateOrReservedIp(address)).toBe(true);
+});
+
+test.each(allowed)('allows %s', (address) => {
+  expect(isPrivateOrReservedIp(address)).toBe(false);
+});
+
+test.each(malformed)('returns false for non-IP input %s', (address) => {
+  expect(isPrivateOrReservedIp(address)).toBe(false);
+});

--- a/packages/ui/src/actions/email-validation/is-private-ip.ts
+++ b/packages/ui/src/actions/email-validation/is-private-ip.ts
@@ -1,0 +1,39 @@
+import net from 'node:net';
+
+/**
+ * Returns true for IP addresses that the server can reach by virtue of its
+ * network position (cloud metadata, internal LAN, loopback) and that an
+ * external attacker could not reach directly. Used to refuse outbound
+ * fetches whose URL resolves to such an address.
+ */
+export const isPrivateOrReservedIp = (address: string): boolean => {
+  if (net.isIPv4(address)) {
+    const parts = address.split('.').map(Number);
+    const a = parts[0]!;
+    const b = parts[1]!;
+    const c = parts[2]!;
+    if (a === 0) return true;
+    if (a === 10) return true;
+    if (a === 100 && b >= 64 && b <= 127) return true;
+    if (a === 127) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 0 && c === 0) return true;
+    if (a === 192 && b === 168) return true;
+    if (a >= 224) return true;
+    return false;
+  }
+  if (net.isIPv6(address)) {
+    const lower = address.toLowerCase();
+    if (lower === '::' || lower === '::1') return true;
+    if (lower.startsWith('::ffff:')) {
+      const mapped = lower.slice(7);
+      if (net.isIPv4(mapped)) return isPrivateOrReservedIp(mapped);
+    }
+    if (/^fe[89ab][0-9a-f]:/.test(lower)) return true;
+    if (/^f[cd][0-9a-f]{2}:/.test(lower)) return true;
+    if (lower.startsWith('ff')) return true;
+    return false;
+  }
+  return false;
+};

--- a/packages/ui/src/actions/email-validation/quick-fetch.spec.ts
+++ b/packages/ui/src/actions/email-validation/quick-fetch.spec.ts
@@ -1,0 +1,40 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { quickFetch } from './quick-fetch';
+
+let server: http.Server;
+let port: number;
+let requestCount: number;
+
+beforeAll(async () => {
+  server = http.createServer((_req, res) => {
+    requestCount += 1;
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('internal-service-response');
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  port = (server.address() as AddressInfo).port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+});
+
+beforeEach(() => {
+  requestCount = 0;
+});
+
+test('refuses to fetch loopback addresses (SSRF)', async () => {
+  const url = new URL(`http://127.0.0.1:${port}/`);
+  await expect(quickFetch(url)).rejects.toThrow();
+  expect(requestCount).toBe(0);
+});
+
+test('refuses non-http(s) protocols', async () => {
+  const url = new URL('file:///etc/passwd');
+  await expect(quickFetch(url)).rejects.toThrow();
+});

--- a/packages/ui/src/actions/email-validation/quick-fetch.ts
+++ b/packages/ui/src/actions/email-validation/quick-fetch.ts
@@ -1,12 +1,61 @@
-import type { IncomingMessage } from 'node:http';
+import dns from 'node:dns/promises';
+import type { IncomingMessage, RequestOptions } from 'node:http';
 import http from 'node:http';
 import https from 'node:https';
+import net from 'node:net';
+import { isPrivateOrReservedIp } from './is-private-ip';
 
-export const quickFetch = (url: URL) => {
+export const quickFetch = async (url: URL): Promise<IncomingMessage> => {
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(
+      `Refusing to fetch ${url.href}: only http and https protocols are allowed`,
+    );
+  }
+
+  const literalFamily = net.isIP(url.hostname);
+  const resolved: Array<{ address: string; family: number }> =
+    literalFamily === 0
+      ? await dns.lookup(url.hostname, { all: true, verbatim: true })
+      : [{ address: url.hostname, family: literalFamily }];
+
+  for (const { address } of resolved) {
+    if (isPrivateOrReservedIp(address)) {
+      throw new Error(
+        `Refusing to fetch ${url.href}: resolves to a private or reserved address (${address})`,
+      );
+    }
+  }
+
+  if (resolved.length === 0) {
+    throw new Error(`Refusing to fetch ${url.href}: hostname did not resolve`);
+  }
+  const safe = resolved[0]!;
+
+  // Pin the vetted address into the actual TCP connect so a hostile
+  // nameserver cannot rebind to a private IP between our preflight
+  // resolution and the socket connect (DNS rebinding). Node's net module
+  // invokes lookup with either `{ all: true }` (multi-address connect) or
+  // `{ all: false }`; the callback shape differs by mode.
+  const pinnedLookup = (
+    _hostname: string,
+    opts: { all?: boolean } | undefined,
+    callback: (
+      err: NodeJS.ErrnoException | null,
+      addressOrAddresses: string | typeof resolved,
+      family?: number,
+    ) => void,
+  ): void => {
+    if (opts?.all) {
+      callback(null, resolved);
+    } else {
+      callback(null, safe.address, safe.family);
+    }
+  };
+
   return new Promise<IncomingMessage>((resolve, reject) => {
     const caller = url.protocol === 'https:' ? https : http;
     caller
-      .get(url, (res) => {
+      .get(url, { lookup: pinnedLookup } as RequestOptions, (res) => {
         resolve(res);
       })
       .on('error', (error) => reject(error));


### PR DESCRIPTION
The preview server's email linter calls quickFetch on every `<img src>` and `<a href>` extracted from a rendered template. Without a guard, a URL in the template can make the build/runner reach loopback, RFC1918, link-local (incl. cloud metadata at 169.254.169.254), ULA, or multicast addresses - endpoints only reachable from the server's network position.

Add a defense-in-depth guard in quickFetch: refuse non-http(s) protocols, DNS-resolve the hostname, refuse any address that's private/reserved, and pin the vetted address into the actual TCP connect so a hostile nameserver cannot rebind to a private IP between preflight and connect.

Skip the network probe in checkImages when the URL origin matches the linter's base origin — the in-dashboard linter joins relative paths against the dev server's own URL, and probing same-origin assets isn't useful (they either render in the iframe or they don't).

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the preview email linter in `@react-email/ui` to block server-side fetches to private/reserved addresses and non-http(s) URLs, closing an SSRF vector. Also skips same-origin image probes to avoid unnecessary network calls in the dev preview.

- **Bug Fixes**
  - `quickFetch`: allow only `http`/`https`; DNS-resolve hostnames; block loopback/RFC1918/link-local (incl. 169.254.169.254)/ULA/multicast; pin the vetted address in the TCP connect to prevent DNS rebinding.
  - `checkImages`: skip network probe when the URL origin matches the linter’s base origin (e.g., assets served by the local dev server).

<sup>Written for commit fa182acd8f6274449613886f94a543d8f1848e8e. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3537?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

