### PR TITLE
fix(editor): possible XSS via pasted HTML

### DIFF
--- a/.changeset/sanitize-paste-urls-and-tags.md
+++ b/.changeset/sanitize-paste-urls-and-tags.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+scrub `javascript:`, `vbscript:`, and non-image `data:` URLs from pasted HTML and drop `script`, `iframe`, `object`, `embed`, `meta`, and `base` elements. This pass now runs on every paste; previously, content carrying the editor's `node-*` class marker took a fast-path that skipped sanitization entirely and could be spoofed by hosting attacker HTML with the same class name. Legitimate intra-editor copy/paste still round-trips `class`, `style`, and `data-*` attributes as before.

--- a/packages/editor/src/utils/paste-sanitizer.spec.ts
+++ b/packages/editor/src/utils/paste-sanitizer.spec.ts
@@ -1,0 +1,101 @@
+import { sanitizePastedHtml } from './paste-sanitizer';
+
+describe('sanitizePastedHtml', () => {
+  describe('strips dangerous elements from external paste', () => {
+    it('removes <script>', () => {
+      const out = sanitizePastedHtml('<p>hi</p><script>alert(1)</script>');
+      expect(out.toLowerCase()).not.toContain('<script');
+    });
+
+    it('removes <iframe>', () => {
+      const out = sanitizePastedHtml('<p>hi</p><iframe></iframe>');
+      expect(out.toLowerCase()).not.toContain('<iframe');
+    });
+
+    it('removes <object> and <embed>', () => {
+      const out = sanitizePastedHtml(
+        '<object data="x"></object><embed src="x">',
+      );
+      expect(out.toLowerCase()).not.toContain('<object');
+      expect(out.toLowerCase()).not.toContain('<embed');
+    });
+
+    it('removes <meta> and <base>', () => {
+      const out = sanitizePastedHtml(
+        '<meta http-equiv="refresh" content="0;url=https://evil.example"><base href="https://evil.example/">',
+      );
+      expect(out.toLowerCase()).not.toContain('<meta');
+      expect(out.toLowerCase()).not.toContain('<base');
+    });
+  });
+
+  describe('strips dangerous URL schemes', () => {
+    it('removes javascript: from <a href>', () => {
+      const out = sanitizePastedHtml('<a href="javascript:alert(1)">click</a>');
+      expect(out.toLowerCase()).not.toContain('javascript:');
+    });
+
+    it('removes javascript: from <img src>', () => {
+      const out = sanitizePastedHtml('<img src="javascript:alert(1)">');
+      expect(out.toLowerCase()).not.toContain('javascript:');
+    });
+  });
+
+  describe('editor-origin fast-path cannot be spoofed to skip sanitization', () => {
+    // The fast-path is keyed on a class-name marker in the raw HTML.
+    // An attacker can host content carrying that marker so a victim's
+    // paste skips sanitization — so the fast-path must not pass
+    // dangerous content through untouched.
+    it('does not pass through <script> when the editor marker is present', () => {
+      const out = sanitizePastedHtml(
+        '<div class="paragraph node-paragraph"><script>alert(1)</script></div>',
+      );
+      expect(out.toLowerCase()).not.toContain('<script');
+    });
+  });
+
+  describe('preserves legitimate content (regression guards)', () => {
+    it('keeps basic semantic HTML', () => {
+      const out = sanitizePastedHtml('<p>hello <strong>world</strong></p>');
+      expect(out).toContain('<p>');
+      expect(out.toLowerCase()).toContain('<strong>');
+      expect(out).toContain('hello');
+      expect(out).toContain('world');
+    });
+
+    it('keeps safe http(s) links with allowed attributes', () => {
+      const out = sanitizePastedHtml(
+        '<a href="https://example.com" target="_blank" rel="noopener">x</a>',
+      );
+      expect(out).toContain('href="https://example.com"');
+      expect(out).toContain('target="_blank"');
+      expect(out).toContain('rel="noopener"');
+    });
+
+    it('keeps images with safe src and allowed attributes', () => {
+      const out = sanitizePastedHtml(
+        '<img src="https://example.com/a.png" alt="a" width="10" height="10">',
+      );
+      expect(out).toContain('src="https://example.com/a.png"');
+      expect(out).toContain('alt="a"');
+    });
+
+    it('keeps data:image URLs on <img src>', () => {
+      const png =
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgAAIAAAUAAen63NgAAAAASUVORK5CYII=';
+      const out = sanitizePastedHtml(`<img src="${png}" alt="dot">`);
+      expect(out).toContain(`src="${png}"`);
+    });
+
+    it('preserves editor-origin attributes (class, style, data-type)', () => {
+      // Intra-editor copy/paste relies on these attributes round-tripping
+      // so Tiptap can reconstruct the node type and styling.
+      const out = sanitizePastedHtml(
+        '<div class="node-paragraph" style="color:red" data-type="container">x</div>',
+      );
+      expect(out).toContain('class="node-paragraph"');
+      expect(out).toContain('style="color:red"');
+      expect(out).toContain('data-type="container"');
+    });
+  });
+});

--- a/packages/editor/src/utils/paste-sanitizer.ts
+++ b/packages/editor/src/utils/paste-sanitizer.ts
@@ -1,13 +1,22 @@
 /**
  * Sanitizes pasted HTML.
- * - From editor (has node-* classes): pass through as-is
- * - From external: strip all styles/classes, keep only semantic HTML
+ * - Always: drop dangerous elements (script, iframe, ...) and unsafe URL schemes (javascript:, ...).
+ * - From editor (has node-* classes): preserve attributes so node identity round-trips.
+ * - From external: strip all styles/classes, keep only semantic HTML.
  */
 
-/**
- * Detects content from the Resend editor by checking for node-* class names.
- */
 const EDITOR_CLASS_PATTERN = /class="[^"]*node-/;
+
+const FORBIDDEN_TAGS = new Set([
+  'script',
+  'iframe',
+  'object',
+  'embed',
+  'meta',
+  'base',
+]);
+
+const URL_ATTRIBUTES = new Set(['href', 'src']);
 
 /**
  * Attributes to preserve on specific elements for EXTERNAL content.
@@ -27,16 +36,57 @@ function isFromEditor(html: string): boolean {
 }
 
 export function sanitizePastedHtml(html: string): string {
-  if (isFromEditor(html)) {
-    return html;
-  }
-
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');
+
+  removeForbiddenElements(doc.body);
+  scrubUnsafeUrlAttributes(doc.body);
+
+  if (isFromEditor(html)) {
+    return doc.body.innerHTML;
+  }
 
   sanitizeNode(doc.body);
 
   return doc.body.innerHTML;
+}
+
+function removeForbiddenElements(root: Element): void {
+  const toRemove: Element[] = [];
+  for (const tag of FORBIDDEN_TAGS) {
+    for (const el of Array.from(root.getElementsByTagName(tag))) {
+      toRemove.push(el);
+    }
+  }
+  for (const el of toRemove) {
+    el.remove();
+  }
+}
+
+function scrubUnsafeUrlAttributes(node: Node): void {
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    const el = node as HTMLElement;
+    const allowDataImage = el.tagName.toLowerCase() === 'img';
+    for (const attr of URL_ATTRIBUTES) {
+      const value = el.getAttribute(attr);
+      if (value !== null && !isSafeUrl(value, allowDataImage)) {
+        el.removeAttribute(attr);
+      }
+    }
+  }
+  for (const child of Array.from(node.childNodes)) {
+    scrubUnsafeUrlAttributes(child);
+  }
+}
+
+function isSafeUrl(value: string, allowDataImage: boolean): boolean {
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed.startsWith('javascript:')) return false;
+  if (trimmed.startsWith('vbscript:')) return false;
+  if (trimmed.startsWith('data:')) {
+    return allowDataImage && trimmed.startsWith('data:image/');
+  }
+  return true;
 }
 
 function sanitizeNode(node: Node): void {

--- a/packages/editor/src/utils/paste-sanitizer.ts
+++ b/packages/editor/src/utils/paste-sanitizer.ts
@@ -52,20 +52,15 @@ export function sanitizePastedHtml(html: string): string {
 }
 
 function removeForbiddenElements(root: Element): void {
-  const toRemove: Element[] = [];
   for (const tag of FORBIDDEN_TAGS) {
     for (const el of Array.from(root.getElementsByTagName(tag))) {
-      toRemove.push(el);
+      el.remove();
     }
-  }
-  for (const el of toRemove) {
-    el.remove();
   }
 }
 
-function scrubUnsafeUrlAttributes(node: Node): void {
-  if (node.nodeType === Node.ELEMENT_NODE) {
-    const el = node as HTMLElement;
+function scrubUnsafeUrlAttributes(root: Element): void {
+  for (const el of Array.from(root.querySelectorAll<HTMLElement>('[href], [src]'))) {
     const allowDataImage = el.tagName.toLowerCase() === 'img';
     for (const attr of URL_ATTRIBUTES) {
       const value = el.getAttribute(attr);
@@ -73,9 +68,6 @@ function scrubUnsafeUrlAttributes(node: Node): void {
         el.removeAttribute(attr);
       }
     }
-  }
-  for (const child of Array.from(node.childNodes)) {
-    scrubUnsafeUrlAttributes(child);
   }
 }
 

--- a/packages/editor/src/utils/paste-sanitizer.ts
+++ b/packages/editor/src/utils/paste-sanitizer.ts
@@ -60,7 +60,9 @@ function removeForbiddenElements(root: Element): void {
 }
 
 function scrubUnsafeUrlAttributes(root: Element): void {
-  for (const el of Array.from(root.querySelectorAll<HTMLElement>('[href], [src]'))) {
+  for (const el of Array.from(
+    root.querySelectorAll<HTMLElement>('[href], [src]'),
+  )) {
     const allowDataImage = el.tagName.toLowerCase() === 'img';
     for (const attr of URL_ATTRIBUTES) {
       const value = el.getAttribute(attr);


### PR DESCRIPTION
Run unsafe-URL and forbidden-tag stripping on every paste. Intra-editor round-trip of `class`, `style`, and `data-*` is preserved.

closes https://github.com/resend/react-email/security/code-scanning/242

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes possible XSS via pasted HTML by sanitizing every paste in `@react-email/editor`. Dangerous URLs and tags are stripped even when content has the `node-*` marker, blocking spoofed bypasses.

- **Bug Fixes**
  - Remove `script`, `iframe`, `object`, `embed`, `meta`, and `base` on paste.
  - Strip `javascript:`, `vbscript:`, and non-image `data:` from `href`/`src`.
  - Preserve `class`, `style`, and `data-*` for editor-origin content; external paste still removes styles/classes.
  - Simplify helpers (direct element removal; single `[href], [src]` scan) and add tests for marker spoofing and safe-content regression.

<sup>Written for commit 2b33a1b5cfc72dd7732f386814803bd8448fb7a2. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/react-email/pull/3544?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



