### PR TITLE
fix: stop spam check failures from breaking `email build`

### DIFF
--- a/.changeset/spam-check-non-fatal.md
+++ b/.changeset/spam-check-non-fatal.md
@@ -1,0 +1,5 @@
+---
+"@react-email/ui": patch
+---
+
+Stop failing `email build` when the spam check API errors or times out — the build now logs a warning and continues without a baked-in spam score.

--- a/apps/web/src/utils/spam-assassin/parse-pointing-table-rows.spec.ts
+++ b/apps/web/src/utils/spam-assassin/parse-pointing-table-rows.spec.ts
@@ -239,6 +239,55 @@ Content-Type: text/html; charset="UTF-8"
     `);
   });
 
+  test('works when a wrapped description line falls outside the columns', () => {
+    const partialSpamResponse = `
+ pts rule name              description
+---- ---------------------- --------------------------------------------------
+ 1.8 MISSING_SUBJECT        Missing Subject: header
+ 0.0 URIBL_BLOCKED          ADMINISTRATOR NOTICE: The query to URIBL was blocked.
+                            See
+                            http://wiki.apache.org/spamassassin/DnsBlocklists#dnsbl-block
+                             for more information.
+                            [URI:
+react-email-vercel-repro-n0vqufobp-felipefreitag-5792s-projects.vercel.app]
+ 0.0 HTML_MESSAGE           BODY: HTML included in message`;
+
+    expect(parsePointingTableRows(partialSpamResponse)).toEqual([
+      {
+        pts: 1.8,
+        ruleName: 'MISSING_SUBJECT',
+        description: 'Missing Subject: header',
+      },
+      {
+        pts: 0,
+        ruleName: 'URIBL_BLOCKED',
+        description:
+          'ADMINISTRATOR NOTICE: The query to URIBL was blocked. See http://wiki.apache.org/spamassassin/DnsBlocklists#dnsbl-block for more information. [URI: react-email-vercel-repro-n0vqufobp-felipefreitag-5792s-projects.vercel.app]',
+      },
+      {
+        pts: 0,
+        ruleName: 'HTML_MESSAGE',
+        description: 'BODY: HTML included in message',
+      },
+    ]);
+  });
+
+  test('skips unrecognizable lines that appear before any row', () => {
+    const partialSpamResponse = `
+ pts rule name              description
+---- ---------------------- --------------------------------------------------
+some stray line that is not a row
+ 1.8 MISSING_SUBJECT        Missing Subject: header`;
+
+    expect(parsePointingTableRows(partialSpamResponse)).toEqual([
+      {
+        pts: 1.8,
+        ruleName: 'MISSING_SUBJECT',
+        description: 'Missing Subject: header',
+      },
+    ]);
+  });
+
   test('works with a multiline description', () => {
     const partialSpamResponse = `â€Œâ [...]
 

--- a/apps/web/src/utils/spam-assassin/parse-pointing-table-rows.ts
+++ b/apps/web/src/utils/spam-assassin/parse-pointing-table-rows.ts
@@ -31,42 +31,33 @@ export const parsePointingTableRows = (response: string) => {
   for (const line of responseFromTableStart.split(/\r\n|\n|\r/)) {
     if (line.trim().length === 0) break;
 
-    const match = line.match(columnsRegex);
-
     // This means the description column was done with multi columns.
     if (currentRow && line.startsWith('  ')) {
       currentRow.description += ` ${line.trimStart()}`;
       continue;
     }
 
-    if (match?.groups === undefined) {
-      throw new Error('Could not match the columns in the row', {
-        cause: {
-          line,
-          match,
-        },
-      });
+    const match = line.match(columnsRegex);
+    const parsedPoints = match?.groups
+      ? Number.parseFloat(match.groups.pts!)
+      : Number.NaN;
+
+    // Lines that don't look like a row are wrapping artifacts — SpamAssassin
+    // word-wraps long descriptions (e.g. long URIs) at unpredictable indents.
+    if (match?.groups === undefined || Number.isNaN(parsedPoints)) {
+      if (currentRow) {
+        currentRow.description += ` ${line.trim()}`;
+      }
+      continue;
     }
-    const pts = match.groups.pts!;
-    const ruleName = match.groups.ruleName!.trim();
-    const description = match.groups.description!;
 
     if (currentRow) {
       rows.push(currentRow);
     }
-    const parsedPoints = Number.parseFloat(pts);
-    if (Number.isNaN(parsedPoints)) {
-      throw new Error('could not parse points to insert into rows array', {
-        cause: {
-          line,
-          match,
-        },
-      });
-    }
     currentRow = {
       pts: parsedPoints,
-      ruleName: ruleName.trim(),
-      description: description.trim(),
+      ruleName: match.groups.ruleName!.trim(),
+      description: match.groups.description!.trim(),
     };
   }
   if (currentRow) {

--- a/packages/ui/src/app/preview/[...slug]/page.tsx
+++ b/packages/ui/src/app/preview/[...slug]/page.tsx
@@ -102,24 +102,31 @@ This is most likely not an issue with the preview server. Maybe there was a typo
       }
     }
 
-    const response = await fetch('https://react.email/api/check-spam', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        html: serverEmailRenderingResult.prettyMarkup,
-        plainText: serverEmailRenderingResult.plainText,
-      }),
-    });
-    const responseBody = (await response.json()) as
-      | { error: string }
-      | SpamCheckingResult;
-    if ('error' in responseBody) {
-      throw new Error(`Failed doing Spam Check. ${responseBody.error}`, {
-        cause: responseBody,
+    try {
+      const response = await fetch('https://react.email/api/check-spam', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          html: serverEmailRenderingResult.prettyMarkup,
+          plainText: serverEmailRenderingResult.plainText,
+        }),
+        signal: AbortSignal.timeout(20_000),
       });
-    }
+      const responseBody = (await response.json()) as
+        | { error: string }
+        | SpamCheckingResult;
+      if ('error' in responseBody) {
+        throw new Error(responseBody.error);
+      }
 
-    spamCheckingResult = responseBody;
+      spamCheckingResult = responseBody;
+    } catch (exception) {
+      console.warn(
+        `Skipping spam check for ${slug}: ${
+          exception instanceof Error ? exception.message : String(exception)
+        }`,
+      );
+    }
   }
 
   return (


### PR DESCRIPTION
## Problem

During `email build`, every preview page is statically prerendered, and the page server component calls `https://react.email/api/check-spam` so the deployed app ships with a baked-in spam score. Any error response was rethrown — and a throw during prerendering is a fatal Next.js build error, so a failing spam check killed the entire build.

<img width="2248" height="704" alt="CleanShot 2026-07-02 at 17 52 15@2x" src="https://github.com/user-attachments/assets/8439b408-7e1c-4f9d-85e3-0234c59a8466" />

This is deterministic on Vercel with the stock `create-email` templates: `VERCEL_URL` (always a long `<project>-<hash>-<scope>.vercel.app` hostname) is interpolated into the templates' image URLs, and emails containing such hostnames make SpamAssassin word-wrap its report table in a way the API's column parser rejects (`Could not match the columns in the row`). The API returns an error, the prerender throws, and the deploy fails — for every project following the deployment docs.

Verified live: deploying the stock starter to Vercel fails on `/preview/plaid-verify-identity` with exactly this error, twice in a row, and `VERCEL_URL=<long-host>.vercel.app email build` reproduces it locally.

## Fix

Two independent layers:

- **`@react-email/ui`** — the build-time spam check is now non-fatal: failures (including a new 20s timeout) log a warning and the build continues without a baked-in result. The toolbar already handles an absent initial result and offers its own client-side re-check. A remote, cosmetic feature can no longer veto builds.
- **`web` (react.email API)** — the report parser no longer throws on lines that don't match the rule-table columns. SpamAssassin wraps long descriptions (e.g. long URIs) at unpredictable indents — this is the third wrap variant to break this parser (the spec already contains two earlier ones). Unrecognized lines are now treated as description continuations of the open row, or skipped. Regression tests were verified red against the old parser (both fail with the exact production error) and green against the fix.

## Verification

On a real Vercel project with the stock starter templates and the still-broken production API:

- before: build fails at prerender with `Failed doing Spam Check. Could not match the columns in the row`
- after (with the patched `@react-email/ui`): build logs `Skipping spam check` for each affected template, completes 8/8 pages, deploys, and all preview pages serve

Once react.email deploys the parser fix, the warnings disappear and deployed previews get their spam scores back.