### PR TITLE
fix(tailwind): stop silently dropping space-/divide- utilities

### DIFF
--- a/.changeset/tailwind-nested-rule-utilities.md
+++ b/.changeset/tailwind-nested-rule-utilities.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Stop silently dropping Tailwind utilities that compile to a nested rule (`space-y-*`, `space-x-*`, `divide-y`, `divide-x`, `divide-<color>`). They were classified as inlinable, produced an empty inline style, and vanished from the output along with their class name; they are now emitted in the `<head>` `<style>` block and the class is kept.

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
@@ -147,4 +147,25 @@ describe('extractRulesPerClass()', async () => {
       }
     `);
   });
+
+  it('keeps nested-rule utilities (space-y/divide) instead of dropping them', async () => {
+    const tailwind = await setupTailwind({});
+    const classes = ['space-y-4', 'divide-y'];
+    tailwind.addUtilities(classes);
+
+    const stylesheet = tailwind.getStyleSheet();
+
+    const { inlinable, nonInlinable } = extractRulesPerClass(
+      stylesheet,
+      classes,
+    );
+
+    // The bodies compile to an unparsed nested rule; they must not be treated
+    // as inlinable (which silently produced an empty style and dropped them).
+    expect(Object.keys(convertToComparable(inlinable))).toEqual([]);
+    expect(Object.keys(convertToComparable(nonInlinable))).toEqual([
+      'space-y-4',
+      'divide-y',
+    ]);
+  });
 });

--- a/packages/react-email/src/components/tailwind/utils/css/is-part-inlinable.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/is-part-inlinable.ts
@@ -1,6 +1,13 @@
 import { type CssNode, find } from 'css-tree';
 
 export function isPartInlinable(part: CssNode): boolean {
+  // A nested rule body css-tree left unparsed (space-y/divide's
+  // `:where(& > :not(:last-child)) { … }`) arrives here as a Raw block child;
+  // it has no flat declarations to inline, so keep it in the <style> output.
+  if (part.type === 'Raw') {
+    return false;
+  }
+
   const hasAtRuleInside = find(part, (node) => node.type === 'Atrule') !== null;
 
   const hasPseudoSelector =

--- a/packages/react-email/src/components/tailwind/utils/css/is-rule-inlinable.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/is-rule-inlinable.ts
@@ -11,5 +11,16 @@ export function isRuleInlinable(rule: Rule): boolean {
         node.type === 'PseudoElementSelector',
     ) !== null;
 
-  return !hasAtRuleInside && !hasPseudoSelector;
+  // css-tree leaves a nested rule body (space-y/divide compile to
+  // `:where(& > :not(:last-child)) { … }`) as an unparsed Raw block child that
+  // find() can't descend into; such a rule can't be inlined as flat styles.
+  let hasNestedRuleBlock = false;
+  for (const child of rule.block.children) {
+    if (child.type === 'Raw') {
+      hasNestedRuleBlock = true;
+      break;
+    }
+  }
+
+  return !hasAtRuleInside && !hasPseudoSelector && !hasNestedRuleBlock;
 }


### PR DESCRIPTION
### What

Tailwind utilities whose CSS compiles to a *nested* rule are silently dropped from the output: `space-y-*`, `space-x-*`, `divide-y`, `divide-x`, and `divide-<color>`. Putting them on an element produces no inline style, no `<style>` rule, and the class is removed too, so the spacing/dividers just disappear.

```tsx
<Tailwind><Html><Head/><body>
  <div className="space-y-4"><p>one</p><p>two</p></div>
</body></Html></Tailwind>
// before: <div><p>one</p><p>two</p></div>  + empty <style></style>
```

These utilities compile to e.g. `.space-y-4 { :where(& > :not(:last-child)) { … } }`. css-tree leaves that nested body as a single unparsed `Raw` block child, and `find()` cannot descend into a `Raw` node, so `isRuleInlinable`/`isPartInlinable` see no pseudo-selector and judge the rule inlinable. `makeInlineStylesFor` then finds no `Declaration` nodes in the `Raw` and yields an empty style - the rule is dropped.

### Fix

Treat a `Raw` node that is a direct **block child** as non-inlinable in both helpers, so the rule is kept and emitted in the `<head>` `<style>` block (with the class preserved) instead of vanishing. The check is on block children specifically, not any `Raw`, so a `var()` fallback like `line-height: var(--tw-leading, var(--…))` (which css-tree also represents as `Raw`, but inside a declaration value) is unaffected and still inlines.

```
// after: div keeps class="space-y-4", and <head> <style> contains .space-y-4 { … }
```

Added a regression test asserting `space-y-4`/`divide-y` land in the non-inlinable set instead of being dropped. All 126 tailwind tests pass; `text-lg`, `bg-red-500`, and `&:hover` utilities still inline as before.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop dropping Tailwind nested-rule utilities like `space-y-*`, `space-x-*`, and `divide-*`. These are now kept as non-inlinable rules so the class stays on the element and CSS is emitted in the `<head>`.

- **Bug Fixes**
  - Treat `Raw` block children as non-inlinable in `is-rule-inlinable` and `is-part-inlinable`.
  - Added regression test for `space-y-4`/`divide-y`; other inlining behavior remains unchanged.

<sup>Written for commit 7543b8bb263cfb8212cb66e4f8124de7e4a2e65e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

