### PR TITLE
fix(tailwind): split two-value logical shorthands with auto/var/calc

### DIFF
--- a/.changeset/tailwind-logical-shorthand-split.md
+++ b/.changeset/tailwind-logical-shorthand-split.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Fix two-value logical shorthands whose values aren't all numeric (e.g. `margin-inline: 1rem auto`, `padding-inline: 10px calc(1rem + 2px)`) producing invalid duplicated longhands. They are now split into the correct per-side declarations.

--- a/packages/react-email/src/components/tailwind/utils/css/sanitize-declarations.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/sanitize-declarations.spec.ts
@@ -129,6 +129,26 @@ describe('sanitizeDeclarations', () => {
     );
   });
 
+  it('separates two-value logical shorthands with auto, var, or calc', () => {
+    let root = parse('.x { margin-inline: 1rem auto; }');
+    sanitizeDeclarations(root);
+    expect(generate(root)).toMatchInlineSnapshot(
+      `".x{margin-right:auto;margin-left:1rem}"`,
+    );
+
+    root = parse('.x { margin-inline: 0 auto; }');
+    sanitizeDeclarations(root);
+    expect(generate(root)).toMatchInlineSnapshot(
+      `".x{margin-right:auto;margin-left:0}"`,
+    );
+
+    root = parse('.x { padding-inline: 10px calc(1rem + 2px); }');
+    sanitizeDeclarations(root);
+    expect(generate(root)).toMatchInlineSnapshot(
+      `".x{padding-right:calc(1rem + 2px);padding-left:10px}"`,
+    );
+  });
+
   test('oklch to rgb conversion', () => {
     let stylesheet = parse('div { color: oklch(90.5% 0.2 180); }');
     sanitizeDeclarations(stylesheet);

--- a/packages/react-email/src/components/tailwind/utils/css/sanitize-declarations.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/sanitize-declarations.ts
@@ -133,11 +133,11 @@ function separteShorthandDeclaration(
     shorthandToReplace.value.type === 'Value'
       ? shorthandToReplace.value.children
           .toArray()
+          // Count every real value component, not just numeric ones, so a
+          // two-value shorthand with `auto`/`var()`/`calc()` (e.g.
+          // `margin-inline: 1rem auto`) still splits into two longhands.
           .filter(
-            (child) =>
-              child.type === 'Dimension' ||
-              child.type === 'Number' ||
-              child.type === 'Percentage',
+            (child) => child.type !== 'Operator' && child.type !== 'WhiteSpace',
           )
       : [shorthandToReplace.value];
   let endValue = shorthandToReplace.value;


### PR DESCRIPTION
### What

`separteShorthandDeclaration` splits logical shorthands (`margin-inline`, `margin-block`, `padding-inline`, `padding-block`) into per-side longhands for email-client compatibility. It decides whether a value has one or two parts by filtering the value's children to `Dimension | Number | Percentage`:

```ts
.filter((child) =>
  child.type === 'Dimension' || child.type === 'Number' || child.type === 'Percentage')
```

A non-numeric component like `auto`, `var(...)` or `calc(...)` is dropped by that filter, so a genuinely two-value shorthand looks like one value and is not split. Both longhands then receive the full two-value string, which is invalid:

```
margin-inline: 1rem auto            ->  margin-right:1rem auto; margin-left:1rem auto   // invalid
padding-inline: 10px calc(1rem+2px) ->  padding-right:10px calc(…); padding-left:10px calc(…)
```

### Fix

Count every real value component (everything that isn't an `Operator`/`WhiteSpace`) so the two parts are detected and split correctly:

```
margin-inline: 1rem auto             ->  margin-right:auto; margin-left:1rem
padding-inline: 10px calc(1rem + 2px) ->  padding-right:calc(1rem + 2px); padding-left:10px
```

Single values (`margin-inline: auto`, `mx-auto`) and existing numeric two-value cases are unchanged. Added regression tests; all tailwind tests pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes splitting of two-value logical shorthands (`margin-inline`, `padding-inline`) when one side is `auto`, `var()`, or `calc()`, so we emit valid per-side longhands for email clients.

- **Bug Fixes**
  - Count all non-operator/whitespace tokens when parsing shorthand values to detect two parts; single values and numeric pairs are unchanged.
  - Added regression tests for `1rem auto`, `0 auto`, and `10px calc(1rem + 2px)` in `react-email`.

<sup>Written for commit cd6e74e6f0901eb3c96ddf6bb59e253c887f9abd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

