### PR TITLE
fix(editor): use Selection.atStart when clearing selection on blur

### DIFF
--- a/.changeset/blur-selection-atstart.md
+++ b/.changeset/blur-selection-atstart.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+Fix invalid `TextSelection` on blur. Clearing the selection on blur used `TextSelection.create(doc, 0)`, which resolves to the doc node (no inline content) and made ProseMirror log "TextSelection endpoint not pointing into a node with inline content (doc)". It now uses `Selection.atStart(doc)`, which resolves to the first valid cursor position.

--- a/packages/editor/src/extensions/focus-scopes.spec.ts
+++ b/packages/editor/src/extensions/focus-scopes.spec.ts
@@ -82,32 +82,46 @@ describe('FocusScopes', () => {
 
   it('clears the selection on blur without an invalid TextSelection warning', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const { editor, element } = createEditor();
-    await waitForCreate();
+    let editor: Editor | undefined;
+    let element: HTMLElement | undefined;
 
-    editor.commands.setTextSelection({ from: 2, to: 7 });
-    editor.view.dom.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    try {
+      ({ editor, element } = createEditor());
+      await waitForCreate();
 
-    editor.view.dom.dispatchEvent(
-      new FocusEvent('focusout', {
-        bubbles: true,
-        relatedTarget: document.body,
-      }),
-    );
+      editor.commands.setTextSelection({ from: 2, to: 7 });
+      editor.view.dom.dispatchEvent(
+        new FocusEvent('focusin', { bubbles: true }),
+      );
 
-    expect(editor.isFocused).toBe(false);
-    expect(editor.state.selection.empty).toBe(true);
-    expect(editor.state.selection.$from.parent.inlineContent).toBe(true);
-    // Position 0 resolves to the doc node, which has no inline content, and
-    // ProseMirror warns when a TextSelection endpoint lands there.
-    expect(warn).not.toHaveBeenCalledWith(
-      expect.stringContaining(
-        'TextSelection endpoint not pointing into a node with inline content',
-      ),
-    );
+      editor.view.dom.dispatchEvent(
+        new FocusEvent('focusout', {
+          bubbles: true,
+          relatedTarget: document.body,
+        }),
+      );
 
-    warn.mockRestore();
-    editor.destroy();
-    element.remove();
+      expect(editor.isFocused).toBe(false);
+      expect(editor.state.selection.empty).toBe(true);
+      expect(editor.state.selection.$from.parent.inlineContent).toBe(true);
+      // Position 0 resolves to the doc node, which has no inline content, and
+      // ProseMirror warns when a TextSelection endpoint lands there. Scan every
+      // argument of every recorded call for the warning substring so additional
+      // ProseMirror arguments cannot turn this into a false negative.
+      const warnedAboutInvalidEndpoint = warn.mock.calls.some((args) =>
+        args.some((arg) =>
+          String(arg).includes(
+            'TextSelection endpoint not pointing into a node with inline content',
+          ),
+        ),
+      );
+      expect(warnedAboutInvalidEndpoint).toBe(false);
+    } finally {
+      // Clean up in `finally` so a failed assertion above cannot leak the
+      // console.warn spy or a live editor instance into later tests.
+      warn.mockRestore();
+      editor?.destroy();
+      element?.remove();
+    }
   });
 });

--- a/packages/editor/src/extensions/focus-scopes.spec.ts
+++ b/packages/editor/src/extensions/focus-scopes.spec.ts
@@ -1,4 +1,5 @@
 import { Editor, extensions as nativeTiptapExtensions } from '@tiptap/core';
+import { vi } from 'vitest';
 import { StarterKit } from '.';
 import { focusScopePluginKey } from './focus-scopes';
 
@@ -69,10 +70,44 @@ describe('FocusScopes', () => {
     );
 
     expect(editor.isFocused).toBe(false);
-    expect(editor.state.selection.from).toBe(0);
+    // The selection is reset to the start of the document. It must resolve
+    // into a node with inline content (not the doc node at position 0), so
+    // the first valid cursor position is used.
+    expect(editor.state.selection.$from.parent.inlineContent).toBe(true);
 
     editor.destroy();
     element.remove();
     externalScope.remove();
+  });
+
+  it('clears the selection on blur without an invalid TextSelection warning', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { editor, element } = createEditor();
+    await waitForCreate();
+
+    editor.commands.setTextSelection({ from: 2, to: 7 });
+    editor.view.dom.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+    editor.view.dom.dispatchEvent(
+      new FocusEvent('focusout', {
+        bubbles: true,
+        relatedTarget: document.body,
+      }),
+    );
+
+    expect(editor.isFocused).toBe(false);
+    expect(editor.state.selection.empty).toBe(true);
+    expect(editor.state.selection.$from.parent.inlineContent).toBe(true);
+    // Position 0 resolves to the doc node, which has no inline content, and
+    // ProseMirror warns when a TextSelection endpoint lands there.
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining(
+        'TextSelection endpoint not pointing into a node with inline content',
+      ),
+    );
+
+    warn.mockRestore();
+    editor.destroy();
+    element.remove();
   });
 });

--- a/packages/editor/src/extensions/focus-scopes.ts
+++ b/packages/editor/src/extensions/focus-scopes.ts
@@ -3,7 +3,7 @@ import {
   Extension,
   extensions as nativeTiptapExtensions,
 } from '@tiptap/core';
-import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
+import { Plugin, PluginKey, Selection } from '@tiptap/pm/state';
 
 export interface FocusScopesOptions {
   clearSelectionOnBlur: boolean;
@@ -87,7 +87,7 @@ export function createFocusScopePlugin({
           .setMeta('addToHistory', false);
 
         if (clearSelectionOnBlur) {
-          transaction.setSelection(TextSelection.create(transaction.doc, 0));
+          transaction.setSelection(Selection.atStart(transaction.doc));
         }
 
         editor.view.dispatch(transaction);


### PR DESCRIPTION
## Summary

`@react-email/editor`'s `focusScope` extension cleared the selection on blur with `TextSelection.create(transaction.doc, 0)`. Position `0` resolves to the top-level `doc` node, which has no inline content, so ProseMirror's `checkTextSelection` logs `TextSelection endpoint not pointing into a node with inline content (doc)` to the console on every editor blur (e.g. focusing any other field on the page).

This swaps it for `Selection.atStart(transaction.doc)` — same intent (cursor at document start) but a valid inline position, so no warning. This is the fix suggested in the issue.

## Changes

- Use `Selection.atStart(transaction.doc)` in `focus-scopes.ts`
- Corrected the existing blur test (it asserted the buggy `from === 0`) and added a regression test that asserts no console warning on blur
- Added a changeset

## Testing

- `pnpm vitest run --project unit src/extensions/focus-scopes.spec.ts` → 3 passed
- Full unit project → 489 passed / 1 skipped
- `tsc --noEmit` clean; `biome check` clean
- Reverting only the source (keeping the tests) makes the new tests fail — confirms they catch the bug

Closes #3564

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the ProseMirror warning on editor blur by moving the cursor to the first valid inline position. `@react-email/editor` now uses `Selection.atStart(doc)` instead of `TextSelection.create(doc, 0)`.

- **Bug Fixes**
  - Clear selection on blur with `Selection.atStart(doc)` to avoid an invalid selection at position 0.
  - Strengthen tests: always restore the `console.warn` spy and scan `warn.mock.calls` to avoid false negatives.

<sup>Written for commit 3753544029e9f97868519c6f5f1c08218c39b55b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

