### PR TITLE
fix(docs): recommend next "latest" instead of "*" for Vercel deployment

### DIFF
--- a/apps/docs/deployment.mdx
+++ b/apps/docs/deployment.mdx
@@ -22,7 +22,7 @@ icon: "rocket"
     ```diff
      {
        "devDependencies": {
-    +    "next": "*",
+    +    "next": "latest",
        }
      }
     ```


### PR DESCRIPTION
The deployment docs tell users to add `"next": "*"` to `devDependencies` so Vercel's Next.js framework preset detects the project. But `@vercel/next` treats a `*` version range as a legacy Next.js project (`isLegacyNext` checks `semver.maxSatisfying` against its legacy version list, which `*` matches) and force-installs `next-server@7`, so the deploy fails during `npm install`:

```
npm error ERESOLVE unable to resolve dependency tree
npm error peer react@"^16.0.0" from next-server@7.0.2-canary.49
```

`"latest"` is explicitly exempt from the legacy check, and the root `next` version is only used for framework detection — the preview app itself builds with the Next version pinned by `@react-email/ui` — so `latest` cannot drift out of sync with anything.

Verified with real deployments of a stock `create-email` project following the docs recipe:

- `"next": "*"` → build fails at `npm install` with the ERESOLVE above
- `"next": "latest"` → deploys green and the preview app serves

Related to the deployment issues reported in #3557.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Vercel deployment docs to use `next: "latest"` instead of `"*"`. This avoids `@vercel/next` legacy detection that installs `next-server@7` and causes install failures, so deploys succeed.

<sup>Written for commit 32d18ed42b23125adb1c34af34f181afc854a7bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

