### PR TITLE
fix(editor): use 'strike' mark name for inspector strikethrough

### DIFF
--- a/.changeset/fix-inspector-strikethrough.md
+++ b/.changeset/fix-inspector-strikethrough.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+Fix the Strikethrough button in the typography inspector throwing "There is no mark type named 'line-through'". The `FORMAT_ITEMS` entry now uses the tiptap mark name `strike` instead of the CSS `text-decoration` value `line-through`.

--- a/packages/editor/src/ui/inspector/config/text-config.tsx
+++ b/packages/editor/src/ui/inspector/config/text-config.tsx
@@ -127,7 +127,7 @@ export const FORMAT_ITEMS: FormatItem[] = [
   { value: 'bold', icon: BoldIcon, label: 'Bold' },
   { value: 'italic', icon: ItalicIcon, label: 'Italic' },
   { value: 'underline', icon: UnderlineIcon, label: 'Underline' },
-  { value: 'line-through', icon: StrikethroughIcon, label: 'Strikethrough' },
+  { value: 'strike', icon: StrikethroughIcon, label: 'Strikethrough' },
   { value: 'code', icon: CodeIcon, label: 'Code' },
   { value: 'uppercase', icon: CaseUpperIcon, label: 'Uppercase' },
 ];


### PR DESCRIPTION
## Fixes #3560

### Problem
Clicking **Strikethrough** in the typography inspector (`Inspector.Text` → Format row) throws and does nothing:

```
Uncaught Error: There is no mark type named 'line-through'. Maybe you forgot to add the extension?
```

The `BubbleMenu` strikethrough works; only the inspector button is affected.

### Root cause
`FORMAT_ITEMS` in `packages/editor/src/ui/inspector/config/text-config.tsx` defined the strikethrough entry with the CSS `text-decoration` value `line-through` as the mark identifier:

```ts
{ value: 'line-through', icon: StrikethroughIcon, label: 'Strikethrough' }
```

But `typography.tsx` passes `item.value` straight into the tiptap command:

```ts
onClick={() => toggleMark(item.value)}   // -> editor.chain().focus().toggleMark(mark).run()
aria-pressed={marks[item.value] ?? false}
```

There is no tiptap mark named `line-through`, so the toggle throws. The pressed state was also always `false`, because `activeMarks` is keyed by `MARK_NAMES = ['bold','italic','underline','strike','code']`.

### Fix
Use the tiptap mark name `strike` (matching `BubbleMenuStrike` in `ui/bubble-menu/strike.tsx`):

```ts
{ value: 'strike', icon: StrikethroughIcon, label: 'Strikethrough' }
```

This fixes both the throw and the pressed-state indicator.

### Scope / not changed
- `MARK_TOGGLES` keeps `line-through` — it uses an explicit `toggleStrike` command and `text-block-utils` maps from the stored `text-decoration` value (covered by an existing test).
- `TEXT_DECORATION_ITEMS` keeps `line-through` — those are genuine CSS `text-decoration` values.

A changeset is included (`@react-email/editor` patch).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the Strikethrough button in the typography inspector in `@react-email/editor` by using the tiptap mark name `strike` instead of the CSS value `line-through`. This removes the runtime error and restores the pressed state.

<sup>Written for commit 731aea271eead50dae0b93b97a31c4663ff6b095. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

