### PR TITLE
fix(tailwind): convert color-mix opacity percentage to a decimal alpha

### DIFF
--- a/.changeset/tailwind-colormix-opacity-alpha.md
+++ b/.changeset/tailwind-colormix-opacity-alpha.md
@@ -2,4 +2,4 @@
 "react-email": patch
 ---
 
-Fix the Tailwind opacity modifier (e.g. `bg-blue-600/50`, `text-black/25`) producing an invalid percentage alpha. Tailwind v4 emits these as `color-mix(in oklab, <color> 50%, transparent)`, and that `50%` was being copied straight into the comma-based `rgb()` we downlevel to, giving `rgb(21,93,252,50%)`. A percentage alpha is invalid in the legacy `rgb()` syntax and is dropped or ignored by several email clients, so the opacity now normalizes to a unitless decimal (`rgb(21,93,252,0.5)`), matching how the existing `rgb()` handling already converts percentage alphas.
+Fix Tailwind opacity modifiers (e.g. `bg-blue-600/50`) rendering an invalid percentage alpha that breaks in some email clients.

--- a/.changeset/tailwind-colormix-opacity-alpha.md
+++ b/.changeset/tailwind-colormix-opacity-alpha.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Fix the Tailwind opacity modifier (e.g. `bg-blue-600/50`, `text-black/25`) producing an invalid percentage alpha. Tailwind v4 emits these as `color-mix(in oklab, <color> 50%, transparent)`, and that `50%` was being copied straight into the comma-based `rgb()` we downlevel to, giving `rgb(21,93,252,50%)`. A percentage alpha is invalid in the legacy `rgb()` syntax and is dropped or ignored by several email clients, so the opacity now normalizes to a unitless decimal (`rgb(21,93,252,0.5)`), matching how the existing `rgb()` handling already converts percentage alphas.

--- a/packages/react-email/src/components/tailwind/utils/css/sanitize-declarations.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/sanitize-declarations.spec.ts
@@ -348,7 +348,39 @@ describe('sanitizeDeclarations', () => {
     sanitizeDeclarations(stylesheet);
     const result = generate(stylesheet);
     expect(result).toMatchInlineSnapshot(
-      `".bg-blue-600/50{background-color:rgb(21,93,252,60%)}"`,
+      `".bg-blue-600/50{background-color:rgb(21,93,252,0.6)}"`,
+    );
+  });
+
+  it('converts the color-mix opacity percentage into a decimal alpha', () => {
+    let stylesheet = parse(`
+      .bg-blue-600\\/50 {
+        background-color: color-mix(in oklab, oklch(54.6% 0.245 262.881) 50%, transparent);
+      }
+    `);
+    sanitizeDeclarations(stylesheet);
+    expect(generate(stylesheet), 'half opacity').toMatchInlineSnapshot(
+      `".bg-blue-600\\/50{background-color:rgb(21,93,252,0.5)}"`,
+    );
+
+    stylesheet = parse(`
+      .bg-blue-600\\/12\\.5 {
+        background-color: color-mix(in oklab, oklch(54.6% 0.245 262.881) 12.5%, transparent);
+      }
+    `);
+    sanitizeDeclarations(stylesheet);
+    expect(generate(stylesheet), 'fractional opacity').toMatchInlineSnapshot(
+      `".bg-blue-600\\/12\\.5{background-color:rgb(21,93,252,0.125)}"`,
+    );
+
+    stylesheet = parse(`
+      .bg-blue-600\\/100 {
+        background-color: color-mix(in oklab, oklch(54.6% 0.245 262.881) 100%, transparent);
+      }
+    `);
+    sanitizeDeclarations(stylesheet);
+    expect(generate(stylesheet), 'full opacity').toMatchInlineSnapshot(
+      `".bg-blue-600\\/100{background-color:rgb(21,93,252)}"`,
     );
   });
 

--- a/packages/react-email/src/components/tailwind/utils/css/sanitize-declarations.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/sanitize-declarations.ts
@@ -385,11 +385,6 @@ export function sanitizeDeclarations(nodeContainingDeclarations: CssNode) {
               opacity
             ) {
               if (opacity.type === 'Percentage') {
-                // Tailwind emits the opacity modifier (e.g. `bg-blue-600/50`) as a
-                // percentage, but the comma-based `rgb()` syntax we downlevel to
-                // expects a unitless decimal alpha. A percentage alpha here is
-                // invalid and breaks in several email clients, so normalize it the
-                // same way the `rgb()` handling above does.
                 const alpha = Number.parseFloat(opacity.value) / 100;
                 if (alpha < 1) {
                   color.children.appendData({

--- a/packages/react-email/src/components/tailwind/utils/css/sanitize-declarations.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/sanitize-declarations.ts
@@ -384,11 +384,30 @@ export function sanitizeDeclarations(nodeContainingDeclarations: CssNode) {
               color?.name === 'rgb' &&
               opacity
             ) {
-              color.children.appendData({
-                type: 'Operator',
-                value: ',',
-              });
-              color.children.appendData(opacity);
+              if (opacity.type === 'Percentage') {
+                // Tailwind emits the opacity modifier (e.g. `bg-blue-600/50`) as a
+                // percentage, but the comma-based `rgb()` syntax we downlevel to
+                // expects a unitless decimal alpha. A percentage alpha here is
+                // invalid and breaks in several email clients, so normalize it the
+                // same way the `rgb()` handling above does.
+                const alpha = Number.parseFloat(opacity.value) / 100;
+                if (alpha < 1) {
+                  color.children.appendData({
+                    type: 'Operator',
+                    value: ',',
+                  });
+                  color.children.appendData({
+                    type: 'Number',
+                    value: alpha.toString(),
+                  });
+                }
+              } else {
+                color.children.appendData({
+                  type: 'Operator',
+                  value: ',',
+                });
+                color.children.appendData(opacity);
+              }
               parentListItem.data = color;
             }
           }


### PR DESCRIPTION
Tailwind v4 emits opacity modifiers like `bg-blue-600/50` as `color-mix(in oklab, <color> 50%, transparent)`. When we downlevel that to the comma-based `rgb()` for email clients, the `50%` was being copied straight in as the alpha, giving `rgb(21,93,252,50%)`. A percentage alpha is invalid in the legacy `rgb()` syntax and is dropped by clients like Outlook, so every `bg-*/NN` and `text-*/NN` color silently broke there.

This normalizes the opacity to a unitless decimal (`0.5`) the same way the existing `rgb()` handling already does, dropping it entirely at full opacity. Non-percentage opacity (the `var(--tw-shadow-alpha)` used by box-shadow) keeps the previous behavior, so shadows are unchanged.

Closes #3578

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invalid percentage alpha in downleveled `rgb()` for Tailwind v4 opacity modifiers like `bg-blue-600/50` by converting `color-mix` percentages to decimal alpha. Restores correct opacity in Outlook and other legacy email clients.

- **Bug Fixes**
  - Convert `color-mix(... NN%)` to decimal alpha in `rgb()` (e.g., `50%` -> `0.5`, `12.5%` -> `0.125`).
  - Omit alpha at `100%` to keep `rgb(r,g,b)`; preserve non-percentage opacity tokens (e.g., `var(--tw-shadow-alpha)`).

<sup>Written for commit de20ab1c4975109bdad4694cb56cd5443f80f88f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

