### PR TITLE
fix(markdown): escape double quotes to &quot; in inline styles

### DIFF
--- a/.changeset/markdown-style-double-quote-escape.md
+++ b/.changeset/markdown-style-double-quote-escape.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Fix `Markdown` corrupting double quotes in `markdownCustomStyles`. Inline style values containing a `"` (e.g. `fontFamily: '"Times New Roman", serif'`) were escaped to the apostrophe entity `&#x27;` instead of `&quot;`, silently rewriting the quoted value. Double quotes are now escaped as `&quot;`.

--- a/packages/react-email/src/components/markdown/markdown.spec.tsx
+++ b/packages/react-email/src/components/markdown/markdown.spec.tsx
@@ -116,7 +116,7 @@ console.log(\`Hello, $\{name}!\`);
       </Markdown>,
     );
     expect(actualOutput).toMatchInlineSnapshot(`
-      "<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><div data-id="react-email-markdown"><p><strong style="font:700 23px / 32px &#x27;Roobert PRO&#x27;, system-ui, sans-serif;background:url(&#x27;path/to/image&#x27;)">This is sample bold text in markdown</strong> and <em style="font-style:italic">this is italic text</em></p>
+      "<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><div data-id="react-email-markdown"><p><strong style="font:700 23px / 32px &quot;Roobert PRO&quot;, system-ui, sans-serif;background:url(&quot;path/to/image&quot;)">This is sample bold text in markdown</strong> and <em style="font-style:italic">this is italic text</em></p>
       </div><!--/$-->"
     `);
   });

--- a/packages/react-email/src/components/markdown/utils/parse-css-in-js-to-inline-css.spec.ts
+++ b/packages/react-email/src/components/markdown/utils/parse-css-in-js-to-inline-css.spec.ts
@@ -1,0 +1,42 @@
+import { parseCssInJsToInlineCss } from './parse-css-in-js-to-inline-css.js';
+
+describe('parseCssInJsToInlineCss', () => {
+  it('returns an empty string for undefined styles', () => {
+    expect(parseCssInJsToInlineCss(undefined)).toBe('');
+  });
+
+  it('converts camelCase properties to kebab-case', () => {
+    expect(parseCssInJsToInlineCss({ fontFamily: 'serif' })).toBe(
+      'font-family:serif',
+    );
+  });
+
+  it('appends px to numeric values of numerical properties', () => {
+    expect(parseCssInJsToInlineCss({ fontSize: 16 })).toBe('font-size:16px');
+  });
+
+  it('joins multiple declarations with a semicolon', () => {
+    expect(parseCssInJsToInlineCss({ color: 'red', fontSize: 16 })).toBe(
+      'color:red;font-size:16px',
+    );
+  });
+
+  it('escapes double quotes so they do not break the style attribute', () => {
+    const result = parseCssInJsToInlineCss({
+      fontFamily: '"Times New Roman", serif',
+    });
+
+    expect(result).toBe('font-family:&quot;Times New Roman&quot;, serif');
+    expect(result).not.toContain('"');
+  });
+
+  it('does not corrupt double-quoted values into apostrophes', () => {
+    const result = parseCssInJsToInlineCss({
+      fontFamily: '"Times New Roman", serif',
+    });
+
+    // `&#x27;` is the apostrophe entity and would silently change the
+    // quoted font name; a double quote must be escaped as `&quot;`.
+    expect(result).not.toContain('&#x27;');
+  });
+});

--- a/packages/react-email/src/components/markdown/utils/parse-css-in-js-to-inline-css.ts
+++ b/packages/react-email/src/components/markdown/utils/parse-css-in-js-to-inline-css.ts
@@ -4,7 +4,7 @@ function camelToKebabCase(str: string): string {
 
 function escapeQuotes(value: unknown) {
   if (typeof value === 'string' && value.includes('"')) {
-    return value.replace(/"/g, '&#x27;');
+    return value.replace(/"/g, '&quot;');
   }
   return value;
 }


### PR DESCRIPTION
`parseCssInJsToInlineCss` (used by the `Markdown` component to inline `markdownCustomStyles` into `style="..."`) escaped a double quote `"` to `&#x27;` — the HTML entity for an apostrophe, not a double quote. Any double-quoted style value (e.g. `fontFamily: '"Times New Roman", serif'`, `url("...")`) was silently rewritten to apostrophes in the rendered HTML. The existing markdown snapshot had baked in the corrupted `&#x27;` output, so it was shipping.

Fix: escape to `&quot;`. Adds unit tests for the previously-untested util, updates the stale snapshot, and includes a `patch` changeset.

Full `react-email` unit suite passes (274 tests); `pnpm typecheck` clean; `biome check` clean on the changed files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect escaping of double quotes in Markdown inline styles. `parseCssInJsToInlineCss` now escapes `"` as `&quot;` (not `&#x27;`), so quoted values in `markdownCustomStyles` render correctly.

- **Bug Fixes**
  - Escape `"` to `&quot;` in styles generated by `parseCssInJsToInlineCss`.
  - Add unit tests and refresh the Markdown snapshot.
  - Add a patch changeset for `react-email`.

<sup>Written for commit 3774e83da7efb5c42b32f87d6db4889343fb4ea4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

