### PR TITLE
fix: replace deprecated React form event types 

### DIFF
--- a/apps/web/src/components/send.tsx
+++ b/apps/web/src/components/send.tsx
@@ -22,7 +22,7 @@ export const Send = ({
   const [isSending, setIsSending] = React.useState(false);
   const [isPopOverOpen, setIsPopOverOpen] = React.useState(false);
 
-  const onFormSubmit = async (e: React.FormEvent) => {
+  const onFormSubmit = async (e: React.SubmitEvent<HTMLFormElement>) => {
     try {
       e.preventDefault();
       setIsSending(true);

--- a/packages/editor/src/ui/bubble-menu/button-form.tsx
+++ b/packages/editor/src/ui/bubble-menu/button-form.tsx
@@ -73,7 +73,7 @@ export function BubbleMenuButtonForm({
     return null;
   }
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  function handleSubmit(e: React.SubmitEvent<HTMLFormElement>) {
     e.preventDefault();
 
     const value = inputValue.trim();

--- a/packages/editor/src/ui/bubble-menu/button-form.tsx
+++ b/packages/editor/src/ui/bubble-menu/button-form.tsx
@@ -51,7 +51,7 @@ export function BubbleMenuButtonForm({
     const handleClickOutside = (event: MouseEvent) => {
       if (formRef.current && !formRef.current.contains(event.target as Node)) {
         const form = formRef.current;
-        const submitEvent = new Event('submit', {
+        const submitEvent = new SubmitEvent('submit', {
           bubbles: true,
           cancelable: true,
         });

--- a/packages/editor/src/ui/bubble-menu/image-form.tsx
+++ b/packages/editor/src/ui/bubble-menu/image-form.tsx
@@ -76,7 +76,7 @@ export function BubbleMenuImageForm({
     return null;
   }
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  function handleSubmit(e: React.SubmitEvent<HTMLFormElement>) {
     e.preventDefault();
 
     const value = inputValue.trim();

--- a/packages/editor/src/ui/bubble-menu/image-form.tsx
+++ b/packages/editor/src/ui/bubble-menu/image-form.tsx
@@ -54,7 +54,7 @@ export function BubbleMenuImageForm({
     const handleClickOutside = (event: MouseEvent) => {
       if (formRef.current && !formRef.current.contains(event.target as Node)) {
         const form = formRef.current;
-        const submitEvent = new Event('submit', {
+        const submitEvent = new SubmitEvent('submit', {
           bubbles: true,
           cancelable: true,
         });

--- a/packages/editor/src/ui/bubble-menu/link-form.tsx
+++ b/packages/editor/src/ui/bubble-menu/link-form.tsx
@@ -79,7 +79,7 @@ export function BubbleMenuLinkForm({
     return null;
   }
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  function handleSubmit(e: React.SubmitEvent<HTMLFormElement>) {
     e.preventDefault();
 
     const value = inputValue.trim();

--- a/packages/editor/src/ui/bubble-menu/link-form.tsx
+++ b/packages/editor/src/ui/bubble-menu/link-form.tsx
@@ -57,7 +57,7 @@ export function BubbleMenuLinkForm({
     const handleClickOutside = (event: MouseEvent) => {
       if (formRef.current && !formRef.current.contains(event.target as Node)) {
         const form = formRef.current;
-        const submitEvent = new Event('submit', {
+        const submitEvent = new SubmitEvent('submit', {
           bubbles: true,
           cancelable: true,
         });

--- a/packages/editor/src/ui/bubble-menu/link-selector.tsx
+++ b/packages/editor/src/ui/bubble-menu/link-selector.tsx
@@ -178,7 +178,7 @@ function LinkForm({
     };
   }, [editor, setIsOpen]);
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  function handleSubmit(e: React.SubmitEvent<HTMLFormElement>) {
     e.preventDefault();
 
     const value = inputValue.trim();

--- a/packages/editor/src/ui/bubble-menu/link-selector.tsx
+++ b/packages/editor/src/ui/bubble-menu/link-selector.tsx
@@ -160,7 +160,7 @@ function LinkForm({
     const handleClickOutside = (event: MouseEvent) => {
       if (formRef.current && !formRef.current.contains(event.target as Node)) {
         const form = formRef.current;
-        const submitEvent = new Event('submit', {
+        const submitEvent = new SubmitEvent('submit', {
           bubbles: true,
           cancelable: true,
         });

--- a/packages/ui/src/components/send.tsx
+++ b/packages/ui/src/components/send.tsx
@@ -34,7 +34,7 @@ export const Send = ({ markup, defaultSubject, storageKey }: SendProps) => {
   const [isSending, setIsSending] = useState(false);
   const [isPopOverOpen, setIsPopOverOpen] = useState(false);
 
-  const onFormSubmit = async (e: React.FormEvent) => {
+  const onFormSubmit = async (e: React.SubmitEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsSending(true);
 


### PR DESCRIPTION
## Overview

This change replaces deprecated `React.FormEvent` usages with the more specific `React.SubmitEvent<HTMLFormElement>` type for form submit handlers.

`React.FormEvent` is deprecated in the current React type definitions because there is no native DOM event named `FormEvent`. Since these handlers are attached to `<form onSubmit>`, `React.SubmitEvent<HTMLFormElement>` better represents the actual event type and removes the deprecation warning.

## Changes

- Updated form submit handlers in `apps/web`, `packages/ui`, and `packages/editor`.
- Replaced `React.FormEvent` / `React.FormEvent<HTMLFormElement>` with `React.SubmitEvent<HTMLFormElement>`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced deprecated React form event types with submit-specific types and aligned programmatic submit events. Removes TypeScript warnings and uses the correct `SubmitEvent` semantics for form submissions.

- **Bug Fixes**
  - Switched onSubmit handler types to `React.SubmitEvent<HTMLFormElement>` in `apps/web`, `packages/ui`, and editor bubble menu forms.
  - In `packages/editor` bubble menus, replaced `new Event('submit')` with `new SubmitEvent('submit', { bubbles: true, cancelable: true })`.

<sup>Written for commit 4682bc63de163eca3f14ce031aa279b9b021d967. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

