### PR TITLE
fix(ui): atomically write jsx-dev-runtime to fix flaky `email build` on multi-core

### DIFF
--- a/.changeset/atomic-jsx-runtime-write.md
+++ b/.changeset/atomic-jsx-runtime-write.md
@@ -1,0 +1,5 @@
+---
+"@react-email/ui": patch
+---
+
+Fix flaky `email build` crash on multi-core builds (e.g. Vercel) where static prerendering failed with `(void 0) is not a function` on a random template. `createJsxRuntime` wrote the shared `jsx-dev-runtime.js` in place; under `next build`'s multi-process static generation, one process could read a half-written runtime produced by another (its `jsxDEV` export `undefined`). The runtime is now written to a unique temp file and atomically renamed into place, complementing the existing in-process build cache.

--- a/packages/ui/src/utils/create-jsx-runtime.ts
+++ b/packages/ui/src/utils/create-jsx-runtime.ts
@@ -32,9 +32,21 @@ export const createJsxRuntime = (
           'utf8',
         );
       }
+      // `next build` prerenders pages across multiple worker processes, each building this
+      // shared `jsx-dev-runtime.js` (the promise cache only dedupes within a process). An
+      // in-place write isn't atomic, so a process can read a half-written runtime whose `jsxDEV`
+      // is `undefined`, throwing `(void 0) is not a function`. Write to a temp file and rename
+      // it into place atomically instead.
+      const finalRuntimeFilePath = path.join(
+        jsxRuntimePath,
+        'jsx-dev-runtime.js',
+      );
+      const temporaryRuntimeFilePath = `${finalRuntimeFilePath}.${Math.random()
+        .toString(36)
+        .slice(2)}.tmp`;
       await esbuild.build({
         bundle: true,
-        outfile: path.join(jsxRuntimePath, 'jsx-dev-runtime.js'),
+        outfile: temporaryRuntimeFilePath,
         format: 'cjs',
         logLevel: 'silent',
         stdin: {
@@ -46,6 +58,7 @@ export const createJsxRuntime = (
           ),
         },
       });
+      await fs.promises.rename(temporaryRuntimeFilePath, finalRuntimeFilePath);
 
       return jsxRuntimePath;
     })();


### PR DESCRIPTION
## Problem

`email build` intermittently fails during static prerendering on multi-core builds (we hit it consistently on **Vercel**, never locally) with:

```
Error occurred prerendering page "/preview/<Template>/<Template>"
Error: (void 0) is not a function
Export encountered an error on /preview/[...slug]/page, exiting the build.
```

The failing template is **different every build** but the error/digest are identical — a build-time race, not a faulty template.

## Cause

`createJsxRuntime` esbuilds a single shared file, `node_modules/.react-email-jsx-runtime/jsx-dev-runtime.js`, with a **non-atomic in-place write**. `getEmailComponent` then reads that file (via `jsxImportSource`) to bundle each email. `next build` prerenders pages across **multiple worker processes**, so one process can read a **half-written** runtime produced by another → its `jsxDEV` export is `undefined` → `(void 0) is not a function`.

The existing `jsxRuntimePromiseCache` only dedupes builds **within** a process; each worker process still builds the same on-disk file, so the **cross-process** race remains.

## Fix

Write the runtime to a unique temp file, then `fs.rename()` it into place. `rename()` is atomic on the same filesystem, so concurrent readers always see a complete file. This complements the in-process cache (cache → no concurrent builds within a worker; atomic rename → no corruption across workers).

## Verification

Filesystem-level reproduction of the mechanism: in a tight concurrent write+read loop, the in-place write produced **~258 truncated reads**; temp + rename produced **0**.

Closes #3582

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky `email build` crashes on multi-core builds (e.g., Vercel) by atomically writing the shared `jsx-dev-runtime.js`. This prevents half-written reads across `next build` workers and makes prerendering reliable.

- **Bug Fixes**
  - Build the runtime to a unique temp file, then atomically move it into place with `fs.rename()`.
  - Eliminates the cross-process race that made `jsxDEV` `undefined` and triggered `(void 0) is not a function` during prerendering.

<sup>Written for commit 54e2e837d955fe9ffa41a7eca5e1f1931bd6e49e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

