### PR TITLE
fix(editor): repair columns.spec.tsx type errors + run typecheck on CI

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,33 @@
+name: Typecheck
+on:
+  push:
+    branches:
+      - main
+      - canary
+  pull_request:
+permissions:
+  contents: read
+  pull-requests: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  typecheck:
+    timeout-minutes: 20
+    runs-on: depot-ubuntu-22.04-2
+    container:
+      image: node:24-slim
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          fetch-depth: 1
+      - name: pnpm setup
+        uses: pnpm/action-setup@738f428026a1f5a72398de22aeed83d859c4a660
+      - name: Install packages
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Run Typecheck
+        run: pnpm typecheck
+        env:
+          TURBO_TOKEN: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.TURBO_TOKEN || '' }}
+          TURBO_TEAM: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.TURBO_TEAM || '' }}

--- a/apps/web/components/ensure-matching-variants.spec.tsx
+++ b/apps/web/components/ensure-matching-variants.spec.tsx
@@ -1,14 +1,17 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { parse, stringify } from 'html-to-ast';
-import type { Attr, IDoc as Doc } from 'html-to-ast/dist/types';
 import postcss from 'postcss';
 import { pretty, render } from 'react-email';
 import { getComponentElement } from '../src/app/components/get-imported-components-for';
 import { Layout } from './_components/layout';
 import { componentsStructure, getComponentPathFromSlug } from './structure';
 
+// `html-to-ast` does not expose its internal `IDoc`/`Attr` types via a public
+// subpath, so derive them from the functions it does export.
 type MaybeDoc = ReturnType<typeof parse>[number];
+type Doc = Parameters<typeof stringify>[0][number];
+type Attr = NonNullable<MaybeDoc['attrs']>;
 
 const walkAst = <T extends MaybeDoc>(ast: T[], callback: (doc: T) => void) => {
   for (const doc of ast) {

--- a/apps/web/components/ensure-matching-variants.spec.tsx
+++ b/apps/web/components/ensure-matching-variants.spec.tsx
@@ -7,8 +7,6 @@ import { getComponentElement } from '../src/app/components/get-imported-componen
 import { Layout } from './_components/layout';
 import { componentsStructure, getComponentPathFromSlug } from './structure';
 
-// `html-to-ast` does not expose its internal `IDoc`/`Attr` types via a public
-// subpath, so derive them from the functions it does export.
 type MaybeDoc = ReturnType<typeof parse>[number];
 type Doc = Parameters<typeof stringify>[0][number];
 type Attr = NonNullable<MaybeDoc['attrs']>;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "release": "turbo run build --filter=./packages/* && pnpm changeset publish",
     "test": "turbo run test",
     "test:watch": "turbo run test:watch",
+    "typecheck": "turbo run typecheck",
     "version": "changeset version && pnpm install --no-frozen-lockfile && pnpm lint:fix"
   },
   "devDependencies": {

--- a/packages/editor/src/extensions/columns.spec.tsx
+++ b/packages/editor/src/extensions/columns.spec.tsx
@@ -195,11 +195,18 @@ describe('Column Variants', () => {
   });
 
   it('reflects column spacing in editor HTML without inventing a default gap', () => {
-    const renderHTML = TwoColumns.config.renderHTML;
+    // `renderHTML` declares a typed `this` (the tiptap extension context) that
+    // we don't bind in tests — strip it with `OmitThisParameter` so we can
+    // call it as a free function. The implementation in `columns.ts` does not
+    // reference `this`, so this is safe at runtime.
+    type RenderHTMLFn = NonNullable<typeof TwoColumns.config.renderHTML>;
+    const renderHTML = TwoColumns.config.renderHTML as
+      | OmitThisParameter<RenderHTMLFn>
+      | undefined;
 
     const defaultHtml = renderHTML?.({
       HTMLAttributes: {},
-    } as Parameters<NonNullable<typeof renderHTML>>[0]) as [
+    } as unknown as Parameters<RenderHTMLFn>[0]) as [
       string,
       Record<string, unknown>,
       number,
@@ -208,7 +215,7 @@ describe('Column Variants', () => {
 
     const spacedHtml = renderHTML?.({
       HTMLAttributes: { cellspacing: '12', style: 'padding: 10px;' },
-    } as Parameters<NonNullable<typeof renderHTML>>[0]) as [
+    } as unknown as Parameters<RenderHTMLFn>[0]) as [
       string,
       Record<string, unknown>,
       number,
@@ -259,7 +266,7 @@ describe('Column Deletion', () => {
   }
 
   function findColDepth(
-    $from: ReturnType<typeof Editor.prototype.state.selection.$from>,
+    $from: typeof Editor.prototype.state.selection.$from,
   ): number | undefined {
     for (let d = $from.depth; d >= 0; d--) {
       if ($from.node(d).type.name === 'columnsColumn') return d;

--- a/packages/editor/src/extensions/columns.spec.tsx
+++ b/packages/editor/src/extensions/columns.spec.tsx
@@ -195,10 +195,6 @@ describe('Column Variants', () => {
   });
 
   it('reflects column spacing in editor HTML without inventing a default gap', () => {
-    // `renderHTML` declares a typed `this` (the tiptap extension context) that
-    // we don't bind in tests — strip it with `OmitThisParameter` so we can
-    // call it as a free function. The implementation in `columns.ts` does not
-    // reference `this`, so this is safe at runtime.
     type RenderHTMLFn = NonNullable<typeof TwoColumns.config.renderHTML>;
     const renderHTML = TwoColumns.config.renderHTML as
       | OmitThisParameter<RenderHTMLFn>

--- a/packages/react-email/tsconfig.json
+++ b/packages/react-email/tsconfig.json
@@ -35,5 +35,10 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": [
+    "dist",
+    "node_modules",
+    "src/cli/utils/preview/hot-reloading/test",
+    "src/components/tailwind/e2e"
+  ]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -50,6 +50,9 @@
       "outputs": ["dist/**"]
     },
     "lint": {},
+    "typecheck": {
+      "dependsOn": ["^build"]
+    },
     "//#format": {},
     "//#format:check": {},
     "test:e2e": {


### PR DESCRIPTION
`tsc --noEmit` exits non-zero today on three packages — no CI workflow runs it, so type errors have been slipping through.

This PR fixes the backlog and adds a workflow to catch new ones.

- `packages/editor`: three real type bugs in `columns.spec.tsx` from #3430 — unbound `this`, missing `unknown` in a cast, `ReturnType<>` applied to a non-function.
- `packages/react-email`: tsconfig now excludes the e2e/CLI fixture directories, which are standalone projects with their own tsconfigs.
- `apps/web`: drop a broken `html-to-ast/dist/types` subpath import (no public export); derive the same types from `parse`/`stringify`.
- Adds a `typecheck` turbo task (`dependsOn: ["^build"]` so workspace `.d.mts` outputs are present), a root `typecheck` script, and a standalone `typecheck.yml` modeled on `lint.yml`.

`pnpm typecheck` → 7 of 7 tasks pass.

The workflow is its own file rather than a step in `tests.yml` so it gets a discrete status check, mirrors the existing `lint.yml` / `e2e.yml` split, and runs on the small runner without the Playwright container.