### PR TITLE
fix(markdown): escape double quotes in link href/title and image title

### DIFF
--- a/.changeset/markdown-escape-link-quotes.md
+++ b/.changeset/markdown-escape-link-quotes.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Escape double quotes in `Markdown` link `href`/`title` and image `title` attributes, matching the escaping already applied to image `src`/`alt`. A markdown title like `'The "Complete" Guide'` no longer breaks out of the attribute in the rendered HTML.

--- a/packages/react-email/src/components/markdown/markdown.spec.tsx
+++ b/packages/react-email/src/components/markdown/markdown.spec.tsx
@@ -131,6 +131,18 @@ console.log(\`Hello, $\{name}!\`);
     `);
   });
 
+  it('escapes double quotes in link/image href and title attributes', async () => {
+    const actualOutput = await render(
+      <Markdown>
+        {`[guide](https://example.com/?q="a" 'The "Complete" Guide') and ![logo](https://cdn.example.com/a.png 'Acme "logo"')`}
+      </Markdown>,
+    );
+    expect(actualOutput).toMatchInlineSnapshot(`
+      "<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><div data-id="react-email-markdown"><p><a href="https://example.com/?q=&quot;a&quot;" target="_blank" title="The &quot;Complete&quot; Guide" style="color:#007bff;text-decoration:underline;background-color:transparent">guide</a> and <img src="https://cdn.example.com/a.png" alt="logo" title="Acme &quot;logo&quot;"></p>
+      </div><!--/$-->"
+    `);
+  });
+
   it('renders lists in the correct format for browsers', async () => {
     const actualOutput = await render(
       <Markdown>

--- a/packages/react-email/src/components/markdown/markdown.tsx
+++ b/packages/react-email/src/components/markdown/markdown.tsx
@@ -98,7 +98,7 @@ export const Markdown = React.forwardRef<HTMLDivElement, MarkdownProps>(
 
     renderer.image = ({ href, text, title }) => {
       return `<img src="${href.replaceAll('"', '&quot;')}" alt="${text.replaceAll('"', '&quot;')}"${
-        title ? ` title="${title}"` : ''
+        title ? ` title="${title.replaceAll('"', '&quot;')}"` : ''
       }${
         parseCssInJsToInlineCss(finalStyles.image) !== ''
           ? ` style="${parseCssInJsToInlineCss(finalStyles.image)}"`
@@ -109,8 +109,8 @@ export const Markdown = React.forwardRef<HTMLDivElement, MarkdownProps>(
     renderer.link = ({ href, title, tokens }) => {
       const text = renderer.parser.parseInline(tokens);
 
-      return `<a href="${href}" target="_blank"${
-        title ? ` title="${title}"` : ''
+      return `<a href="${href.replaceAll('"', '&quot;')}" target="_blank"${
+        title ? ` title="${title.replaceAll('"', '&quot;')}"` : ''
       }${
         parseCssInJsToInlineCss(finalStyles.link) !== ''
           ? ` style="${parseCssInJsToInlineCss(finalStyles.link)}"`


### PR DESCRIPTION
### What

The `Markdown` renderer escapes double quotes in image `src` and `alt`, but not in link `href`, link `title`, or image `title` - those are interpolated raw into the attribute:

```ts
renderer.image = ({ href, text, title }) =>
  `<img src="${href.replaceAll('"', '&quot;')}" alt="${text.replaceAll('"', '&quot;')}"${
    title ? ` title="${title}"` : ''   // not escaped
  }…>`;

renderer.link = ({ href, title, tokens }) =>
  `<a href="${href}" target="_blank"${    // not escaped
    title ? ` title="${title}"` : ''      // not escaped
  }…>`;
```

So a markdown title that contains a double quote breaks out of the attribute:

```
[guide](https://example.com 'The "Complete" Guide')
-> <a … title="The "Complete" Guide" …>   // attribute terminates at the first "
```

The same happens for an image title and for an href that contains a quote.

### Fix

Apply the same `.replaceAll('"', '&quot;')` already used for image `src`/`alt` to link `href`, link `title`, and image `title`. Added a regression test rendering a link and image whose title/href contain quotes. Existing snapshots are unaffected.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escape double quotes in `react-email`’s `Markdown` renderer for link `href`/`title` and image `title` to prevent HTML attribute breakouts, matching the existing escaping for image `src`/`alt`. Adds a regression test that covers quotes in link/image titles and hrefs.

<sup>Written for commit 0aef517dc01926a456b800f6379a7375e4a0e516. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

