### PR TITLE
fix(render): make prettier an optional peer dependency

### DIFF
--- a/.changeset/render-optional-prettier.md
+++ b/.changeset/render-optional-prettier.md
@@ -1,0 +1,7 @@
+---
+"@react-email/render": patch
+---
+
+Make `prettier` an optional peer dependency of `@react-email/render`.
+
+`prettier` (~8MB) was a hard dependency but is only used when rendering with `pretty: true`, which is off by default. It is now an optional peer dependency and loaded lazily via a dynamic `import()` at the format call site. Consumers who already have `prettier` installed get identical output; those who never opt into pretty rendering no longer pay the install/bundle cost. If `pretty: true` is requested without `prettier` installed, `render` returns the (semantically identical) unformatted HTML instead of failing, logging a one-time warning.

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -119,12 +119,17 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "html-to-text": "^9.0.5",
-    "prettier": "^3.5.3"
+    "html-to-text": "^9.0.5"
   },
   "peerDependencies": {
+    "prettier": "^3.5.3",
     "react": "^18.0 || ^19.0 || ^19.0.0-rc",
     "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+  },
+  "peerDependenciesMeta": {
+    "prettier": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@edge-runtime/vm": "5.0.0",
@@ -134,6 +139,7 @@
     "@types/shelljs": "0.10.0",
     "jsdom": "26.1.0",
     "playwright": "1.59.1",
+    "prettier": "^3.5.3",
     "shelljs": "0.10.0",
     "tsconfig": "workspace:*",
     "typescript": "catalog:",

--- a/packages/render/src/shared/utils/pretty.ts
+++ b/packages/render/src/shared/utils/pretty.ts
@@ -1,7 +1,5 @@
 import type { Options, Plugin } from 'prettier';
 import type { builders } from 'prettier/doc';
-import * as html from 'prettier/plugins/html';
-import { format } from 'prettier/standalone';
 
 interface HtmlNode {
   type?: 'element' | 'text' | 'ieConditionalComment';
@@ -86,46 +84,95 @@ function recursivelyMapDoc(
   return callback(doc);
 }
 
-const modifiedHtml = { ...html } as Plugin;
-if (modifiedHtml.printers) {
-  const previousPrint = modifiedHtml.printers.html.print;
-  modifiedHtml.printers.html.print = (path, options, print, args) => {
-    const node = getHtmlNode(
-      path as Parameters<NonNullable<Plugin['printers']>['html']['print']>[0],
-    );
-
-    const rawPrintingResult = previousPrint(path, options, print, args);
-
-    if (
-      node?.type === 'ieConditionalComment' ||
-      node?.kind === 'ieConditionalComment'
-    ) {
-      const printingResult = recursivelyMapDoc(rawPrintingResult, (doc) => {
-        if (typeof doc === 'object' && doc.type === 'line') {
-          return doc.soft ? '' : ' ';
-        }
-
-        return doc;
-      });
-
-      return printingResult;
-    }
-
-    return rawPrintingResult;
-  };
+// prettier is an optional peer dependency. It is only needed when rendering with
+// `pretty: true` (off by default), so importing it unconditionally forced an
+// ~8MB dependency on every consumer, including backends that never prettify. We
+// load it lazily so it stays out of installs and bundles unless it is actually
+// installed and a caller opts into pretty output.
+interface LoadedPrettier {
+  format: typeof import('prettier/standalone').format;
+  defaults: Options;
 }
 
-const defaults: Options = {
-  endOfLine: 'lf',
-  tabWidth: 2,
-  plugins: [modifiedHtml],
-  bracketSameLine: true,
-  parser: 'html',
-};
+let loaded: LoadedPrettier | null | undefined;
+let warnedMissingPrettier = false;
 
-export const pretty = (str: string, options: Options = {}) => {
-  return format(str.replaceAll('\0', ''), {
-    ...defaults,
+async function loadPrettier(): Promise<LoadedPrettier | null> {
+  if (loaded !== undefined) {
+    return loaded;
+  }
+
+  try {
+    const [{ format }, html] = await Promise.all([
+      import('prettier/standalone'),
+      import('prettier/plugins/html'),
+    ]);
+
+    const modifiedHtml = { ...html } as Plugin;
+    if (modifiedHtml.printers) {
+      const previousPrint = modifiedHtml.printers.html.print;
+      modifiedHtml.printers.html.print = (path, options, print, args) => {
+        const node = getHtmlNode(
+          path as Parameters<
+            NonNullable<Plugin['printers']>['html']['print']
+          >[0],
+        );
+
+        const rawPrintingResult = previousPrint(path, options, print, args);
+
+        if (
+          node?.type === 'ieConditionalComment' ||
+          node?.kind === 'ieConditionalComment'
+        ) {
+          return recursivelyMapDoc(rawPrintingResult, (doc) => {
+            if (typeof doc === 'object' && doc.type === 'line') {
+              return doc.soft ? '' : ' ';
+            }
+
+            return doc;
+          });
+        }
+
+        return rawPrintingResult;
+      };
+    }
+
+    loaded = {
+      format,
+      defaults: {
+        endOfLine: 'lf',
+        tabWidth: 2,
+        plugins: [modifiedHtml],
+        bracketSameLine: true,
+        parser: 'html',
+      },
+    };
+  } catch {
+    loaded = null;
+  }
+
+  return loaded;
+}
+
+export const pretty = async (str: string, options: Options = {}) => {
+  const sanitized = str.replaceAll('\0', '');
+  const prettier = await loadPrettier();
+
+  // prettier is not installed: return the HTML unformatted (semantically
+  // identical, only cosmetic whitespace is skipped) and warn once so it is
+  // clear why `pretty` had no effect.
+  if (!prettier) {
+    if (!warnedMissingPrettier) {
+      warnedMissingPrettier = true;
+      console.warn(
+        '[@react-email/render] `pretty` was requested but `prettier` is not installed, so the HTML is returned unformatted. Install `prettier` to enable pretty output.',
+      );
+    }
+    return sanitized;
+  }
+
+  return prettier.format(sanitized, {
+    ...prettier.defaults,
     ...options,
   });
 };


### PR DESCRIPTION
Closes #3608.

`prettier` was a hard dependency of `@react-email/render` but is only used on the `pretty: true` path, which is off by default. This moves it to an optional peer dependency and lazily loads it with a dynamic import, so it no longer ships to consumers who never prettify.

Following @y-nk's outline on the issue (optional dep + dynamic import). One open call: when `pretty: true` is used without prettier installed, this returns the unformatted HTML and warns once (rather than throwing, since editor/ui call pretty() directly). I can make it a hard throw instead if that's preferred.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `prettier` optional in `@react-email/render` and load it only when `pretty: true` is used. This reduces install and bundle size for consumers who don’t prettify, with identical output when `prettier` is present.

- **Dependencies**
  - Moved `prettier` from `dependencies` to an optional `peerDependency` and kept it in `devDependencies` for this repo.
  - Dynamically import `prettier/standalone` and `prettier/plugins/html` only when `pretty: true` is requested.
  - If `pretty: true` is used without `prettier` installed, return unformatted HTML and log a one-time warning.
  - Formatting behavior is unchanged when `prettier` is installed (custom HTML printer tweaks are preserved).

<sup>Written for commit 6e25a1ad22aef0a418e6d76eae4db4b8a18e606f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

