### PR TITLE
fix(markdown): escape double quotes with the correct &quot; entity

### DIFF
--- a/packages/react-email/src/components/markdown/utils/parse-css-in-js-to-inline-css.spec.ts
+++ b/packages/react-email/src/components/markdown/utils/parse-css-in-js-to-inline-css.spec.ts
@@ -1,0 +1,17 @@
+import { parseCssInJsToInlineCss } from './parse-css-in-js-to-inline-css.js';
+
+describe('parseCssInJsToInlineCss', () => {
+  it('returns an empty string for undefined input', () => {
+    expect(parseCssInJsToInlineCss(undefined)).toBe('');
+  });
+
+  it('appends px to numerical properties', () => {
+    expect(parseCssInJsToInlineCss({ fontSize: 16 })).toBe('font-size:16px');
+  });
+
+  it('escapes double quotes with the &quot; entity so the style attribute stays valid', () => {
+    expect(
+      parseCssInJsToInlineCss({ fontFamily: '"Times New Roman", serif' }),
+    ).toBe('font-family:&quot;Times New Roman&quot;, serif');
+  });
+});

--- a/packages/react-email/src/components/markdown/utils/parse-css-in-js-to-inline-css.ts
+++ b/packages/react-email/src/components/markdown/utils/parse-css-in-js-to-inline-css.ts
@@ -4,7 +4,7 @@ function camelToKebabCase(str: string): string {
 
 function escapeQuotes(value: unknown) {
   if (typeof value === 'string' && value.includes('"')) {
-    return value.replace(/"/g, '&#x27;');
+    return value.replace(/"/g, '&quot;');
   }
   return value;
 }


### PR DESCRIPTION
## What's broken
`parseCssInJsToInlineCss` (used by `<Markdown>` to build `style="..."` attributes) escapes double quotes in CSS values to `&#x27;`. That is the HTML entity for an apostrophe, not a double quote — so a value like `fontFamily: '"Times New Roman", serif'` is rendered as `font-family:&#x27;Times New Roman&#x27;, serif`, which the client decodes to single quotes, silently changing the author's CSS.

## Why it happens
`escapeQuotes()` does `value.replace(/"/g, '&#x27;')`. `&#x27;` is `'`; the entity for `"` is `&quot;` (`&#x22;`).

## Fix
Replace `&#x27;` with `&quot;` in `escapeQuotes()`.

## Test
Added `parse-css-in-js-to-inline-css.spec.ts`. The double-quote case fails before the change (`Received "...&#x27;..."`) and passes after (`...&quot;...`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double-quote escaping in inline CSS by using `&quot;` in `parseCssInJsToInlineCss`, so values like font-family: "Times New Roman" render correctly and the style attribute stays valid.

- **Bug Fixes**
  - Use `&quot;` for double quotes in `escapeQuotes()` to prevent quotes turning into apostrophes.
  - Add tests covering quote escaping, px suffixing, and undefined input.

<sup>Written for commit 8332566d18342f36599beef3526136f20ea50952. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

