### PR TITLE
fix(render): strip auto-injected image preload links from rendered HTML

### DIFF
--- a/.changeset/render-strip-image-preload-links.md
+++ b/.changeset/render-strip-image-preload-links.md
@@ -1,0 +1,5 @@
+---
+"@react-email/render": patch
+---
+
+Strip React's auto-injected `<link rel="preload" as="image">` resource hints from rendered email HTML. React adds one to the document `<head>` for every `<img>` during SSR, but email clients ignore preload hints, so they were just noise in the output. Other `<link>` tags (stylesheets, fonts, user-authored non-image preloads) are left untouched.

--- a/packages/react-email/src/cli/commands/testing/export.spec.ts
+++ b/packages/react-email/src/cli/commands/testing/export.spec.ts
@@ -20,8 +20,6 @@ test('email export', { retry: 3 }, async () => {
     "<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
     <html dir="ltr" lang="en">
       <head>
-        <link rel="preload" as="image" href="/static/vercel-logo.png" />
-        <link rel="preload" as="image" href="/static/vercel-arrow.png" />
         <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
         <meta name="x-apple-disable-message-reformatting" />
         <title>Join undefined on Vercel</title>

--- a/packages/react-email/src/components/img/img.spec.tsx
+++ b/packages/react-email/src/components/img/img.spec.tsx
@@ -24,7 +24,7 @@ describe('<Img> component', () => {
       <Img alt="Cat" height="300" src="cat.jpg" width="300" />,
     );
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><link rel="preload" as="image" href="cat.jpg"/><!--$--><img alt="Cat" height="300" src="cat.jpg" style="display:block;outline:none;border:none;text-decoration:none" width="300"/><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><img alt="Cat" height="300" src="cat.jpg" style="display:block;outline:none;border:none;text-decoration:none" width="300"/><!--/$-->"`,
     );
   });
 });

--- a/packages/render/src/browser/render-web.spec.tsx
+++ b/packages/render/src/browser/render-web.spec.tsx
@@ -54,7 +54,7 @@ describe('render on the browser environment', () => {
     const actualOutput = await render(<Template firstName="Jim" />);
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><link rel="preload" as="image" href="img/test.png"/><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
     );
   });
 
@@ -108,7 +108,7 @@ describe('render on the browser environment', () => {
     const actualOutput = await render(<Template firstName="Jim" />);
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><link rel="preload" as="image" href="img/test.png"/><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
     );
   });
 

--- a/packages/render/src/browser/render.tsx
+++ b/packages/render/src/browser/render.tsx
@@ -3,6 +3,7 @@ import { pretty, toPlainText } from '../node';
 import { createErrorBoundary } from '../shared/error-boundary';
 import type { Options } from '../shared/options';
 import { readStream } from '../shared/read-stream.browser';
+import { stripImagePreloadLinks } from '../shared/utils/strip-image-preload-links';
 
 export const render = async (node: React.ReactNode, options?: Options) => {
   const reactDOMServer = await import('react-dom/server').then((m) => {
@@ -30,7 +31,7 @@ export const render = async (node: React.ReactNode, options?: Options) => {
         await stream.allReady;
         return readStream(stream);
       })
-      .then(resolve)
+      .then((result) => resolve(stripImagePreloadLinks(result)))
       .catch(reject);
   });
 

--- a/packages/render/src/edge/render.spec.tsx
+++ b/packages/render/src/edge/render.spec.tsx
@@ -55,7 +55,7 @@ describe('render on the edge', () => {
     const actualOutput = await render(<Template firstName="Jim" />);
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><link rel="preload" as="image" href="img/test.png"/><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
     );
   });
 
@@ -109,7 +109,7 @@ describe('render on the edge', () => {
     const actualOutput = await render(<Template firstName="Jim" />);
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><link rel="preload" as="image" href="img/test.png"/><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
     );
   });
 

--- a/packages/render/src/edge/render.tsx
+++ b/packages/render/src/edge/render.tsx
@@ -3,6 +3,7 @@ import { pretty } from '../node';
 import { createErrorBoundary } from '../shared/error-boundary';
 import type { Options } from '../shared/options';
 import { readStream } from '../shared/read-stream.browser';
+import { stripImagePreloadLinks } from '../shared/utils/strip-image-preload-links';
 import { toPlainText } from '../shared/utils/to-plain-text';
 import { importReactDom } from './import-react-dom';
 
@@ -36,7 +37,7 @@ export const render = async (
         await stream.allReady;
         return readStream(stream);
       })
-      .then(resolve)
+      .then((result) => resolve(stripImagePreloadLinks(result)))
       .catch(reject);
   });
 

--- a/packages/render/src/node/render-edge.spec.tsx
+++ b/packages/render/src/node/render-edge.spec.tsx
@@ -37,7 +37,7 @@ describe('render on the edge', () => {
     const actualOutput = await render(<Template firstName="Jim" />);
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><link rel="preload" as="image" href="img/test.png"/><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
     );
 
     vi.resetAllMocks();
@@ -93,7 +93,7 @@ describe('render on the edge', () => {
     const actualOutput = await render(<Template firstName="Jim" />);
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><link rel="preload" as="image" href="img/test.png"/><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
     );
   });
 
@@ -142,7 +142,7 @@ describe('render on the edge', () => {
       const actualOutput = await render(<Template firstName="Jim" />);
 
       expect(actualOutput).toMatchInlineSnapshot(
-        `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><link rel="preload" as="image" href="img/test.png"/><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
+        `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
       );
     });
 

--- a/packages/render/src/node/render-node.spec.tsx
+++ b/packages/render/src/node/render-node.spec.tsx
@@ -41,7 +41,7 @@ describe('render on node environments', () => {
     const actualOutput = await render(<Template firstName="Jim" />);
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><link rel="preload" as="image" href="img/test.png"/><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
     );
 
     vi.resetAllMocks();
@@ -125,7 +125,7 @@ describe('render on node environments', () => {
     const actualOutput = await render(<Template firstName="Jim" />);
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><link rel="preload" as="image" href="img/test.png"/><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><h1>Welcome, <!-- -->Jim<!-- -->!</h1><img alt="test" src="img/test.png"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p><!--/$-->"`,
     );
   });
 

--- a/packages/render/src/node/render.tsx
+++ b/packages/render/src/node/render.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import { createErrorBoundary } from '../shared/error-boundary';
 import type { Options } from '../shared/options';
 import { pretty } from '../shared/utils/pretty';
+import { stripImagePreloadLinks } from '../shared/utils/strip-image-preload-links';
 import { toPlainText } from '../shared/utils/to-plain-text';
 import { readStream } from './read-stream';
 
@@ -65,6 +66,8 @@ export const render = async (node: React.ReactNode, options?: Options) => {
       );
     }
   });
+
+  html = stripImagePreloadLinks(html);
 
   if (options?.plainText) {
     return toPlainText(html, options.htmlToTextOptions);

--- a/packages/render/src/shared/utils/strip-image-preload-links.spec.ts
+++ b/packages/render/src/shared/utils/strip-image-preload-links.spec.ts
@@ -1,0 +1,60 @@
+import { stripImagePreloadLinks } from './strip-image-preload-links';
+
+describe('stripImagePreloadLinks()', () => {
+  it('removes React-injected image preload links', () => {
+    const html =
+      '<head><link rel="preload" as="image" href="https://example.com/logo.png"/></head><body><img src="https://example.com/logo.png"/></body>';
+
+    expect(stripImagePreloadLinks(html)).toBe(
+      '<head></head><body><img src="https://example.com/logo.png"/></body>',
+    );
+  });
+
+  it('removes every image preload link when there are multiple images', () => {
+    const html =
+      '<head><link rel="preload" as="image" href="a.png"/><link rel="preload" as="image" href="b.png"/></head>';
+
+    expect(stripImagePreloadLinks(html)).toBe('<head></head>');
+  });
+
+  it('removes image preloads emitted from srcSet (no href)', () => {
+    const html =
+      '<head><link rel="preload" as="image" imageSrcSet="a.png 2x" crossorigin=""/></head>';
+
+    expect(stripImagePreloadLinks(html)).toBe('<head></head>');
+  });
+
+  it('keeps user-authored non-image preloads', () => {
+    const html =
+      '<head><link rel="preload" as="style" href="styles.css"/><link rel="preload" as="font" href="font.woff2"/></head>';
+
+    expect(stripImagePreloadLinks(html)).toBe(html);
+  });
+
+  it('keeps other link tags such as stylesheets and icons', () => {
+    const html =
+      '<head><link rel="stylesheet" href="styles.css"/><link rel="icon" href="favicon.ico"/></head>';
+
+    expect(stripImagePreloadLinks(html)).toBe(html);
+  });
+
+  it('is unaffected by attribute order', () => {
+    const html =
+      '<head><link as="image" href="logo.png" rel="preload"/></head>';
+
+    expect(stripImagePreloadLinks(html)).toBe('<head></head>');
+  });
+
+  it('does not touch text that merely mentions a preload link', () => {
+    const html =
+      '<body><code>&lt;link rel="preload" as="image" /&gt;</code></body>';
+
+    expect(stripImagePreloadLinks(html)).toBe(html);
+  });
+
+  it('returns the HTML untouched when there are no links', () => {
+    const html = '<body><p>Hello</p></body>';
+
+    expect(stripImagePreloadLinks(html)).toBe(html);
+  });
+});

--- a/packages/render/src/shared/utils/strip-image-preload-links.ts
+++ b/packages/render/src/shared/utils/strip-image-preload-links.ts
@@ -1,0 +1,53 @@
+/**
+ * React injects `<link rel="preload" as="image" />` resource hints into the
+ * document `<head>` for every `<img>` it renders during server-side rendering.
+ *
+ * These hints are meant for browsers loading a web page, where they can speed
+ * up the initial paint. In an email they are dead weight: email clients ignore
+ * `<link rel="preload">`, and the tags only add noise to the rendered HTML.
+ *
+ * @see https://github.com/resend/react-email/issues/3034
+ *
+ * This removes only those auto-injected image preload links, leaving every
+ * other `<link>` (stylesheets, fonts, user-authored non-image preloads, ...)
+ * untouched. It parses each `<link>` tag's attributes instead of relying on a
+ * fixed string match, so it is not affected by attribute order or spacing.
+ */
+export const stripImagePreloadLinks = (html: string): string => {
+  return html.replace(/<link\b[^>]*\/?>/gi, (tag) =>
+    isImagePreloadLink(tag) ? '' : tag,
+  );
+};
+
+const isImagePreloadLink = (tag: string): boolean => {
+  const attributes = parseAttributes(tag);
+  return attributes.rel === 'preload' && attributes.as === 'image';
+};
+
+const ATTRIBUTE_PATTERN =
+  /([a-z][a-z0-9-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+)))?/gi;
+
+/**
+ * Parses the attributes of a single, already-isolated HTML tag string (e.g.
+ * `<link rel="preload" as="image" href="..." />`) into a name → value map.
+ * Attribute names are lower-cased; values are read from double, single, or
+ * unquoted forms.
+ */
+const parseAttributes = (tag: string): Record<string, string> => {
+  // Skip the tag name (`<link`) so it is not read as an attribute.
+  const attributeSection = tag.replace(/^<[a-z][a-z0-9-]*/i, '');
+
+  const attributes: Record<string, string> = {};
+  for (const [
+    ,
+    name,
+    doubleQuoted,
+    singleQuoted,
+    unquoted,
+  ] of attributeSection.matchAll(ATTRIBUTE_PATTERN)) {
+    attributes[name.toLowerCase()] =
+      doubleQuoted ?? singleQuoted ?? unquoted ?? '';
+  }
+
+  return attributes;
+};

--- a/packages/ui/src/utils/get-email-component.spec.ts
+++ b/packages/ui/src/utils/get-email-component.spec.ts
@@ -28,10 +28,6 @@ describe('getEmailComponent()', () => {
         "<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
         <html dir="ltr" lang="en">
           <head>
-            <link rel="preload" as="image" href="/static/vercel-logo.png" />
-            <link rel="preload" as="image" href="/static/vercel-user.png" />
-            <link rel="preload" as="image" href="/static/vercel-arrow.png" />
-            <link rel="preload" as="image" href="/static/vercel-team.png" />
             <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
             <meta name="x-apple-disable-message-reformatting" />
             <title>Join Alan on Vercel</title>


### PR DESCRIPTION
React adds a `<link rel="preload" as="image">` resource hint to the document head for every `<img>` it renders during SSR. Email clients ignore preload hints, so these only add noise to the rendered email.

This removes them from the final HTML in all three render paths (node, edge, browser). The removal parses each <link> tag's attributes and drops only rel=preload + as=image links, so stylesheets, fonts and any user-authored non-image preloads are left untouched.

Closes #3034


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip React’s auto-injected image preload links from rendered email HTML to reduce noise. Preserves all non-image `<link>` tags.

- **Bug Fixes**
  - Added `stripImagePreloadLinks` to remove only `<link rel="preload" as="image">` via attribute parsing (order/spacing safe; supports `imageSrcSet`-only cases).
  - Integrated across all `@react-email/render` paths (node, edge, browser) with updated tests and snapshots, including the testing export; no user changes required.

<sup>Written for commit ba2a21a2a446d16557a50719c52ae40ce2d4f615. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



