### PR TITLE
docs(integrations): add Bird integration

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -100,6 +100,7 @@
             "pages": [
               "integrations/overview",
               "integrations/resend",
+              "integrations/bird",
               "integrations/inbound",
               "integrations/nodemailer",
               "integrations/mailgun",

--- a/apps/docs/integrations/bird.mdx
+++ b/apps/docs/integrations/bird.mdx
@@ -1,0 +1,77 @@
+---
+title: "Send email using Bird"
+sidebarTitle: "Bird"
+description: "Learn how to send an email using React Email and the Bird TypeScript SDK."
+"og:image": "https://react.email/static/covers/react-email.png"
+---
+
+## 1. Install dependencies
+
+Get the [react-email](https://www.npmjs.com/package/react-email) package and the [Bird TypeScript SDK](https://www.npmjs.com/package/@messagebird/sdk).
+
+<CodeGroup>
+
+```sh npm
+npm install @messagebird/sdk react-email
+```
+
+```sh yarn
+yarn add @messagebird/sdk react-email
+```
+
+```sh pnpm
+pnpm add @messagebird/sdk react-email
+```
+
+</CodeGroup>
+
+## 2. Create an email using React
+
+Start by building your email template in a `.jsx` or `.tsx` file.
+
+```tsx email.tsx
+import * as React from "react";
+import { Html, Button } from "react-email";
+
+export function Email(props) {
+  const { url } = props;
+
+  return (
+    <Html lang="en">
+      <Button href={url}>Click me</Button>
+    </Html>
+  );
+}
+```
+
+## 3. Convert to HTML and send email
+
+Import the email template you just built, convert it into an HTML string, and use the Bird SDK to send it.
+
+```tsx
+import { render } from "react-email";
+import { BirdClient } from "@messagebird/sdk";
+import { Email } from "./email";
+
+const bird = new BirdClient({ apiKey: process.env.BIRD_API_KEY });
+
+const emailHtml = await render(<Email url="https://example.com" />);
+
+await bird.email.send({
+  from: { email: "you@example.com", name: "You" },
+  to: ["user@gmail.com"],
+  subject: "hello world",
+  html: emailHtml,
+});
+```
+
+## Try it yourself
+
+<Card
+  title="Bird example"
+  icon="arrow-up-right-from-square"
+  iconType="duotone"
+  href="https://github.com/resend/react-email/tree/main/examples/bird"
+>
+  See the full source code.
+</Card>

--- a/apps/docs/snippets/integrations.mdx
+++ b/apps/docs/snippets/integrations.mdx
@@ -2,6 +2,9 @@
   <Card title="Resend" href="/integrations/resend">
     Send email using Resend
   </Card>
+  <Card title="Bird" href="/integrations/bird">
+    Send email using Bird
+  </Card>
   <Card title="Nodemailer" href="/integrations/nodemailer">
     Send email using Nodemailer
   </Card>

--- a/examples/bird/package.json
+++ b/examples/bird/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "react-email-with-bird",
+  "license": "MIT",
+  "private": true,
+  "sideEffects": false,
+  "type": "module",
+  "main": "./dist/index.js",
+  "files": [
+    "dist/**"
+  ],
+  "scripts": {
+    "build": "tsdown src/index.tsx --format esm --target node20",
+    "dev": "tsdown src/index.tsx --format esm --target node20 --watch",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@messagebird/sdk": "0.2.0",
+    "react-email": "6.0.3",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
+  },
+  "devDependencies": {
+    "tsdown": "0.21.9",
+    "typescript": "5.9.3"
+  }
+}

--- a/examples/bird/src/email.tsx
+++ b/examples/bird/src/email.tsx
@@ -1,0 +1,13 @@
+import { Button, Html } from 'react-email';
+
+interface EmailProps {
+  url: string;
+}
+
+export const Email: React.FC<Readonly<EmailProps>> = ({ url }) => {
+  return (
+    <Html lang="en">
+      <Button href={url}>Click me</Button>
+    </Html>
+  );
+};

--- a/examples/bird/src/index.tsx
+++ b/examples/bird/src/index.tsx
@@ -1,0 +1,14 @@
+import { BirdClient } from '@messagebird/sdk';
+import { render } from 'react-email';
+import { Email } from './email';
+
+const bird = new BirdClient({ apiKey: process.env.BIRD_API_KEY || '' });
+
+const emailHtml = await render(<Email url="https://example.com" />);
+
+await bird.email.send({
+  from: { email: 'you@example.com', name: 'You' },
+  to: ['user@gmail.com'],
+  subject: 'hello world',
+  html: emailHtml,
+});

--- a/examples/bird/tsconfig.json
+++ b/examples/bird/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": false,
+    "isolatedModules": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "jsx": "react-jsx",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "target": "ESNext",
+    "types": ["vitest/globals"]
+  },
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"]
+}


### PR DESCRIPTION
Add a "Send email using Bird" integration guide and a runnable example, following the standard render-to-HTML pattern used by the other ESP integrations . Bird's @messagebird/sdk accepts an HTML string, so the template is rendered with react-email's render() and passed as `html` to bird.email.send().

- apps/docs/integrations/bird.mdx: new integration page
- apps/docs/docs.json: register the page in the Integrations nav
- apps/docs/snippets/integrations.mdx: add a Bird card to the overview
- examples/bird/: runnable example (mirrors examples/sendgrid)

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Bird integration guide and runnable example using the render-to-HTML pattern so users can send emails via Bird with `@messagebird/sdk` and `react-email`. Improves docs discoverability with a new page and overview card.

- **New Features**
  - New integration page: how to render with `react-email`’s `render()` and send via `bird.email.send()` using `@messagebird/sdk`.
  - Added Bird card to Integrations overview and registered the page in the nav.
  - Runnable example in `examples/bird` mirroring the SendGrid example.

<sup>Written for commit ec8bd22923c8c1b87bdd37e0c6f75eb53effed53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

