### PR TITLE
fix(editor): add keys to serialized email nodes

### DIFF
--- a/.changeset/keyed-email-serialization.md
+++ b/.changeset/keyed-email-serialization.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+Avoid React key warnings when exporting editor content containing marked text. Serialized email nodes are now keyed at the mapped result boundary, so marks like bold, italic, and links no longer produce missing-key warnings during email export.

--- a/packages/editor/src/core/serializer/compose-react-email.tsx
+++ b/packages/editor/src/core/serializer/compose-react-email.tsx
@@ -1,5 +1,6 @@
 import type { Editor, JSONContent } from '@tiptap/core';
 import type { MarkType, Schema } from '@tiptap/pm/model';
+import { Fragment } from 'react';
 import { pretty, render, toPlainText } from 'react-email';
 import { inlineCssToJs } from '../../utils/styles';
 import { DefaultBaseTemplate } from './default-base-template';
@@ -101,7 +102,6 @@ export const composeReactEmail = async ({
         node.text
       ) : (
         <NodeComponent
-          key={index}
           node={
             node.type === 'table' && inlineStyles.width && !node.attrs?.width
               ? {
@@ -144,7 +144,7 @@ export const composeReactEmail = async ({
         }
       }
 
-      return renderedNode;
+      return <Fragment key={index}>{renderedNode}</Fragment>;
     });
   }
 


### PR DESCRIPTION
## Overview:

This change moves the React `key` to the actual element returned from the `content.map()` call in `composeReactEmail`.

Previously, `key={index}` was only applied to `NodeComponent`. That covered regular non-text nodes, but it did not cover text nodes, or nodes wrapped by marks such as bold, italic, or links. When a text node had marks, the final rendered item became a `MarkComponent`, and the original key on `NodeComponent` was either absent or no longer attached to the list item returned by the map.

This caused React to warn when exporting email HTML from editor content containing marked text:

```txt
Each child in a list should have a unique "key" prop.
```

The fix wraps each mapped result in a keyed `Fragment`:

```tsx
return <Fragment key={index}>{renderedNode}</Fragment>;
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix React key warnings when exporting email HTML from editor content. Keys are now applied to each mapped node, including text and nodes with marks.

- **Bug Fixes**
  - Wrap each mapped result in a keyed `Fragment` in `composeReactEmail`, ensuring the key is attached to the final item returned by `content.map()`.

<sup>Written for commit f18de4c480e5b709c8dcb4bed6a316d359c67930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

