### PR TITLE
chore(ui): raise timeout for combined tailwind css-configs test

### DIFF
--- a/packages/ui/src/utils/caniemail/tailwind/get-tailwind-css-configs.spec.ts
+++ b/packages/ui/src/utils/caniemail/tailwind/get-tailwind-css-configs.spec.ts
@@ -130,7 +130,9 @@ describe('caniemail integration: styles produced by theme/utility reach the chec
     });
   });
 
-  it('combines config, theme, and utility together', async () => {
+  it('combines config, theme, and utility together', {
+    timeout: 15_000,
+  }, async () => {
     const themeStyles = await styleFor(
       'dummy-email-template-combined.tsx',
       'bg-brand',


### PR DESCRIPTION
## Summary

The `combines config, theme, and utility together` test in `get-tailwind-css-configs.spec.ts` is the heaviest test in the file: it runs the full extract → esbuild bundle → Tailwind compile → inline pipeline three times against the combined fixture. On busy CI runners it can exceed vitest's 5s default timeout — observed at 5.0s on a PR run (twice in a row) vs 2.8s on a canary run of the same code, e.g. on #3568 where it failed CI for an unrelated one-line editor change.

This raises the per-test timeout to 15s, following the existing pattern in `get-email-component.spec.ts`.

## Changes

- Add `{ timeout: 15_000 }` to the combined caniemail integration test

## Testing

- The options-object form is already used elsewhere in the package and vitest picks the test up normally; the timeout only changes the failure threshold, not the assertions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the per-test timeout of the "combines config, theme, and utility together" test in `packages/ui/src/utils/caniemail/tailwind/get-tailwind-css-configs.spec.ts` to 15s to reduce CI flakiness on slow runners. This test runs the extract → bundle → compile → inline pipeline three times and can exceed `vitest`’s 5s default.

<sup>Written for commit 6c24b7ed8742443471b2a1d5f2d1057a92fb43e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

