### PR TITLE
fix(render): add bugs.url to @react-email/render package manifest

### DIFF
--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -107,6 +107,9 @@
     "url": "https://github.com/resend/react-email.git",
     "directory": "packages/render"
   },
+  "bugs": {
+    "url": "https://github.com/resend/react-email/issues"
+  },
   "keywords": [
     "react",
     "email"


### PR DESCRIPTION
Adds missing `bugs.url` field to `@react-email/render` package.json, pointing to the repository issues page.

Supersedes #3561 (resolved merge conflict).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing `bugs.url` field to the `@react-email/render` package.json, pointing to https://github.com/resend/react-email/issues. This ensures npm and related tooling link bug reports to the correct issue tracker.

<sup>Written for commit 42af078fc50430ed1f95cd18af1441587490897b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

