### PR TITLE
fix(ui): count CRLF as one line break in getLineAndColumnFromOffset

### DIFF
--- a/.changeset/silent-pillows-cry.md
+++ b/.changeset/silent-pillows-cry.md
@@ -1,0 +1,5 @@
+---
+"@react-email/ui": patch
+---
+
+Fix line and column calculation for CRLF line endings in the email validation diagnostics. A `\r\n` was being counted as two line breaks, so line and column numbers reported for templates authored with Windows line endings were off.

--- a/packages/ui/src/utils/get-line-and-column-from-offset.spec.ts
+++ b/packages/ui/src/utils/get-line-and-column-from-offset.spec.ts
@@ -9,3 +9,35 @@ test('getLineAndColumnFromOffset()', () => {
   const offset = content.indexOf('className');
   expect(getLineAndColumnFromOffset(offset, content)).toEqual([2, 15]);
 });
+
+test('getLineAndColumnFromOffset() counts a CRLF as a single line break', () => {
+  const content = 'first line\r\nsecond line\r\nthird line';
+
+  expect(
+    getLineAndColumnFromOffset(content.indexOf('second'), content),
+  ).toEqual([2, 1]);
+  expect(getLineAndColumnFromOffset(content.indexOf('third'), content)).toEqual(
+    [3, 1],
+  );
+  expect(
+    getLineAndColumnFromOffset(content.indexOf('line', 12), content),
+  ).toEqual([2, 8]);
+});
+
+test('getLineAndColumnFromOffset() handles a lone carriage return', () => {
+  const content = 'first line\rsecond line';
+
+  expect(
+    getLineAndColumnFromOffset(content.indexOf('second'), content),
+  ).toEqual([2, 1]);
+});
+
+test('getLineAndColumnFromOffset() does not split a CRLF when the offset is between the carriage return and the line feed', () => {
+  const content = 'a\r\nb';
+
+  // Offset of the `\n` itself: the CRLF has not been fully passed, so this is
+  // still on line 1 rather than being treated as a lone carriage return.
+  expect(getLineAndColumnFromOffset(2, content)).toEqual([1, 2]);
+  // Offset of `b`, the first character after the CRLF.
+  expect(getLineAndColumnFromOffset(3, content)).toEqual([2, 1]);
+});

--- a/packages/ui/src/utils/get-line-and-column-from-offset.ts
+++ b/packages/ui/src/utils/get-line-and-column-from-offset.ts
@@ -2,10 +2,25 @@ export const getLineAndColumnFromOffset = (
   offset: number,
   content: string,
 ): [line: number, column: number] => {
-  const lineBreaks = [...content.slice(0, offset).matchAll(/\n|\r|\r\n/g)];
+  // `\r\n` must come first in the alternation so a CRLF is matched as a single
+  // line break. With `\n|\r|\r\n`, the `\r` branch would match first, so a CRLF
+  // would count as two line breaks and inflate both the line and the column.
+  //
+  // We also scan the whole `content` (not `content.slice(0, offset)`) and keep
+  // only the breaks that fully end at or before `offset`. That way an `offset`
+  // landing between the `\r` and `\n` of a CRLF isn't mistaken for a lone `\r`.
+  const precedingLineBreaks = [...content.matchAll(/\r\n|\n|\r/g)].filter(
+    (lineBreak) => lineBreak.index + lineBreak[0].length <= offset,
+  );
 
-  const line = lineBreaks.length + 1;
-  const column = offset - (lineBreaks[lineBreaks.length - 1]?.index ?? 0);
+  const line = precedingLineBreaks.length + 1;
+
+  // Column is measured from the character right after the last line break.
+  // On line 1 (no preceding break) this keeps the original 0-based first column.
+  const lastLineBreak = precedingLineBreaks[precedingLineBreaks.length - 1];
+  const column = lastLineBreak
+    ? offset - (lastLineBreak.index + lastLineBreak[0].length) + 1
+    : offset;
 
   return [line, column];
 };


### PR DESCRIPTION
## Summary

`getLineAndColumnFromOffset` in `@react-email/ui` converts a character offset to a 1-based `[line, column]` (used by the email-validation diagnostics shown to users). Its regex `/\n|\r|\r\n/g` matched a Windows CRLF as **two** line breaks — in ordered alternation the `\r` branch always wins before `\r\n` — so line/column were inflated for any CRLF-authored template. Empirically, `"a\r\nb"` reported `b` at line 3 instead of line 2.

## Changes

- Reorder the split to `/\r\n|\n|\r/g` so CRLF counts as a single break
- Subtract the matched break's full length for a consistent column, and scan the whole content so an offset between `\r` and `\n` isn't split
- 3 regression tests + a `patch` changeset for `@react-email/ui`

LF behavior is byte-identical.

## Testing

- `vitest run get-line-and-column-from-offset` → 4 passed
- Red-green proven: reverting the source fails the 2 CRLF tests, LF stays green
- `biome check` clean on changed files; `tsc --noEmit` clean on the changed file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes line/column reporting in `@react-email/ui` diagnostics for Windows line endings by correcting `getLineAndColumnFromOffset`. Positions are now accurate across CRLF and LF files.

- **Bug Fixes**
  - Use `/\r\n|\n|\r/g` and compute columns from the end of the matched break for consistent results.
  - Consider only breaks that end at or before the offset to avoid splitting a CRLF when the offset is between `\r` and `\n`.
  - Add regression tests and a patch changeset.

<sup>Written for commit d476ad1f8f48e8337c65bccf0a089c00bd44b00d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

