### PR TITLE
chore(ui): fix "defalt" typo in seed script log

### DIFF
--- a/packages/ui/scripts/seed.mts
+++ b/packages/ui/scripts/seed.mts
@@ -23,7 +23,7 @@ if (existsSync(emailsDirectoryPath)) {
   }
 }
 
-console.info('Copying over the defalt seed to the emails directory');
+console.info('Copying over the default seed to the emails directory');
 await fs.cp(seedPath, emailsDirectoryPath, {
   recursive: true,
 });


### PR DESCRIPTION
`packages/ui/scripts/seed.mts:26` printed "Copying over the defalt seed to the emails directory". Log message only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a typo in the seed script log in `packages/ui/scripts/seed.mts`, changing "defalt" to "default" when copying the seed to the emails directory.

<sup>Written for commit ea66698c3dfc07fb7c41757c8e7eac5c478ac1c3. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3540?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

