### PR TITLE
fix(editor): preserve image styles when replacing an image

### DIFF
--- a/.changeset/tricky-planets-cry.md
+++ b/.changeset/tricky-planets-cry.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": minor
+---
+
+preserve image styles when replacing an image node

--- a/packages/editor/src/plugins/image/upload-flow.spec.ts
+++ b/packages/editor/src/plugins/image/upload-flow.spec.ts
@@ -1,0 +1,107 @@
+import { Editor } from '@tiptap/core';
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { NodeSelection } from '@tiptap/pm/state';
+import StarterKit from '@tiptap/starter-kit';
+import { describe, expect, it, vi } from 'vitest';
+import { StyleAttribute } from '../../extensions/style-attribute';
+import { createImageExtension } from './extension';
+import { executeUploadFlow } from './upload-flow';
+
+vi.mock('@tiptap/react', () => ({
+  ReactNodeViewRenderer: () => () => null,
+  useEditorState: vi.fn(),
+}));
+
+function createEditor() {
+  const uploadImage = vi.fn().mockResolvedValue({ url: '' });
+  return new Editor({
+    extensions: [
+      StarterKit,
+      createImageExtension({ uploadImage }),
+      StyleAttribute.configure({ types: ['image'] }),
+    ],
+  });
+}
+
+function findImageNode(
+  editor: Editor,
+): { node: ProseMirrorNode; pos: number } | null {
+  let result: { node: ProseMirrorNode; pos: number } | null = null;
+  editor.state.doc.descendants((node, pos) => {
+    if (node.type.name === 'image') {
+      result = { node, pos };
+      return false;
+    }
+    return true;
+  });
+  return result;
+}
+
+describe('executeUploadFlow', () => {
+  it('preserves the existing image attributes (e.g. style) when replacing a selected image', async () => {
+    const editor = createEditor();
+
+    // Insert an image carrying a custom style attribute. `style` is a global
+    // attribute (from StyleAttribute), so insert via explicit content to set it.
+    editor
+      .chain()
+      .focus()
+      .insertContent({
+        type: 'image',
+        attrs: {
+          src: 'https://example.com/original.png',
+          style: 'border-radius: 12px',
+          width: '300',
+          alt: 'logo',
+        },
+      })
+      .run();
+
+    const inserted = findImageNode(editor);
+    expect(inserted).not.toBeNull();
+
+    // Select the image via a NodeSelection (as clicking the atom would).
+    const { tr } = editor.state;
+    tr.setSelection(NodeSelection.create(editor.state.doc, inserted!.pos));
+    editor.view.dispatch(tr);
+    expect(editor.state.selection).toBeInstanceOf(NodeSelection);
+
+    const file = new File(['data'], 'replacement.png', { type: 'image/png' });
+    const uploadImage = vi
+      .fn()
+      .mockResolvedValue({ url: 'https://example.com/new.png' });
+
+    await executeUploadFlow({ editor, file, uploadImage });
+
+    const replaced = findImageNode(editor);
+    expect(replaced).not.toBeNull();
+    // src is updated to the uploaded url ...
+    expect(replaced!.node.attrs.src).toBe('https://example.com/new.png');
+    // ... while the custom styling and other attrs are preserved.
+    expect(replaced!.node.attrs.style).toBe('border-radius: 12px');
+    expect(replaced!.node.attrs.width).toBe('300');
+    expect(replaced!.node.attrs.alt).toBe('logo');
+
+    editor.destroy();
+  });
+
+  it('does not carry over attributes when no image is selected (fresh insert)', async () => {
+    const editor = createEditor();
+    editor.commands.focus();
+
+    const file = new File(['data'], 'fresh.png', { type: 'image/png' });
+    const uploadImage = vi
+      .fn()
+      .mockResolvedValue({ url: 'https://example.com/fresh.png' });
+
+    await executeUploadFlow({ editor, file, uploadImage });
+
+    const inserted = findImageNode(editor);
+    expect(inserted).not.toBeNull();
+    expect(inserted!.node.attrs.src).toBe('https://example.com/fresh.png');
+    // Default style (empty) since nothing was selected.
+    expect(inserted!.node.attrs.style).toBe('');
+
+    editor.destroy();
+  });
+});

--- a/packages/editor/src/plugins/image/upload-flow.spec.ts
+++ b/packages/editor/src/plugins/image/upload-flow.spec.ts
@@ -41,8 +41,6 @@ describe('executeUploadFlow', () => {
   it('preserves the existing image attributes (e.g. style) when replacing a selected image', async () => {
     const editor = createEditor();
 
-    // Insert an image carrying a custom style attribute. `style` is a global
-    // attribute (from StyleAttribute), so insert via explicit content to set it.
     editor
       .chain()
       .focus()
@@ -60,7 +58,6 @@ describe('executeUploadFlow', () => {
     const inserted = findImageNode(editor);
     expect(inserted).not.toBeNull();
 
-    // Select the image via a NodeSelection (as clicking the atom would).
     const { tr } = editor.state;
     tr.setSelection(NodeSelection.create(editor.state.doc, inserted!.pos));
     editor.view.dispatch(tr);
@@ -75,9 +72,7 @@ describe('executeUploadFlow', () => {
 
     const replaced = findImageNode(editor);
     expect(replaced).not.toBeNull();
-    // src is updated to the uploaded url ...
     expect(replaced!.node.attrs.src).toBe('https://example.com/new.png');
-    // ... while the custom styling and other attrs are preserved.
     expect(replaced!.node.attrs.style).toBe('border-radius: 12px');
     expect(replaced!.node.attrs.width).toBe('300');
     expect(replaced!.node.attrs.alt).toBe('logo');
@@ -99,7 +94,6 @@ describe('executeUploadFlow', () => {
     const inserted = findImageNode(editor);
     expect(inserted).not.toBeNull();
     expect(inserted!.node.attrs.src).toBe('https://example.com/fresh.png');
-    // Default style (empty) since nothing was selected.
     expect(inserted!.node.attrs.style).toBe('');
 
     editor.destroy();

--- a/packages/editor/src/plugins/image/upload-flow.ts
+++ b/packages/editor/src/plugins/image/upload-flow.ts
@@ -8,11 +8,6 @@ interface ExecuteUploadFlowParams {
   uploadImage: UseEditorImageOptions['uploadImage'];
 }
 
-/**
- * Returns the attributes of the currently selected image node, or `undefined`
- * when the selection isn't a single image. Used to carry custom styling (e.g.
- * border radius, width/height/alignment/href/alt) over when replacing an image.
- */
 function getSelectedImageAttrs(
   editor: Editor,
 ): Record<string, unknown> | undefined {
@@ -33,8 +28,6 @@ export async function executeUploadFlow({
 }: ExecuteUploadFlowParams): Promise<void> {
   const blobUrl = URL.createObjectURL(file);
 
-  // When replacing a selected image, preserve its existing attributes (custom
-  // styling like border radius, etc.) and only override the src.
   const selectedImageAttrs = getSelectedImageAttrs(editor);
 
   editor

--- a/packages/editor/src/plugins/image/upload-flow.ts
+++ b/packages/editor/src/plugins/image/upload-flow.ts
@@ -1,10 +1,29 @@
 import type { Editor } from '@tiptap/core';
+import { NodeSelection } from '@tiptap/pm/state';
 import type { UseEditorImageOptions } from './types';
 
 interface ExecuteUploadFlowParams {
   editor: Editor;
   file: File;
   uploadImage: UseEditorImageOptions['uploadImage'];
+}
+
+/**
+ * Returns the attributes of the currently selected image node, or `undefined`
+ * when the selection isn't a single image. Used to carry custom styling (e.g.
+ * border radius, width/height/alignment/href/alt) over when replacing an image.
+ */
+function getSelectedImageAttrs(
+  editor: Editor,
+): Record<string, unknown> | undefined {
+  const { selection } = editor.state;
+  if (
+    selection instanceof NodeSelection &&
+    selection.node.type.name === 'image'
+  ) {
+    return selection.node.attrs;
+  }
+  return undefined;
 }
 
 export async function executeUploadFlow({
@@ -14,7 +33,15 @@ export async function executeUploadFlow({
 }: ExecuteUploadFlowParams): Promise<void> {
   const blobUrl = URL.createObjectURL(file);
 
-  editor.chain().focus().setImage({ src: blobUrl }).run();
+  // When replacing a selected image, preserve its existing attributes (custom
+  // styling like border radius, etc.) and only override the src.
+  const selectedImageAttrs = getSelectedImageAttrs(editor);
+
+  editor
+    .chain()
+    .focus()
+    .setImage({ ...selectedImageAttrs, src: blobUrl })
+    .run();
 
   try {
     const { url } = await uploadImage(file);


### PR DESCRIPTION
When replacing a selected image via the uploadImage command, carry over the existing image node's attributes (style/border-radius, width, height, alignment, href, alt) instead of resetting them to defaults. Only the src is overridden with the new blob URL. Paste/drop/slash-insert of a brand-new image (no image selected) is unaffected.

Adds a focused upload-flow.spec.ts covering both the replace (attrs preserved) and fresh-insert (no carry-over) paths.


Claude-Session: https://claude.ai/code/session_01D5NmDNeo9mgSaDCVFzi2a2

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves existing image styling and metadata when replacing a selected image via upload; only the image source changes and paste/drop/slash-insert of new images is unchanged. Adds a changeset for a minor `@react-email/editor` release.

- **Bug Fixes**
  - Preserve style, width, height, alignment, href, and alt when replacing a selected image; only `src` updates (blob → uploaded URL).
  - Detect selected image with `NodeSelection` and pass its attrs to `setImage`; tests cover replace vs fresh insert in `upload-flow.spec.ts`.

- **Refactors**
  - Removed unnecessary comments in `upload-flow.ts`.

<sup>Written for commit 51650a1b750f2d641c9f091abcbb150fb010fbb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

