### PR TITLE
fix(web): add missing types to webgl Billboard component

### DIFF
--- a/apps/web/src/webgl/Billboard.tsx
+++ b/apps/web/src/webgl/Billboard.tsx
@@ -1,12 +1,27 @@
 'use client';
 
-import { useFrame } from '@react-three/fiber';
+import { type ThreeElements, useFrame } from '@react-three/fiber';
 import { useRef } from 'react';
 import * as THREE from 'three';
 
 import '@/webgl/materials/MeshImageMaterial';
 
-function setupCylinderTextureMapping(texture, dimensions, radius, height) {
+interface TextureDimensions {
+  aspectRatio: number;
+}
+
+type BillboardProps = ThreeElements['mesh'] & {
+  texture: THREE.Texture;
+  dimensions: TextureDimensions;
+  radius?: number;
+};
+
+function setupCylinderTextureMapping(
+  texture: THREE.Texture,
+  dimensions: TextureDimensions,
+  radius: number,
+  height: number,
+) {
   const cylinderCircumference = 2 * Math.PI * radius;
   const cylinderHeight = height;
   const cylinderAspectRatio = cylinderCircumference / cylinderHeight;
@@ -26,8 +41,13 @@ function setupCylinderTextureMapping(texture, dimensions, radius, height) {
   texture.offset.y = (1 - texture.repeat.y) / 2;
 }
 
-export function Billboard({ texture, dimensions, radius = 5, ...props }) {
-  const ref = useRef(null);
+export function Billboard({
+  texture,
+  dimensions,
+  radius = 5,
+  ...props
+}: BillboardProps) {
+  const ref = useRef<THREE.Mesh>(null);
 
   setupCylinderTextureMapping(texture, dimensions, radius, 2);
 


### PR DESCRIPTION
## Overview: 

Adds explicit TypeScript types to the `Billboard` component and the `setupCylinderTextureMapping` function in `apps/web/src/webgl/Billboard.tsx`, which previously had implicit `any` on all parameters and props.

  ## Changes:
  - Added `TextureDimensions` interface for the `dimensions` prop shape
  - Added `BillboardProps` type extending `ThreeElements['mesh']` with the component's specific props
  - Typed all parameters of `setupCylinderTextureMapping`
  - Added `THREE.Mesh` generic to `useRef`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit TypeScript types to the WebGL `Billboard` component and its texture mapping helper to remove implicit any and improve type safety. This clarifies props and ref types without changing runtime behavior.

- **Refactors**
  - Introduced `TextureDimensions` and `BillboardProps` (extends `ThreeElements['mesh']`) for clear prop shapes.
  - Annotated `setupCylinderTextureMapping` parameters (`THREE.Texture`, dimensions, `radius`, `height`).
  - Set `useRef<THREE.Mesh>` for the mesh reference.

<sup>Written for commit a78028ea3a258b442b8a528bab19cfe1f80e5fd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

