### PR TITLE
fix(ui): build failing because of motion-dom, motion-utils version mismatch

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -61,6 +61,8 @@
     "framer-motion": "catalog:",
     "log-symbols": "catalog:",
     "module-punycode": "npm:punycode@2.3.1",
+    "motion-dom": "catalog:",
+    "motion-utils": "catalog:",
     "next-safe-action": "8.5.2",
     "node-html-parser": "7.1.0",
     "picospinner": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,12 @@ catalogs:
     log-symbols:
       specifier: ^7.0.0
       version: 7.0.1
+    motion-dom:
+      specifier: 12.38.0
+      version: 12.38.0
+    motion-utils:
+      specifier: 12.36.0
+      version: 12.36.0
     next:
       specifier: 16.2.6
       version: 16.2.6
@@ -922,6 +928,12 @@ importers:
       module-punycode:
         specifier: npm:punycode@2.3.1
         version: punycode@2.3.1
+      motion-dom:
+        specifier: 'catalog:'
+        version: 12.38.0
+      motion-utils:
+        specifier: 'catalog:'
+        version: 12.36.0
       next-safe-action:
         specifier: 8.5.2
         version: 8.5.2(next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,13 @@ catalog:
   esbuild: 0.28.0
   framer-motion: 12.38.0
   log-symbols: ^7.0.0
+  # motion-dom and motion-utils are framer-motion's lockstep siblings: they
+  # rely on internal cross-package symbols only guaranteed to match at the same
+  # release. framer-motion is pinned exact, so these must be pinned too or the
+  # generated .react-email app's fresh npm install floats them to an
+  # incompatible minor and Turbopack fails on a missing export (see #3599).
+  motion-dom: 12.38.0
+  motion-utils: 12.36.0
   next: 16.2.6
   nypm: 0.6.6
   ora: ^8.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,11 +38,6 @@ catalog:
   esbuild: 0.28.0
   framer-motion: 12.38.0
   log-symbols: ^7.0.0
-  # motion-dom and motion-utils are framer-motion's lockstep siblings: they
-  # rely on internal cross-package symbols only guaranteed to match at the same
-  # release. framer-motion is pinned exact, so these must be pinned too or the
-  # generated .react-email app's fresh npm install floats them to an
-  # incompatible minor and Turbopack fails on a missing export (see #3599).
   motion-dom: 12.38.0
   motion-utils: 12.36.0
   next: 16.2.6


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pins `motion-dom` and `motion-utils` to versions compatible with our pinned `framer-motion` to stop Turbopack build failures during email preview builds. Addresses DEV-1085.

- **Bug Fixes**
  - Pinned `motion-dom@12.38.0` and `motion-utils@12.36.0` in the workspace `catalog` to match `framer-motion@12.38.0`.
  - Added explicit `motion-dom` and `motion-utils` deps in `packages/ui/package.json` using `catalog:`.
  - Updated `pnpm-workspace.yaml` catalog and `pnpm-lock.yaml`.

<sup>Written for commit 3db269cc004d9572f2ca2f1065545ab7809b9484. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

