### PR TITLE
fix(heading): keep unit on margin values like `mx="2rem"`

### DIFF
--- a/.changeset/heading-margin-unit.md
+++ b/.changeset/heading-margin-unit.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Fix `Heading` margin props mangling unit values like `mx="2rem"` into the invalid `2rempx`; values that already carry a unit are now passed through untouched.

--- a/packages/react-email/src/components/heading/utils/spaces.ts
+++ b/packages/react-email/src/components/heading/utils/spaces.ts
@@ -56,8 +56,15 @@ export const withSpace = (
     return styles;
   }
 
+  // Pass unit-bearing strings like "2rem" through untouched; only bare
+  // numbers get a px suffix, so "2rem" doesn't become an invalid "2rempx".
+  const dimension =
+    typeof value === 'string' && !/^-?\d*\.?\d+$/.test(value.trim())
+      ? value
+      : `${value}px`;
+
   for (const property of properties) {
-    styles[property] = `${value}px` as React.CSSProperties[MarginCSSProperty];
+    styles[property] = dimension as React.CSSProperties[MarginCSSProperty];
   }
 
   return styles;

--- a/packages/react-email/src/components/heading/utils/utils.spec.ts
+++ b/packages/react-email/src/components/heading/utils/utils.spec.ts
@@ -67,4 +67,12 @@ describe('withSpace', () => {
     const result = withSpace(15, ['marginTop', 'marginLeft']);
     expect(result).toEqual({ marginTop: '15px', marginLeft: '15px' });
   });
+
+  it('keeps the unit on values that already have one', () => {
+    expect(withSpace('2rem', ['margin'])).toEqual({ margin: '2rem' });
+    expect(withSpace('10%', ['marginTop'])).toEqual({ marginTop: '10%' });
+    expect(withSpace('-1.5em', ['marginLeft'])).toEqual({
+      marginLeft: '-1.5em',
+    });
+  });
 });


### PR DESCRIPTION
### What

`Heading` accepts `m`/`mx`/`my`/`mt`/`mr`/`mb`/`ml` as `number | string`, but `withSpace` appended `px` to any value whose leading number parsed. So a string that already carries a unit produced invalid CSS:

```tsx
<Heading mx="2rem">…</Heading>   // -> margin-left:2rempx; margin-right:2rempx
<Heading my="10%">…</Heading>    // -> margin-top:10%px; margin-bottom:10%px
```

`parseFloat("2rem")` is `2` (not NaN), so the existing guard let it through and `${value}px` mangled it.

### Fix

Suffix `px` only when the value is a bare number (or a unitless numeric string). Strings that already have a unit are passed through untouched. Numbers and unitless strings like `mx={4}` / `mx="20"` are unchanged. Added a regression test in `utils.spec.ts`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `Heading` margin props to keep units (e.g., mx="2rem", my="10%") and only add "px" for bare numbers, preventing invalid CSS. Unitless numbers and numeric strings still get "px".

- **Bug Fixes**
  - Updated `withSpace` to detect unit-bearing strings and pass them through unchanged.
  - Added regression tests for `rem`, `%`, and `em` (including negative values) in `utils.spec.ts` for `react-email`.

<sup>Written for commit b86d9ff1a01ad27f6033edcb1b0ca266e27af427. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

