### PR TITLE
fix(tailwind): convert calc(infinity * 1px) for corner and logical border-radius longhands

### DIFF
--- a/.changeset/tailwind-radius-longhand-infinity.md
+++ b/.changeset/tailwind-radius-longhand-infinity.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Fix Tailwind pill utilities like `rounded-t-full` and `rounded-e-full` leaving an unrenderable `calc(infinity * 1px)` in the inlined email CSS (previously only `rounded-full` was converted to `9999px`).

--- a/packages/react-email/src/components/tailwind/utils/css/sanitize-declarations.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/sanitize-declarations.spec.ts
@@ -32,6 +32,27 @@ describe('sanitizeDeclarations', () => {
     expect(generate(root)).toBe('.rounded-full{border-radius:9999px}');
   });
 
+  it('converts calc(infinity * 1px) for corner and logical border-radius longhands', () => {
+    let root = parse(`.rounded-tl-full {
+  border-top-left-radius: calc(infinity * 1px);
+}
+`);
+    sanitizeDeclarations(root);
+    expect(generate(root)).toBe(
+      '.rounded-tl-full{border-top-left-radius:9999px}',
+    );
+
+    root = parse(`.rounded-e-full {
+  border-start-end-radius: calc(infinity * 1px);
+  border-end-end-radius: calc(infinity * 1px);
+}
+`);
+    sanitizeDeclarations(root);
+    expect(generate(root)).toBe(
+      '.rounded-e-full{border-start-end-radius:9999px;border-end-end-radius:9999px}',
+    );
+  });
+
   it('separates padding-block and padding-inline', () => {
     let root = parse(`.box {
   padding-inline: 4px 14;

--- a/packages/react-email/src/components/tailwind/utils/css/sanitize-declarations.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/sanitize-declarations.ts
@@ -183,7 +183,7 @@ export function sanitizeDeclarations(nodeContainingDeclarations: CssNode) {
         }) as Value | Raw;
       }
       if (
-        /border-radius\s*:\s*calc\s*\(\s*infinity\s*\*\s*1px\s*\)/i.test(
+        /border-(?:[a-z]+-){0,2}radius\s*:\s*calc\s*\(\s*infinity\s*\*\s*1px\s*\)/i.test(
           generate(declaration),
         )
       ) {


### PR DESCRIPTION
## Description

Tailwind v4 emits `border-radius: calc(infinity * 1px)` for pill utilities, and `sanitizeDeclarations` rewrites that to `9999px` so email clients can render the pill. But the regex only matched the `border-radius` **shorthand**, so the corner and logical longhands that Tailwind also emits this value for were missed:

- `rounded-t-full` / `rounded-tl-full` / `rounded-br-full` → `border-top-left-radius` / `border-bottom-right-radius` …
- `rounded-e-full` / `rounded-ss-full` → `border-start-end-radius` / `border-start-start-radius` …

Those shipped `calc(infinity * 1px)` straight into the inline `style`, which Outlook/Gmail can't render, so the corner stayed square (only `rounded-full` was converted).

The fix broadens just the property part of the existing regex to also match the corner/logical radius longhands (bounded to 0-2 segments, so it never matches `border-width` and friends). The value match and the `9999px` replacement are unchanged.

## Test

Added a regression test in `sanitize-declarations.spec.ts` covering the corner (`border-top-left-radius`) and logical (`border-start-end-radius` / `border-end-end-radius`) longhands - red on `canary`, green with the fix. The existing `border-radius` shorthand test is unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Convert Tailwind v4 `calc(infinity * 1px)` on border-radius corner and logical longhands to `9999px` so `rounded-*-full` utilities render rounded corners in email clients.

- **Bug Fixes**
  - Broadened `react-email` `sanitizeDeclarations` to match `border-(...)-radius` longhands (e.g., `border-top-left-radius`, `border-start-end-radius`) and replace with `9999px`.
  - Added regression tests for corner and logical longhands (`rounded-tl-full`, `rounded-e-full`).

<sup>Written for commit e8278f704bcd586e0686eb8d4ca1b9d52b5a71dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

