### PR TITLE
docs(skill): add email accessibility guidance to skill

### DIFF
--- a/skills/react-email/SKILL.md
+++ b/skills/react-email/SKILL.md
@@ -377,7 +377,7 @@ Upgrade with `npm install react-email@latest` to get these defaults.
 
 **What you still have to do (content choices):**
 - Open with a single `<Heading as="h1">`, nest subheadings in order, never skip levels
-- Set descriptive `alt` on meaningful images; leave decorative images with `alt=""`
+- Set descriptive `alt` on meaningful images; pass an explicit `alt=""` on decorative images — never omit the attribute
 - Write link text that describes the destination (`<Button>Read the report</Button>`, not `click here`)
 - Hit 4.5:1 text contrast (WCAG AA); preview in dark mode
 - For layout tables you build by hand (outside `<Markdown>`), add `role="presentation"`

--- a/skills/react-email/SKILL.md
+++ b/skills/react-email/SKILL.md
@@ -355,12 +355,33 @@ See [references/PATTERNS.md](references/PATTERNS.md) for complete examples inclu
 
 1. **Test across email clients** - Gmail, Outlook, Apple Mail, Yahoo Mail
 2. **Keep it responsive** - Max-width around 600px, test on mobile
-3. **Use absolute image URLs** - Host on reliable CDN, always include `alt` text
-4. **Provide plain text version** - Required for accessibility
-5. **Keep file size under 102KB** - Gmail clips larger emails
-6. **Add proper TypeScript types** - Define interfaces for all email props
-7. **Include preview props** - Add `.PreviewProps` for development testing
-8. **Use verified domains** - For production `from` addresses
+3. **Use absolute image URLs** - Host on reliable CDN
+4. **Write meaningful alt text** - Describe purpose and details for content images; use `alt=""` for decorative images (spacers, dividers, background flourishes). React Email's `<Img>` defaults to `alt=""`.
+5. **Provide plain text version** - Required for accessibility
+6. **Keep file size under 102KB** - Gmail clips larger emails
+7. **Add proper TypeScript types** - Define interfaces for all email props
+8. **Include preview props** - Add `.PreviewProps` for development testing
+9. **Use verified domains** - For production `from` addresses
+
+### Accessibility
+
+The [Email Markup Consortium's 2026 report](https://emailmarkup.org/en/reports/accessibility/2026/) found that only 0.002% of emails pass basic accessibility checks. React Email handles the structural defaults; the rest is content.
+
+**What React Email gives you for free:**
+- `<Html>` sets `lang` and `dir` (defaults: `lang="en" dir="ltr"` — override per locale)
+- `<Img>` defaults to `alt=""` so decorative images are skipped by screen readers
+- `<Markdown>` renders layout tables with `role="presentation"`
+- `<Preview>` also emits a `<title>` tag
+
+Upgrade with `npm install react-email@latest` to get these defaults.
+
+**What you still have to do (content choices):**
+- Open with a single `<Heading as="h1">`, nest subheadings in order, never skip levels
+- Set descriptive `alt` on meaningful images; leave decorative images with `alt=""`
+- Write link text that describes the destination (`<Button>Read the report</Button>`, not `click here`)
+- Hit 4.5:1 text contrast (WCAG AA); preview in dark mode
+- For layout tables you build by hand (outside `<Markdown>`), add `role="presentation"`
+- For non-English emails, pass the locale: `<Html lang={locale} dir={isRTL ? 'rtl' : 'ltr'}>` (see [I18N.md](references/I18N.md))
 
 ## Additional Resources
 

--- a/skills/react-email/references/COMPONENTS.md
+++ b/skills/react-email/references/COMPONENTS.md
@@ -295,7 +295,7 @@ import { Img } from 'react-email';
 **Best practices:**
 - Always use absolute URLs hosted on CDN
 - **Meaningful images**: write descriptive `alt` text covering purpose and key details (e.g., `alt="Red bicycle leaning against a brick wall"`, not `alt="image"`)
-- **Decorative images** (spacers, dividers, background flourishes): leave the default `alt=""` so screen readers skip them cleanly
+- **Decorative images** (spacers, dividers, background flourishes): pass an explicit `alt=""` so screen readers skip them cleanly — never omit the attribute
 - Specify width and height to prevent layout shift
 - Use `block` class to avoid spacing issues
 

--- a/skills/react-email/references/COMPONENTS.md
+++ b/skills/react-email/references/COMPONENTS.md
@@ -155,6 +155,8 @@ import { Section } from 'react-email';
 </Section>
 ```
 
+Layout components (`<Section>`, `<Row>`, `<Container>`, `<Markdown>` tables) render `<table role="presentation">` by default so screen readers don't announce them as data tables. If you drop in a raw `<table>` for layout, add `role="presentation"` yourself.
+
 ### Row & Column
 
 Row displays content areas horizontally, Column displays content areas vertically. A Column needs to be used in combination with a Row component.
@@ -286,13 +288,14 @@ import { Img } from 'react-email';
 
 **Props:**
 - `src` (required) - Image URL (must be absolute)
-- `alt` (required) - Alt text for accessibility
+- `alt` - Alt text for accessibility (defaults to `""`; set a descriptive value for meaningful images)
 - `width` - Image width in pixels
 - `height` - Image height in pixels
 
 **Best practices:**
 - Always use absolute URLs hosted on CDN
-- Always include alt text
+- **Meaningful images**: write descriptive `alt` text covering purpose and key details (e.g., `alt="Red bicycle leaning against a brick wall"`, not `alt="image"`)
+- **Decorative images** (spacers, dividers, background flourishes): leave the default `alt=""` so screen readers skip them cleanly
 - Specify width and height to prevent layout shift
 - Use `block` class to avoid spacing issues
 

--- a/skills/react-email/references/STYLING.md
+++ b/skills/react-email/references/STYLING.md
@@ -153,7 +153,7 @@ Use consistent spacing that respects content hierarchy. Larger margins for headi
 - Never distort user-provided images
 - Never create SVG images
 - Always use absolute URLs
-- Set descriptive `alt` text on meaningful images; leave decorative images with the default `alt=""` so screen readers skip them
+- Set descriptive `alt` text on meaningful images; pass an explicit `alt=""` on decorative images so screen readers skip them — never omit the attribute
 
 ```tsx
 {/* Meaningful image — describe purpose and details */}
@@ -163,8 +163,12 @@ Use consistent spacing that respects content hierarchy. Larger margins for headi
   className="w-full h-auto"
 />
 
-{/* Decorative image — omit alt or pass empty string */}
-<Img src="https://example.com/divider.png" className="w-full" />
+{/* Decorative image — always pass an empty alt string so screen readers skip it */}
+<Img
+  src="https://example.com/divider.png"
+  alt=""
+  className="w-full"
+/>
 ```
 
 ## Buttons

--- a/skills/react-email/references/STYLING.md
+++ b/skills/react-email/references/STYLING.md
@@ -153,14 +153,18 @@ Use consistent spacing that respects content hierarchy. Larger margins for headi
 - Never distort user-provided images
 - Never create SVG images
 - Always use absolute URLs
-- Include `alt` text for accessibility
+- Set descriptive `alt` text on meaningful images; leave decorative images with the default `alt=""` so screen readers skip them
 
 ```tsx
+{/* Meaningful image — describe purpose and details */}
 <Img
-  src="https://example.com/image.png"
-  alt="Description"
+  src="https://example.com/hero.png"
+  alt="A team of engineers reviewing code on a laptop"
   className="w-full h-auto"
 />
+
+{/* Decorative image — omit alt or pass empty string */}
+<Img src="https://example.com/divider.png" className="w-full" />
 ```
 
 ## Buttons


### PR DESCRIPTION
Updates the `react-email` agent skill so agents using it produce accessible emails by default, matching the new accessibility defaults shipped in the latest release and the findings of the [Email Markup Consortium's 2026 accessibility report](https://emailmarkup.org/en/reports/accessibility/2026/) (0.002% pass rate across 376,348 emails).

## What changes

**`skills/react-email/SKILL.md`**
- Fixes the alt-text rule. The old line was "always include `alt` text," which is wrong for decorative images and conflicts with the new `<Img alt="">` default.
- Adds an Accessibility subsection that splits the responsibility cleanly: structural defaults React Email gives you for free (lang/dir on Body, alt="" on Img, role="presentation" on Markdown tables, title from Preview), versus the content choices the author still owns (heading hierarchy, descriptive alt + link text, 4.5:1 contrast, locale handling).

**`skills/react-email/references/COMPONENTS.md`**
- `<Img>` props: notes that `alt` defaults to `""` instead of marking it as required (it isn't anymore), and rewrites the best practices to distinguish meaningful vs. decorative images.
- `<Section>` docs: notes that layout components (`<Section>`, `<Row>`, `<Container>`, `<Markdown>` tables) render `role="presentation"` by default so screen readers don't announce them as data tables, and reminds authors to add it themselves on any raw `<table>` they drop in.

**`skills/react-email/references/STYLING.md`**
- Aligns the image best-practices block with the new alt-text guidance and adds a decorative-image example.

## Why

Agents using this skill generate the templates. If the skill still says "always include alt text," they'll plaster `alt="image"` on decorative spacers and clutter every screen reader. Better to teach the right rule once.

A companion PR adds a full accessibility reference to the `email-best-practices` skill: https://github.com/resend/email-best-practices/pull/16