### PR TITLE
fix(tailwind): stop emitting a bare nested rule for group/peer markers

### DIFF
--- a/.changeset/tailwind-group-peer-duplicate.md
+++ b/.changeset/tailwind-group-peer-duplicate.md
@@ -2,4 +2,4 @@
 "react-email": patch
 ---
 
-Fix `group`/`peer` marker classes injecting a duplicate, malformed parentless `&:is(...)` rule into the `<head>` `<style>` when used with `group-*`/`peer-*` variants. The nested rule is no longer extracted as a standalone utility.
+Fix `group` utilities including bad rules that don't work

--- a/.changeset/tailwind-group-peer-duplicate.md
+++ b/.changeset/tailwind-group-peer-duplicate.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Fix `group`/`peer` marker classes injecting a duplicate, malformed parentless `&:is(...)` rule into the `<head>` `<style>` when used with `group-*`/`peer-*` variants. The nested rule is no longer extracted as a standalone utility.

--- a/packages/react-email/src/components/tailwind/tailwind.spec.tsx
+++ b/packages/react-email/src/components/tailwind/tailwind.spec.tsx
@@ -440,6 +440,33 @@ describe('Tailwind component', () => {
     );
   });
 
+  // See https://github.com/resend/react-email/pull/3594
+  it('does not leak a bare nested group/peer rule into the <head> <style>', async () => {
+    const html = await render(
+      <Html>
+        <Tailwind>
+          <Head />
+          <div className="group">
+            <a className="group-hover:underline" href="https://react.email">
+              link
+            </a>
+          </div>
+        </Tailwind>
+      </Html>,
+    );
+
+    const styleContent = html.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? '';
+
+    // The utility is emitted once, keyed under its own class...
+    expect(styleContent).toContain(
+      '.group-hover_underline{@media (hover:hover){&:is(:where(.group):hover *){text-decoration-line:underline!important}}}',
+    );
+    // ...and its nested `&:is(...)` marker rule is not also emitted standalone.
+    expect(
+      styleContent.match(/&:is\(:where\(\.group\):hover \*\)/g),
+    ).toHaveLength(1);
+  });
+
   it('recognizes custom responsive screen', async () => {
     const actualOutput = await render(
       <Html>

--- a/packages/react-email/src/components/tailwind/tailwind.spec.tsx
+++ b/packages/react-email/src/components/tailwind/tailwind.spec.tsx
@@ -453,18 +453,25 @@ describe('Tailwind component', () => {
           </div>
         </Tailwind>
       </Html>,
-    );
+    ).then(pretty);
 
-    const styleContent = html.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? '';
-
-    // The utility is emitted once, keyed under its own class...
-    expect(styleContent).toContain(
-      '.group-hover_underline{@media (hover:hover){&:is(:where(.group):hover *){text-decoration-line:underline!important}}}',
-    );
-    // ...and its nested `&:is(...)` marker rule is not also emitted standalone.
-    expect(
-      styleContent.match(/&:is\(:where\(\.group\):hover \*\)/g),
-    ).toHaveLength(1);
+    expect(html).toMatchInlineSnapshot(`
+      "<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+      <html dir="ltr" lang="en">
+        <head>
+          <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+          <meta name="x-apple-disable-message-reformatting" />
+          <style>
+            .group-hover_underline{@media (hover:hover){&:is(:where(.group):hover *){text-decoration-line:underline!important}}}
+          </style></head
+        ><!--$--><!--html--><!--head-->
+        <div class="group">
+          <a class="group-hover_underline" href="https://react.email">link</a>
+        </div>
+        <!--/$-->
+      </html>
+      "
+    `);
   });
 
   it('recognizes custom responsive screen', async () => {

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
@@ -206,4 +206,25 @@ describe('extractRulesPerClass()', async () => {
       }
     `);
   });
+
+  it('does not emit a bare nested rule for group/peer marker classes', async () => {
+    const tailwind = await setupTailwind({});
+    const classes = ['group', 'group-hover:underline'];
+    tailwind.addUtilities(classes);
+
+    const stylesheet = tailwind.getStyleSheet();
+    const { inlinable, nonInlinable } = extractRulesPerClass(
+      stylesheet,
+      classes,
+    );
+
+    // Only the real utility is keyed; the `group` marker must not produce a
+    // duplicate, parentless `&:is(...)` rule.
+    expect(Object.keys(convertToComparable(inlinable))).toEqual([]);
+    expect(convertToComparable(nonInlinable)).toMatchInlineSnapshot(`
+      {
+        "group-hover:underline": ".group-hover\\:underline{&:is(:where(.group):hover *){@media (hover:hover){text-decoration-line:underline}}}",
+      }
+    `);
+  });
 });

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
@@ -223,7 +223,9 @@ describe('extractRulesPerClass()', async () => {
     expect(Object.keys(convertToComparable(inlinable))).toEqual([]);
     expect(convertToComparable(nonInlinable)).toMatchInlineSnapshot(`
       {
-        "group-hover:underline": ".group-hover\\:underline{&:is(:where(.group):hover *){@media (hover:hover){text-decoration-line:underline}}}",
+        "group-hover:underline": [
+          ".group-hover\\:underline{&:is(:where(.group):hover *){@media (hover:hover){text-decoration-line:underline}}}",
+        ],
       }
     `);
   });

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
@@ -26,8 +26,24 @@ export function extractRulesPerClass(root: CssNode, classes: string[]) {
   walk(root, {
     visit: 'Rule',
     enter(rule) {
+      // A nested rule (e.g. group/peer's `&:is(:where(.group):hover *)`) belongs
+      // to its parent utility; processing it standalone emits a bare, parentless
+      // `&` rule into the <style> block, so skip it here.
+      const firstSelector =
+        rule.prelude.type === 'SelectorList'
+          ? rule.prelude.children.first
+          : null;
+      if (
+        firstSelector?.type === 'Selector' &&
+        firstSelector.children.first?.type === 'NestingSelector'
+      ) {
+        return;
+      }
+
+      // Only the prelude names the class that owns the rule; classes referenced
+      // inside the block (e.g. `.group` in `:where(.group)`) must not key it.
       const selectorClasses: string[] = [];
-      walk(rule, {
+      walk(rule.prelude, {
         visit: 'ClassSelector',
         enter(classSelector) {
           selectorClasses.push(string.decode(classSelector.name));


### PR DESCRIPTION
### What

Using a `group`/`peer` marker class together with a `group-*`/`peer-*` variant injects a duplicate, malformed rule into the `<head>` `<style>`:

```tsx
<Tailwind><Head/><body>
  <div className="group"><a className="group-hover:underline">x</a></div>
</body></Tailwind>
```

`extractRulesPerClass` produces two non-inlinable entries:

```
"group-hover:underline": ".group-hover\:underline{&:is(:where(.group):hover *){@media (hover:hover){…}}}"   // correct
"group":                 "&:is(:where(.group):hover *){@media (hover:hover){…}}"                            // bare, parentless &
```

The second is invalid CSS in a `<style>` block (the `&` has no parent). It happens because the rule walker descends into the variant's nested `&:is(:where(.group):hover *)` rule and processes it standalone, and because class names are collected from the whole rule block - so the `.group` reference inside `:where(.group)` keys the marker class.

### Fix

In `extractRulesPerClass`:
- skip rules whose prelude is a nesting selector (`&…`) - they belong to a parent utility, not a standalone class;
- collect class names from `rule.prelude` only, so a class *referenced* inside the block doesn't key the rule.

Now only `group-hover:underline` is emitted; the `group` marker produces nothing. Added a regression test; all tailwind tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops emitting the duplicate, parentless `&:is(...)` rule when `group`/`peer` markers are used with `group-*`/`peer-*` variants in `react-email`. This removes invalid CSS from `<head>` and keeps only the correct utility rules.

- **Bug Fixes**
  - In `extractRulesPerClass`, skip rules whose first selector is a nesting selector (`&...`) and only scan `rule.prelude` for class names to avoid keying marker classes.
  - Added a unit test and an end-to-end render test to ensure no bare nested `&:is(...)` rule appears in the rendered `<head>`; snapshots updated to inline format.

<sup>Written for commit a6f4fd829d9277a055187f37c85981f642896a07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

