### PR TITLE
fix(ui): update existing Resend template on upload instead of duplicating

### DIFF
--- a/.changeset/sync-resend-template-on-upload.md
+++ b/.changeset/sync-resend-template-on-upload.md
@@ -1,0 +1,5 @@
+---
+"@react-email/ui": patch
+---
+
+Update the existing Resend template on upload instead of always creating a new one. The "Upload to Resend" and "Bulk Upload" actions now look the template up by name and update it in place when exactly one matches, so re-uploading no longer produces duplicates (`welcome`, `welcome (1)`, ...).

--- a/packages/ui/src/actions/export-single-template.ts
+++ b/packages/ui/src/actions/export-single-template.ts
@@ -4,6 +4,7 @@ import { Resend } from 'resend';
 import { z } from 'zod';
 import { resendApiKey } from '../app/env';
 import { baseActionClient } from './safe-action';
+import { uploadTemplateToResend } from './upload-template-to-resend';
 
 export const exportSingleTemplate = baseActionClient
   .metadata({
@@ -15,22 +16,7 @@ export const exportSingleTemplate = baseActionClient
       html: z.string(),
     }),
   )
-  .action(async ({ parsedInput }) => {
+  .action(({ parsedInput }) => {
     const resend = new Resend(resendApiKey);
-
-    const response = await resend.templates.create({
-      name: parsedInput.name,
-      html: parsedInput.html,
-    });
-
-    if (response.error) {
-      console.error('Error creating single template', response.error);
-      return { name: parsedInput.name, status: 'failed' as const };
-    }
-
-    return {
-      name: parsedInput.name,
-      status: 'succeeded' as const,
-      id: response.data.id,
-    };
+    return uploadTemplateToResend(resend, parsedInput);
   });

--- a/packages/ui/src/actions/upload-template-to-resend.spec.ts
+++ b/packages/ui/src/actions/upload-template-to-resend.spec.ts
@@ -1,0 +1,190 @@
+import type { Resend } from 'resend';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { uploadTemplateToResend } from './upload-template-to-resend';
+
+type TemplatesMock = {
+  list: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+};
+
+const makeResend = (templates: TemplatesMock): Resend =>
+  ({ templates }) as unknown as Resend;
+
+const listSuccess = (templates: { id: string; name: string }[]) => ({
+  data: { object: 'list', data: templates, has_more: false },
+  error: null,
+});
+
+const errorResponse = {
+  data: null,
+  error: { name: 'application_error', message: 'boom' },
+};
+
+describe('uploadTemplateToResend()', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates a new template when no existing template shares the name', async () => {
+    const templates: TemplatesMock = {
+      list: vi.fn().mockResolvedValue(listSuccess([])),
+      create: vi
+        .fn()
+        .mockResolvedValue({ data: { id: 'tmpl_new' }, error: null }),
+      update: vi.fn(),
+    };
+
+    const result = await uploadTemplateToResend(makeResend(templates), {
+      name: 'welcome',
+      html: '<h1>welcome</h1>',
+    });
+
+    expect(result).toEqual({
+      name: 'welcome',
+      status: 'succeeded',
+      id: 'tmpl_new',
+    });
+    expect(templates.create).toHaveBeenCalledWith({
+      name: 'welcome',
+      html: '<h1>welcome</h1>',
+    });
+    expect(templates.update).not.toHaveBeenCalled();
+  });
+
+  it('updates in place when exactly one existing template matches the name', async () => {
+    const templates: TemplatesMock = {
+      list: vi
+        .fn()
+        .mockResolvedValue(
+          listSuccess([{ id: 'tmpl_existing', name: 'welcome' }]),
+        ),
+      create: vi.fn(),
+      update: vi
+        .fn()
+        .mockResolvedValue({ data: { id: 'tmpl_existing' }, error: null }),
+    };
+
+    const result = await uploadTemplateToResend(makeResend(templates), {
+      name: 'welcome',
+      html: '<h1>updated</h1>',
+    });
+
+    expect(result).toEqual({
+      name: 'welcome',
+      status: 'succeeded',
+      id: 'tmpl_existing',
+    });
+    expect(templates.update).toHaveBeenCalledWith('tmpl_existing', {
+      html: '<h1>updated</h1>',
+    });
+    expect(templates.create).not.toHaveBeenCalled();
+  });
+
+  it('falls back to create when several templates share the name', async () => {
+    const templates: TemplatesMock = {
+      list: vi.fn().mockResolvedValue(
+        listSuccess([
+          { id: 'tmpl_a', name: 'welcome' },
+          { id: 'tmpl_b', name: 'welcome' },
+        ]),
+      ),
+      create: vi
+        .fn()
+        .mockResolvedValue({ data: { id: 'tmpl_new' }, error: null }),
+      update: vi.fn(),
+    };
+
+    const result = await uploadTemplateToResend(makeResend(templates), {
+      name: 'welcome',
+      html: '<h1>welcome</h1>',
+    });
+
+    expect(result).toEqual({
+      name: 'welcome',
+      status: 'succeeded',
+      id: 'tmpl_new',
+    });
+    expect(templates.create).toHaveBeenCalledTimes(1);
+    expect(templates.update).not.toHaveBeenCalled();
+  });
+
+  it('ignores templates whose name does not match', async () => {
+    const templates: TemplatesMock = {
+      list: vi
+        .fn()
+        .mockResolvedValue(
+          listSuccess([{ id: 'tmpl_other', name: 'password-reset' }]),
+        ),
+      create: vi
+        .fn()
+        .mockResolvedValue({ data: { id: 'tmpl_new' }, error: null }),
+      update: vi.fn(),
+    };
+
+    const result = await uploadTemplateToResend(makeResend(templates), {
+      name: 'welcome',
+      html: '<h1>welcome</h1>',
+    });
+
+    expect(result.status).toBe('succeeded');
+    expect(templates.create).toHaveBeenCalledTimes(1);
+    expect(templates.update).not.toHaveBeenCalled();
+  });
+
+  it('returns failed without writing when listing templates errors', async () => {
+    const templates: TemplatesMock = {
+      list: vi.fn().mockResolvedValue(errorResponse),
+      create: vi.fn(),
+      update: vi.fn(),
+    };
+
+    const result = await uploadTemplateToResend(makeResend(templates), {
+      name: 'welcome',
+      html: '<h1>welcome</h1>',
+    });
+
+    expect(result).toEqual({ name: 'welcome', status: 'failed' });
+    expect(templates.create).not.toHaveBeenCalled();
+    expect(templates.update).not.toHaveBeenCalled();
+  });
+
+  it('returns failed when updating an existing template errors', async () => {
+    const templates: TemplatesMock = {
+      list: vi
+        .fn()
+        .mockResolvedValue(
+          listSuccess([{ id: 'tmpl_existing', name: 'welcome' }]),
+        ),
+      create: vi.fn(),
+      update: vi.fn().mockResolvedValue(errorResponse),
+    };
+
+    const result = await uploadTemplateToResend(makeResend(templates), {
+      name: 'welcome',
+      html: '<h1>updated</h1>',
+    });
+
+    expect(result).toEqual({ name: 'welcome', status: 'failed' });
+    expect(templates.create).not.toHaveBeenCalled();
+  });
+
+  it('returns failed when creating a new template errors', async () => {
+    const templates: TemplatesMock = {
+      list: vi.fn().mockResolvedValue(listSuccess([])),
+      create: vi.fn().mockResolvedValue(errorResponse),
+      update: vi.fn(),
+    };
+
+    const result = await uploadTemplateToResend(makeResend(templates), {
+      name: 'welcome',
+      html: '<h1>welcome</h1>',
+    });
+
+    expect(result).toEqual({ name: 'welcome', status: 'failed' });
+  });
+});

--- a/packages/ui/src/actions/upload-template-to-resend.ts
+++ b/packages/ui/src/actions/upload-template-to-resend.ts
@@ -1,0 +1,53 @@
+import type { Resend } from 'resend';
+
+export type UploadTemplateResult =
+  | { name: string; status: 'failed' }
+  | { name: string; status: 'succeeded'; id: string };
+
+/**
+ * Uploads a single email template to Resend.
+ *
+ * Looks the template up by name first so that re-uploading the same template
+ * updates it in place instead of creating a duplicate (`welcome`, `welcome (1)`,
+ * `welcome (2)`, ...). Resend template names are not unique, so the update only
+ * happens when exactly one template matches the name. On zero or several matches
+ * it falls back to creating a new template, which is the previous behavior.
+ *
+ * See https://github.com/resend/react-email/issues/3194.
+ */
+export const uploadTemplateToResend = async (
+  resend: Resend,
+  template: { name: string; html: string },
+): Promise<UploadTemplateResult> => {
+  const existing = await resend.templates.list();
+  if (existing.error) {
+    console.error('Error listing templates', existing.error);
+    return { name: template.name, status: 'failed' };
+  }
+
+  const matches = existing.data.data.filter(
+    (item) => item.name === template.name,
+  );
+  const match = matches.length === 1 ? matches[0] : undefined;
+
+  if (match) {
+    const updated = await resend.templates.update(match.id, {
+      html: template.html,
+    });
+    if (updated.error) {
+      console.error('Error updating single template', updated.error);
+      return { name: template.name, status: 'failed' };
+    }
+    return { name: template.name, status: 'succeeded', id: updated.data.id };
+  }
+
+  const created = await resend.templates.create({
+    name: template.name,
+    html: template.html,
+  });
+  if (created.error) {
+    console.error('Error creating single template', created.error);
+    return { name: template.name, status: 'failed' };
+  }
+  return { name: template.name, status: 'succeeded', id: created.data.id };
+};

--- a/packages/ui/src/components/toolbar/resend.tsx
+++ b/packages/ui/src/components/toolbar/resend.tsx
@@ -135,14 +135,15 @@ export function ResendIntegration({
                     html: renderResult.markup,
                   });
 
-                  if (exportResult.data?.id) {
+                  if (exportResult.data?.status === 'succeeded') {
+                    const { id } = exportResult.data;
                     setItems((prevItems) =>
                       prevItems.map((item, index) =>
                         index === i
                           ? {
                               ...item,
                               status: 'succeeded',
-                              id: exportResult.data!.id,
+                              id,
                             }
                           : item,
                       ),


### PR DESCRIPTION
Closes #3194.

### Problem

The "Upload to Resend" and "Bulk Upload" buttons in the preview server's Resend toolbar always call `resend.templates.create()`, so every upload of the same template creates a brand new template (`welcome`, `welcome (1)`, `welcome (2)`, ...). The template ID your app code references keeps pointing at the original, outdated version, which makes the integration unusable as a sync mechanism.

### Fix

This takes the smaller of the two approaches discussed in the issue. Before creating, `exportSingleTemplate` looks the template up by name via `resend.templates.list()`:

- exactly one match: `resend.templates.update(id, { html })`, updating it in place
- zero or multiple matches: `resend.templates.create(...)`, the previous behavior

Resend template names are not unique, so the exactly-one guard avoids editing the wrong template. The action's return shape is unchanged, and both the single Upload and Bulk Upload paths run through `exportSingleTemplate`, so both are covered.

The sync logic is extracted into a plain `uploadTemplateToResend(resend, template)` helper so it can be unit tested directly, leaving the server action a thin wrapper.

### Known limitations (intentional, deferred to a follow-up)

- `templates.list()` returns a single page, so a template beyond the first page falls back to create.
- Bulk Upload now issues one `list()` per template on top of the existing 600ms throttle, which sits close to the 2 requests/second limit.

Both are fully resolved by the `react-email.config.ts` slug-to-ID mapping from the issue, which removes the need to list at all. That is a larger surface and reads better as its own follow-up PR, as discussed in the thread.

### Tests

Adds `upload-template-to-resend.spec.ts` covering create (no match), update (one match), create fallback (multiple matches), name-mismatch, and the list / update / create error paths with a mocked Resend SDK. No existing tests were changed.

Thanks @gabrielmfern for the go-ahead and @cooperjbrandon for handing it off.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops duplicate Resend templates by updating the existing template on upload when exactly one name match is found. Bulk Upload now reads the template `id` only when the upload succeeds (fixes #3194).

- **Bug Fixes**
  - Look up by name via `resend.templates.list()`; update with `resend.templates.update(id, { html })` on a single match; fall back to `resend.templates.create(...)` otherwise.
  - Extracted `uploadTemplateToResend(resend, template)`; returns a discriminated result where `id` exists only on `status: 'succeeded'`; added unit tests for create/update/multi-match/mismatch and error paths.
  - Bulk Upload UI now narrows on `status === 'succeeded'` before reading the returned `id`.

<sup>Written for commit bc8815c9adadb80f5e241a6b77c3968df45555bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

