### PR TITLE
fix(render): resolve implicit TypeScript type errors in pretty util

### DIFF
--- a/packages/render/src/shared/utils/pretty.spec.ts
+++ b/packages/render/src/shared/utils/pretty.spec.ts
@@ -165,6 +165,13 @@ describe('pretty', () => {
     `);
   });
 
+  test('strips null bytes before formatting', async () => {
+    expect(await pretty('<p>hello\0world</p>')).toMatchInlineSnapshot(`
+      "<p>helloworld</p>
+      "
+    `);
+  });
+
   test('if mso syntax does not wrap', async () => {
     expect(
       await pretty(

--- a/packages/render/src/shared/utils/pretty.ts
+++ b/packages/render/src/shared/utils/pretty.ts
@@ -24,7 +24,7 @@ function getHtmlNode(path: {
     return topNode;
   }
 
-  return path.stack?.[path.stack.length - 1] as HtmlNode;
+  return path.stack?.[path.stack.length - 1] as unknown as HtmlNode;
 }
 
 function recursivelyMapDoc(
@@ -80,7 +80,7 @@ function recursivelyMapDoc(
       }
     }
 
-    return nextDoc as builders.Doc;
+    return nextDoc as unknown as builders.Doc;
   }
 
   return callback(doc);
@@ -91,7 +91,7 @@ if (modifiedHtml.printers) {
   const previousPrint = modifiedHtml.printers.html.print;
   modifiedHtml.printers.html.print = (path, options, print, args) => {
     const node = getHtmlNode(
-      path as Parameters<Plugin['printers']['html']['print']>[0],
+      path as Parameters<NonNullable<Plugin['printers']>['html']['print']>[0],
     );
 
     const rawPrintingResult = previousPrint(path, options, print, args);


### PR DESCRIPTION
 casts against Prettier's internal, loosely-typed APIs.

  Changes:
  - Use `NonNullable<Plugin['printers']>` to safely access the `html` printer without a `| undefined` union error
  - Also adds a missing test for null byte stripping behavior (let me know if I should open another PR)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes implicit TypeScript errors in the pretty util when interacting with `prettier` internals and adds a test for null byte stripping. Safely reads the `html` printer via `NonNullable<Plugin['printers']>` and uses `as unknown as` casts to satisfy TS without changing runtime behavior.

<sup>Written for commit a5034d15a67c2aca3d64396853139409a5fd5d5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

