### PR TITLE
feat(editor): return non-prettified HTML from composeReactEmail

### DIFF
--- a/.changeset/compose-react-email-unformatted-html.md
+++ b/.changeset/compose-react-email-unformatted-html.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": minor
+---
+
+expose the unformatted (non-prettified) HTML from `composeReactEmail` as a new `unformattedHtml` field on the result. The existing `html` field is unchanged and still Prettier-formatted. Consumers that persist or send the email should prefer `unformattedHtml`, since `pretty()` indentation can inflate the byte size by 5–10× on deeply-nested table layouts (e.g. exports from Stripo or Mailchimp) and pushes the output past Gmail's 102 KB clipping threshold.

--- a/packages/editor/src/core/serializer/compose-react-email.spec.tsx
+++ b/packages/editor/src/core/serializer/compose-react-email.spec.tsx
@@ -496,3 +496,34 @@ describe('Button and image reset styles', () => {
     expect(result.html).toContain('test image');
   });
 });
+
+describe('unformattedHtml', () => {
+  it('returns the pre-pretty render() output alongside html and text', async () => {
+    const content = docWithGlobalContent([
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Hello world' }],
+      },
+    ]);
+
+    const ed = createEditorWithContent(content, [EmailTheming]);
+    const result = await composeReactEmail({ editor: ed });
+
+    // Field is present and non-empty.
+    expect(typeof result.unformattedHtml).toBe('string');
+    expect(result.unformattedHtml.length).toBeGreaterThan(0);
+
+    // Same body content as the pretty version (both contain the text).
+    expect(result.unformattedHtml).toContain('Hello world');
+
+    // No Prettier indentation artifacts: no inter-tag whitespace runs.
+    expect(result.unformattedHtml).not.toMatch(/>\s+</);
+
+    // The pretty version, by contrast, does indent between tags.
+    expect(result.html).toMatch(/>\s+</);
+
+    // And the unformatted version is shorter precisely because indentation
+    // is the only difference.
+    expect(result.unformattedHtml.length).toBeLessThan(result.html.length);
+  });
+});

--- a/packages/editor/src/core/serializer/compose-react-email.spec.tsx
+++ b/packages/editor/src/core/serializer/compose-react-email.spec.tsx
@@ -497,33 +497,31 @@ describe('Button and image reset styles', () => {
   });
 });
 
-describe('unformattedHtml', () => {
-  it('returns the pre-pretty render() output alongside html and text', async () => {
-    const content = docWithGlobalContent([
-      {
-        type: 'paragraph',
-        content: [{ type: 'text', text: 'Hello world' }],
-      },
-    ]);
+it('exposes unformattedHtml alongside the prettified html and text', async () => {
+  const content = docWithGlobalContent([
+    {
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'Hello world' }],
+    },
+  ]);
 
-    const ed = createEditorWithContent(content, [EmailTheming]);
-    const result = await composeReactEmail({ editor: ed });
+  const ed = createEditorWithContent(content, [EmailTheming]);
+  const result = await composeReactEmail({ editor: ed });
 
-    // Field is present and non-empty.
-    expect(typeof result.unformattedHtml).toBe('string');
-    expect(result.unformattedHtml.length).toBeGreaterThan(0);
+  // Field is present and non-empty.
+  expect(typeof result.unformattedHtml).toBe('string');
+  expect(result.unformattedHtml.length).toBeGreaterThan(0);
 
-    // Same body content as the pretty version (both contain the text).
-    expect(result.unformattedHtml).toContain('Hello world');
+  // Same body content as the pretty version (both contain the text).
+  expect(result.unformattedHtml).toContain('Hello world');
 
-    // No Prettier indentation artifacts: no inter-tag whitespace runs.
-    expect(result.unformattedHtml).not.toMatch(/>\s+</);
+  // No Prettier indentation artifacts: no inter-tag whitespace runs.
+  expect(result.unformattedHtml).not.toMatch(/>\s+</);
 
-    // The pretty version, by contrast, does indent between tags.
-    expect(result.html).toMatch(/>\s+</);
+  // The pretty version, by contrast, does indent between tags.
+  expect(result.html).toMatch(/>\s+</);
 
-    // And the unformatted version is shorter precisely because indentation
-    // is the only difference.
-    expect(result.unformattedHtml.length).toBeLessThan(result.html.length);
-  });
+  // And the unformatted version is shorter precisely because indentation
+  // is the only difference.
+  expect(result.unformattedHtml.length).toBeLessThan(result.html.length);
 });

--- a/packages/editor/src/core/serializer/compose-react-email.tsx
+++ b/packages/editor/src/core/serializer/compose-react-email.tsx
@@ -34,8 +34,18 @@ function sortMarksBySchema(
 }
 
 interface ComposeReactEmailResult {
+  /** Prettier-formatted HTML, suitable for displaying in a source-code view. */
   html: string;
+  /** Plain-text version of the email body. */
   text: string;
+  /**
+   * Unformatted HTML as produced by `render()` before `pretty()` runs.
+   * Use this when persisting or sending the email — Prettier indentation
+   * can inflate the byte size by 5–10× on deeply-nested table layouts
+   * (e.g. exports from Stripo, Mailchimp), and adds nothing for clients
+   * that parse HTML to render it.
+   */
+  unformattedHtml: string;
 }
 
 export const composeReactEmail = async ({
@@ -150,5 +160,5 @@ export const composeReactEmail = async ({
     toPlainText(unformattedHtml),
   ]);
 
-  return { html: prettyHtml, text };
+  return { html: prettyHtml, text, unformattedHtml };
 };


### PR DESCRIPTION
Currently `composeReactEmail` returns only the Prettier-formatted HTML. For deeply-nested table-based emails (typical Stripo or Mailchimp exports), Prettier indentation accounts for ~78% of the output bytes — a 55 KB import becomes ~400 KB and pushes past Gmail's 102 KB clipping threshold, breaking open tracking and truncating content.

The compact form is already computed inside the function — it's what `render()` returns before `pretty()` runs. This PR additively exposes it as `unformattedHtml`. The existing `html` field is unchanged, so no caller breaks.

```ts
// Before
const { html, text } = await composeReactEmail({ editor });

// After (existing destructure still works)
const { html, text, unformattedHtml } = await composeReactEmail({ editor });
```

### Measurements (deep Stripo-like input)

|                                              | Bytes   |
| -------------------------------------------- | ------: |
| Input HTML                                   |  ~53 KB |
| `render()` output (= new `unformattedHtml`)  |  ~57 KB |
| `pretty()` output (= existing `html`)        | ~393 KB |

### Notes for reviewers

- `unformattedHtml` is non-optional in the return type since the value is always available.
- No behavior change for `html` or `text`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose compact, non-prettified HTML from `composeReactEmail` as `unformattedHtml` to reduce email size for nested table layouts and avoid Gmail’s 102 KB clipping. `html` (Prettier-formatted) and `text` are unchanged; additive and backward-compatible.

- **Migration**
  - Use `unformattedHtml` when persisting or sending; keep `html` for source display views.

<sup>Written for commit 4d874a4c2d258bed529e3838831fef8abf531340. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3538?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

