### PR TITLE
fix(button): add px unit to mso-text-raise on Outlook spacer

### DIFF
--- a/.changeset/button-mso-text-raise-unit.md
+++ b/.changeset/button-mso-text-raise-unit.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Fix `Button` emitting `mso-text-raise` without a unit on its Outlook padding spacer (e.g. `mso-text-raise:18`), which Outlook treats as invalid. The value now carries `px`, matching the unit React already adds on the button label.

--- a/packages/editor/src/extensions/__snapshots__/button.spec.tsx.snap
+++ b/packages/editor/src/extensions/__snapshots__/button.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`EditorButton Node > renders React Email properly 1`] = `
           style="line-height:100%;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px;margin:0;padding:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"
           target="_blank"
           ><span
-            ><!--[if mso]><i style="mso-font-width:0%;mso-text-raise:0" hidden></i><![endif]--></span
+            ><!--[if mso]><i style="mso-font-width:0%;mso-text-raise:0px" hidden></i><![endif]--></span
           ><span
             style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:0"
             >Click me</span

--- a/packages/react-email/src/cli/commands/testing/export.spec.ts
+++ b/packages/react-email/src/cli/commands/testing/export.spec.ts
@@ -169,7 +169,7 @@ test('email export', { retry: 3 }, async () => {
                                   style="line-height:100%;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px;border-radius:0.25rem;background-color:rgb(0,0,0);padding-right:20px;padding-left:20px;padding-bottom:12px;padding-top:12px;text-align:center;font-weight:600;font-size:12px;color:rgb(255,255,255);text-decoration-line:none"
                                   target="_blank"
                                   ><span
-                                    ><!--[if mso]><i style="mso-font-width:500%;mso-text-raise:18" hidden>&#8202;&#8202;</i><![endif]--></span
+                                    ><!--[if mso]><i style="mso-font-width:500%;mso-text-raise:18px" hidden>&#8202;&#8202;</i><![endif]--></span
                                   ><span
                                     style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:9px"
                                     >Join the team</span

--- a/packages/react-email/src/components/button/button.spec.tsx
+++ b/packages/react-email/src/components/button/button.spec.tsx
@@ -24,14 +24,14 @@ describe('<Button> component', () => {
       <Button href="https://example.com" style={{ padding: '12px 20px' }} />,
     );
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><a href="https://example.com" style="line-height:100%;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px;padding:12px 20px;padding-top:12px;padding-right:20px;padding-bottom:12px;padding-left:20px" target="_blank"><span><!--[if mso]><i style="mso-font-width:500%;mso-text-raise:18" hidden>&#8202;&#8202;</i><![endif]--></span><span style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:9px"></span><span><!--[if mso]><i style="mso-font-width:500%" hidden>&#8202;&#8202;&#8203;</i><![endif]--></span></a><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><a href="https://example.com" style="line-height:100%;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px;padding:12px 20px;padding-top:12px;padding-right:20px;padding-bottom:12px;padding-left:20px" target="_blank"><span><!--[if mso]><i style="mso-font-width:500%;mso-text-raise:18px" hidden>&#8202;&#8202;</i><![endif]--></span><span style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:9px"></span><span><!--[if mso]><i style="mso-font-width:500%" hidden>&#8202;&#8202;&#8203;</i><![endif]--></span></a><!--/$-->"`,
     );
   });
 
   it('renders the <Button> component with no padding value', async () => {
     const actualOutput = await render(<Button href="https://example.com" />);
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><a href="https://example.com" style="line-height:100%;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px" target="_blank"><span><!--[if mso]><i style="mso-font-width:0%;mso-text-raise:0" hidden></i><![endif]--></span><span style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px"></span><span><!--[if mso]><i style="mso-font-width:0%" hidden>&#8203;</i><![endif]--></span></a><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><a href="https://example.com" style="line-height:100%;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px" target="_blank"><span><!--[if mso]><i style="mso-font-width:0%;mso-text-raise:0px" hidden></i><![endif]--></span><span style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px"></span><span><!--[if mso]><i style="mso-font-width:0%" hidden>&#8203;</i><![endif]--></span></a><!--/$-->"`,
     );
   });
 
@@ -47,7 +47,7 @@ describe('<Button> component', () => {
       />,
     );
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><a style="line-height:150%;text-decoration:underline red;display:block;max-width:50%;mso-padding-alt:0px" target="_blank"><span><!--[if mso]><i style="mso-font-width:0%;mso-text-raise:0" hidden></i><![endif]--></span><span style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px"></span><span><!--[if mso]><i style="mso-font-width:0%" hidden>&#8203;</i><![endif]--></span></a><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><a style="line-height:150%;text-decoration:underline red;display:block;max-width:50%;mso-padding-alt:0px" target="_blank"><span><!--[if mso]><i style="mso-font-width:0%;mso-text-raise:0px" hidden></i><![endif]--></span><span style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px"></span><span><!--[if mso]><i style="mso-font-width:0%" hidden>&#8203;</i><![endif]--></span></a><!--/$-->"`,
     );
   });
 });

--- a/packages/react-email/src/components/button/button.tsx
+++ b/packages/react-email/src/components/button/button.tsx
@@ -79,7 +79,7 @@ export const Button = React.forwardRef<HTMLAnchorElement, ButtonProps>(
             // See https://github.com/resend/react-email/issues/1512 for why we do not use letter-spacing instead.
             __html: `<!--[if mso]><i style="mso-font-width:${
               plFontWidth * 100
-            }%;mso-text-raise:${textRaise}" hidden>${'&#8202;'.repeat(
+            }%;mso-text-raise:${textRaise}px" hidden>${'&#8202;'.repeat(
               plSpaceCount,
             )}</i><![endif]-->`,
           }}

--- a/packages/react-email/src/components/tailwind/tailwind.spec.tsx
+++ b/packages/react-email/src/components/tailwind/tailwind.spec.tsx
@@ -170,7 +170,7 @@ describe('Tailwind component', () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><a style="line-height:1.4285714285714286;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px;margin-top:2rem;border-radius:0.375rem;background-color:rgb(21,93,252);padding-right:12px;padding-left:12px;padding-bottom:8px;padding-top:8px;color:rgb(229,231,235);font-size:0.875rem" target="_blank"><span><!--[if mso]><i style="mso-font-width:300%;mso-text-raise:12" hidden>&#8202;&#8202;</i><![endif]--></span><span style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:6px">Testing button</span><span><!--[if mso]><i style="mso-font-width:300%" hidden>&#8202;&#8202;&#8203;</i><![endif]--></span></a>Testing<!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><a style="line-height:1.4285714285714286;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px;margin-top:2rem;border-radius:0.375rem;background-color:rgb(21,93,252);padding-right:12px;padding-left:12px;padding-bottom:8px;padding-top:8px;color:rgb(229,231,235);font-size:0.875rem" target="_blank"><span><!--[if mso]><i style="mso-font-width:300%;mso-text-raise:12px" hidden>&#8202;&#8202;</i><![endif]--></span><span style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:6px">Testing button</span><span><!--[if mso]><i style="mso-font-width:300%" hidden>&#8202;&#8202;&#8203;</i><![endif]--></span></a>Testing<!--/$-->"`,
     );
   });
 

--- a/packages/ui/src/utils/get-email-component.spec.ts
+++ b/packages/ui/src/utils/get-email-component.spec.ts
@@ -181,7 +181,7 @@ describe('getEmailComponent()', () => {
                                       style="line-height:100%;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px;border-radius:0.25rem;background-color:rgb(0,0,0);padding-right:20px;padding-left:20px;padding-bottom:12px;padding-top:12px;text-align:center;font-weight:600;font-size:12px;color:rgb(255,255,255);text-decoration-line:none"
                                       target="_blank"
                                       ><span
-                                        ><!--[if mso]><i style="mso-font-width:500%;mso-text-raise:18" hidden>&#8202;&#8202;</i><![endif]--></span
+                                        ><!--[if mso]><i style="mso-font-width:500%;mso-text-raise:18px" hidden>&#8202;&#8202;</i><![endif]--></span
                                       ><span
                                         style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:9px"
                                         >Join the team</span


### PR DESCRIPTION
### What

`Button` builds the left Outlook padding spacer as a raw string and interpolates the vertical raise without a unit:

```ts
const textRaise = pxToPt(y);          // a bare number, e.g. 18
…`mso-font-width:${plFontWidth * 100}%;mso-text-raise:${textRaise}" hidden>…`
```

That renders `mso-text-raise:18`, which Outlook treats as invalid (a non-zero length needs a unit), so the hair-space spacer isn't raised. The sibling button label sets the same property through a React style object (`msoTextRaise: pxToPt(paddingBottom)`), which React serializes *with* a unit (`mso-text-raise:9px`), so the two were inconsistent.

### Fix

Append `px` to the spacer's raise value so it matches the label (`mso-text-raise:18px`). One-line change; the 18:9 ratio is unchanged. Updated the three affected inline snapshots (`mso-text-raise:18` -> `18px`, and two `:0` -> `:0px`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Outlook padding spacer in `Button` by adding the `px` unit to `mso-text-raise` on the left `[if mso]` spacer. Outlook now applies the raise correctly, matching the label.

- **Bug Fixes**
  - Updated remaining inline snapshots to expect `px` on `mso-text-raise` (`18` -> `18px`, `0` -> `0px`).

<sup>Written for commit e34fe666f15cfb329a2baba903e86b11a75ba97b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

