### PR TITLE
fix(editor): keep list item markers visible in dark-mode

### DIFF
--- a/.changeset/editor-dark-mode-list-markers.md
+++ b/.changeset/editor-dark-mode-list-markers.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+Keep native list markers visible in dark-mode mail clients. Apple Mail / iOS auto-darken light emails by recoloring text but leave `list-style` markers at their original color, so bullets vanished on the darkened background. The serialized email head now ships a `prefers-color-scheme: dark` rule that gives `li::marker` an explicit color.

--- a/packages/editor/src/core/serializer/compose-react-email.spec.tsx
+++ b/packages/editor/src/core/serializer/compose-react-email.spec.tsx
@@ -65,7 +65,7 @@ function docWithGlobalContent(
 }
 
 describe('Text marks', () => {
-  it('should nest bold and italic by schema mark rank (same as ProseMirror)', async () => {
+  it('nests bold and italic by schema mark rank (same as ProseMirror)', async () => {
     const content = docWithGlobalContent([
       {
         type: 'paragraph',
@@ -101,7 +101,7 @@ describe('Text marks', () => {
     expect(emClose).toBeGreaterThan(strongClose);
   });
 
-  it('should nest link and bold by schema mark rank (link extension priority 1000)', async () => {
+  it('nests link and bold by schema mark rank (link extension priority 1000)', async () => {
     const content = docWithGlobalContent([
       {
         type: 'paragraph',
@@ -182,7 +182,7 @@ describe('Text marks', () => {
     expect(result.html).toContain('<strong><span>Hello</span></strong>');
   });
 
-  it('should render uppercase marks using the extension renderer', async () => {
+  it('renders uppercase marks using the extension renderer', async () => {
     const content = docWithGlobalContent([
       {
         type: 'paragraph',
@@ -206,7 +206,7 @@ describe('Text marks', () => {
     expect(result.html).toContain('Hello world');
   });
 
-  it('should render sup marks using the extension renderer', async () => {
+  it('renders sup marks using the extension renderer', async () => {
     const content = docWithGlobalContent([
       {
         type: 'paragraph',
@@ -230,7 +230,7 @@ describe('Text marks', () => {
     expect(result.html).toContain('>2</sup>');
   });
 
-  it('should apply inline styles to code marks only', async () => {
+  it('applies inline styles to code marks only', async () => {
     const content = docWithGlobalContent([
       {
         type: 'paragraph',
@@ -256,7 +256,7 @@ describe('Text marks', () => {
     expect(result.html).toMatch(/<code[^>]*>\s*Code\s*<\/code\s*>/s);
   });
 
-  it('should not apply inline text styles to link-only marks', async () => {
+  it('does not apply inline text styles to link-only marks', async () => {
     const content = docWithGlobalContent([
       {
         type: 'paragraph',
@@ -292,7 +292,7 @@ describe('Text marks', () => {
 });
 
 describe('StarterKit node wrappers', () => {
-  it('should render bullet lists using the extension renderer', async () => {
+  it('renders bullet lists using the extension renderer', async () => {
     const content = docWithGlobalContent([
       {
         type: 'bulletList',
@@ -326,7 +326,7 @@ describe('StarterKit node wrappers', () => {
     expect(result.html).toContain('List item');
   });
 
-  it('should inject dark-mode CSS into the email head', async () => {
+  it('injects dark-mode CSS into the email head', async () => {
     const content = docWithGlobalContent([
       {
         type: 'paragraph',
@@ -341,7 +341,7 @@ describe('StarterKit node wrappers', () => {
     expect(result.html).toContain('li::marker');
   });
 
-  it('should render hard breaks using the extension renderer', async () => {
+  it('renders hard breaks using the extension renderer', async () => {
     const content = docWithGlobalContent([
       {
         type: 'paragraph',
@@ -374,7 +374,7 @@ describe('StarterKit node wrappers', () => {
 });
 
 describe('Button and image reset styles', () => {
-  it('should include display:inline-block on buttons with the basic theme', async () => {
+  it('includes display:inline-block on buttons with the basic theme', async () => {
     const content = docWithGlobalContent(
       [
         {
@@ -394,7 +394,7 @@ describe('Button and image reset styles', () => {
     expect(result.html).toContain('Click me');
   });
 
-  it('should include display:inline-block on buttons with the minimal theme', async () => {
+  it('includes display:inline-block on buttons with the minimal theme', async () => {
     const content = docWithGlobalContent(
       [
         {
@@ -414,7 +414,7 @@ describe('Button and image reset styles', () => {
     expect(result.html).toContain('Click me');
   });
 
-  it('should include line-height:100% on buttons with the minimal theme', async () => {
+  it('includes line-height:100% on buttons with the minimal theme', async () => {
     const content = docWithGlobalContent(
       [
         {
@@ -433,7 +433,7 @@ describe('Button and image reset styles', () => {
     expect(result.html).toMatch(/line-height:\s*100%/);
   });
 
-  it('should include max-width:100% on images with the basic theme', async () => {
+  it('includes max-width:100% on images with the basic theme', async () => {
     const ImageNode = EmailNode.create({
       name: 'image',
       group: 'block',
@@ -472,7 +472,7 @@ describe('Button and image reset styles', () => {
     expect(result.html).toContain('test image');
   });
 
-  it('should include max-width:100% on images with the minimal theme', async () => {
+  it('includes max-width:100% on images with the minimal theme', async () => {
     const ImageNode = EmailNode.create({
       name: 'image',
       group: 'block',

--- a/packages/editor/src/core/serializer/compose-react-email.spec.tsx
+++ b/packages/editor/src/core/serializer/compose-react-email.spec.tsx
@@ -326,6 +326,21 @@ describe('StarterKit node wrappers', () => {
     expect(result.html).toContain('List item');
   });
 
+  it('should inject dark-mode CSS into the email head', async () => {
+    const content = docWithGlobalContent([
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Hello world' }],
+      },
+    ]);
+
+    const editor = createEditorWithContent(content);
+    const result = await composeReactEmail({ editor, preview: '' });
+
+    expect(result.html).toContain('@media (prefers-color-scheme: dark)');
+    expect(result.html).toContain('li::marker');
+  });
+
   it('should render hard breaks using the extension renderer', async () => {
     const content = docWithGlobalContent([
       {

--- a/packages/editor/src/core/serializer/compose-react-email.spec.tsx
+++ b/packages/editor/src/core/serializer/compose-react-email.spec.tsx
@@ -341,6 +341,25 @@ describe('StarterKit node wrappers', () => {
     expect(result.html).toContain('li::marker');
   });
 
+  it('omits dark-mode CSS when previewMode is set', async () => {
+    const content = docWithGlobalContent([
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Hello world' }],
+      },
+    ]);
+
+    const editor = createEditorWithContent(content);
+    const result = await composeReactEmail({
+      editor,
+      preview: '',
+      previewMode: true,
+    });
+
+    expect(result.html).not.toContain('prefers-color-scheme');
+    expect(result.html).not.toContain('li::marker');
+  });
+
   it('renders hard breaks using the extension renderer', async () => {
     const content = docWithGlobalContent([
       {

--- a/packages/editor/src/core/serializer/compose-react-email.tsx
+++ b/packages/editor/src/core/serializer/compose-react-email.tsx
@@ -51,9 +51,11 @@ interface ComposeReactEmailResult {
 export const composeReactEmail = async ({
   editor,
   preview,
+  previewMode = false,
 }: {
   editor: Editor;
   preview?: string;
+  previewMode?: boolean;
 }): Promise<ComposeReactEmailResult> => {
   const data = editor.getJSON();
   const extensions = editor.extensionManager.extensions;
@@ -150,7 +152,7 @@ export const composeReactEmail = async ({
 
   const parsedContent = parseContent(data.content);
   const unformattedHtml = await render(
-    <BaseTemplate previewText={preview} editor={editor}>
+    <BaseTemplate previewText={preview} editor={editor} previewMode={previewMode}>
       {parsedContent}
     </BaseTemplate>,
   );

--- a/packages/editor/src/core/serializer/compose-react-email.tsx
+++ b/packages/editor/src/core/serializer/compose-react-email.tsx
@@ -152,7 +152,11 @@ export const composeReactEmail = async ({
 
   const parsedContent = parseContent(data.content);
   const unformattedHtml = await render(
-    <BaseTemplate previewText={preview} editor={editor} previewMode={previewMode}>
+    <BaseTemplate
+      previewText={preview}
+      editor={editor}
+      previewMode={previewMode}
+    >
       {parsedContent}
     </BaseTemplate>,
   );

--- a/packages/editor/src/core/serializer/default-base-template.tsx
+++ b/packages/editor/src/core/serializer/default-base-template.tsx
@@ -5,11 +5,13 @@ import { DARK_MODE_CSS } from '../../utils/dark-mode';
 type BaseTemplateProps = {
   children: React.ReactNode;
   previewText?: string;
+  previewMode?: boolean;
 };
 
 export function DefaultBaseTemplate({
   children,
   previewText,
+  previewMode = false,
 }: BaseTemplateProps) {
   return (
     <Html>
@@ -21,7 +23,7 @@ export function DefaultBaseTemplate({
           content="telephone=no,address=no,email=no,date=no,url=no"
           name="format-detection"
         />
-        <style>{DARK_MODE_CSS}</style>
+        {!previewMode && <style>{DARK_MODE_CSS}</style>}
       </Head>
       {previewText && previewText !== '' && <Preview>{previewText}</Preview>}
 

--- a/packages/editor/src/core/serializer/default-base-template.tsx
+++ b/packages/editor/src/core/serializer/default-base-template.tsx
@@ -1,5 +1,6 @@
 import type * as React from 'react';
 import { Body, Head, Html, Preview } from 'react-email';
+import { DARK_MODE_CSS } from '../../utils/dark-mode';
 
 type BaseTemplateProps = {
   children: React.ReactNode;
@@ -20,6 +21,7 @@ export function DefaultBaseTemplate({
           content="telephone=no,address=no,email=no,date=no,url=no"
           name="format-detection"
         />
+        <style>{DARK_MODE_CSS}</style>
       </Head>
       {previewText && previewText !== '' && <Preview>{previewText}</Preview>}
 

--- a/packages/editor/src/core/serializer/serializer-plugin.ts
+++ b/packages/editor/src/core/serializer/serializer-plugin.ts
@@ -10,5 +10,6 @@ export interface SerializerPlugin {
     previewText?: string;
     children: React.ReactNode;
     editor: Editor;
+    previewMode?: boolean;
   }): React.ReactNode;
 }

--- a/packages/editor/src/extensions/container.spec.tsx
+++ b/packages/editor/src/extensions/container.spec.tsx
@@ -272,6 +272,9 @@ describe('Container Node', () => {
           <meta
             content="telephone=no,address=no,email=no,date=no,url=no"
             name="format-detection" />
+          <style>
+            @media (prefers-color-scheme: dark){li::marker{color:#c4c4c4}}
+          </style>
         </head>
         <body dir="ltr" lang="en" style="background-color:#ffffff">
           <!--$--><!--html--><!--head--><!--body-->
@@ -1382,6 +1385,9 @@ describe('Container Node', () => {
           <meta
             content="telephone=no,address=no,email=no,date=no,url=no"
             name="format-detection" />
+          <style>
+            @media (prefers-color-scheme: dark){li::marker{color:#c4c4c4}}
+          </style>
         </head>
         <body dir="ltr" lang="en">
           <!--$--><!--html--><!--head--><!--body-->
@@ -1497,6 +1503,9 @@ describe('Container Node', () => {
           <meta
             content="telephone=no,address=no,email=no,date=no,url=no"
             name="format-detection" />
+          <style>
+            @media (prefers-color-scheme: dark){li::marker{color:#c4c4c4}}
+          </style>
         </head>
         <body dir="ltr" lang="en">
           <!--$--><!--html--><!--head--><!--body-->
@@ -1580,6 +1589,9 @@ describe('Container Node', () => {
           <meta
             content="telephone=no,address=no,email=no,date=no,url=no"
             name="format-detection" />
+          <style>
+            @media (prefers-color-scheme: dark){li::marker{color:#c4c4c4}}
+          </style>
         </head>
         <body dir="ltr" lang="en" style="background-color:#ffffff">
           <!--$--><!--html--><!--head--><!--body-->

--- a/packages/editor/src/plugins/email-theming/extension.tsx
+++ b/packages/editor/src/plugins/email-theming/extension.tsx
@@ -6,6 +6,7 @@ import type * as React from 'react';
 import { Body, Head, Html, Preview } from 'react-email';
 import type { SerializerPlugin } from '../../core/serializer/serializer-plugin';
 import { getGlobalContent } from '../../extensions/global-content';
+import { DARK_MODE_CSS } from '../../utils/dark-mode';
 import {
   injectGlobalPlainCss,
   injectThemeCss,
@@ -305,6 +306,7 @@ export const EmailTheming = Extension.create<{
                   name="format-detection"
                 />
 
+                <style>{DARK_MODE_CSS}</style>
                 {globalCss && <style>{globalCss}</style>}
               </Head>
               {previewText && previewText !== '' && (

--- a/packages/editor/src/plugins/email-theming/extension.tsx
+++ b/packages/editor/src/plugins/email-theming/extension.tsx
@@ -291,7 +291,7 @@ export const EmailTheming = Extension.create<{
             getMergedCssJs(theming.theme, theming.styles),
           );
         },
-        BaseTemplate({ previewText, children, editor }) {
+        BaseTemplate({ previewText, children, editor, previewMode = false }) {
           const { css: globalCss, styles, theme } = getEmailTheming(editor);
           const mergedStyles = getMergedCssJs(theme, styles);
 
@@ -306,7 +306,7 @@ export const EmailTheming = Extension.create<{
                   name="format-detection"
                 />
 
-                <style>{DARK_MODE_CSS}</style>
+                {!previewMode && <style>{DARK_MODE_CSS}</style>}
                 {globalCss && <style>{globalCss}</style>}
               </Head>
               {previewText && previewText !== '' && (

--- a/packages/editor/src/utils/dark-mode.ts
+++ b/packages/editor/src/utils/dark-mode.ts
@@ -1,0 +1,8 @@
+/**
+ * CSS injected into the email head to keep content visible in dark-mode mail
+ * clients (Apple Mail / iOS), which auto-darken light emails by recoloring text
+ * but leave some properties — like native list markers — at their original
+ * color. `::marker` can't be styled inline, so the rules have to live here.
+ */
+export const DARK_MODE_CSS =
+  '@media (prefers-color-scheme: dark){li::marker{color:#c4c4c4}}';


### PR DESCRIPTION
Dark-mode clients (Apple Mail / iOS) auto-darken light emails by recoloring text but leave native list markers at their original color, so bullets vanish on the darkened background. Inject a dark-mode style rule into the email head (`::marker` can't be styled inline) so the markers stay visible. Applied to both the default and themed base templates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep list bullets visible in dark‑mode mail clients (Apple Mail/iOS) by injecting a CSS rule into the email head. In the editor preview, use previewMode to skip this rule so light previews on a dark OS don’t wash markers.

- New Features
  - Add `previewMode` to `composeReactEmail` and base templates to omit dark‑mode CSS in editor previews.

- Bug Fixes
  - Inject shared `DARK_MODE_CSS` into `<Head>` in the default base template and `EmailTheming` to color `li::marker` under `@media (prefers-color-scheme: dark)`.
  - Tests and release: add coverage for the dark‑mode CSS and preview behavior, refresh container snapshots, drop the "should" prefix from test names, and add a changeset to publish a patch for `@react-email/editor`.

<sup>Written for commit c595278785bed4915a9708853b40b6e3ae1140e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

