### PR TITLE
fix(editor): keep focus scopes registered across plugin reconfigurations

### DIFF
--- a/.changeset/focus-scopes-survive-reconfiguration.md
+++ b/.changeset/focus-scopes-survive-reconfiguration.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+Fix bubble menus and the Inspector losing the editor selection on click. The `FocusScopes` registry was wiped on every plugin reconfiguration; it now persists until the plugin is removed or the editor is destroyed.

--- a/packages/editor/src/extensions/focus-scopes.spec.ts
+++ b/packages/editor/src/extensions/focus-scopes.spec.ts
@@ -1,4 +1,5 @@
 import { Editor, extensions as nativeTiptapExtensions } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { vi } from 'vitest';
 import { StarterKit } from '.';
 import { focusScopePluginKey } from './focus-scopes';
@@ -76,6 +77,79 @@ describe('FocusScopes', () => {
     expect(editor.state.selection.$from.parent.inlineContent).toBe(true);
 
     editor.destroy();
+    element.remove();
+    externalScope.remove();
+  });
+
+  it('keeps registered scopes across a plugin reconfiguration', async () => {
+    const { editor, element } = createEditor();
+    const externalScope = document.createElement('button');
+    document.body.append(externalScope);
+    await waitForCreate();
+
+    editor.extensionStorage.focusScope.registerScope(externalScope);
+    editor.commands.setTextSelection({ from: 2, to: 7 });
+    editor.view.dom.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+    editor.registerPlugin(
+      new Plugin({ key: new PluginKey('reconfigureProbe') }),
+    );
+
+    editor.view.dom.dispatchEvent(
+      new FocusEvent('focusout', {
+        bubbles: true,
+        relatedTarget: externalScope,
+      }),
+    );
+
+    expect(editor.isFocused).toBe(true);
+    expect(editor.state.selection.from).toBe(2);
+    expect(editor.state.selection.to).toBe(7);
+
+    editor.destroy();
+    element.remove();
+    externalScope.remove();
+  });
+
+  it('stops tracking focus once the plugin is unregistered', async () => {
+    const { editor, element } = createEditor();
+    await waitForCreate();
+
+    editor.commands.setTextSelection({ from: 2, to: 7 });
+    editor.view.dom.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    expect(editor.isFocused).toBe(true);
+
+    editor.unregisterPlugin(focusScopePluginKey);
+
+    editor.view.dom.dispatchEvent(
+      new FocusEvent('focusout', {
+        bubbles: true,
+        relatedTarget: document.body,
+      }),
+    );
+
+    expect(editor.isFocused).toBe(true);
+    expect(editor.state.selection.from).toBe(2);
+    expect(editor.state.selection.to).toBe(7);
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('cleans up scope registration when the editor is destroyed', async () => {
+    const { editor, element } = createEditor();
+    const externalScope = document.createElement('button');
+    document.body.append(externalScope);
+    await waitForCreate();
+
+    const storage = editor.extensionStorage.focusScope;
+    editor.destroy();
+
+    const addEventListener = vi.spyOn(externalScope, 'addEventListener');
+    storage.registerScope(externalScope);
+    expect(addEventListener).not.toHaveBeenCalled();
+
+    addEventListener.mockRestore();
     element.remove();
     externalScope.remove();
   });

--- a/packages/editor/src/extensions/focus-scopes.ts
+++ b/packages/editor/src/extensions/focus-scopes.ts
@@ -142,6 +142,17 @@ export function createFocusScopePlugin({
   storage.registerScope = registerScope;
   storage.unregisterScope = unregisterScope;
 
+  const cleanup = () => {
+    for (const scope of [...scopeRefs]) {
+      unregisterScope(scope);
+    }
+    storage.registerScope = noop;
+    storage.unregisterScope = noop;
+    editor.off('destroy', cleanup);
+  };
+
+  editor.on('destroy', cleanup);
+
   return new Plugin({
     key: focusScopePluginKey,
     view(view) {
@@ -151,11 +162,18 @@ export function createFocusScopePlugin({
 
       return {
         destroy() {
-          for (const scope of [...scopeRefs]) {
-            unregisterScope(scope);
-          }
-          storage.registerScope = noop;
-          storage.unregisterScope = noop;
+          // ProseMirror destroys plugin views on every reconfiguration, with
+          // view.state already pointing at the new state. Only clean up when
+          // this plugin was actually removed; editor destroy is handled by the
+          // 'destroy' event above (isDestroyed is still false at this point).
+          const stillRegistered =
+            !editor.isDestroyed &&
+            editor.state.plugins.some(
+              (plugin) => plugin.spec.key === focusScopePluginKey,
+            );
+          if (stillRegistered) return;
+
+          cleanup();
         },
       };
     },


### PR DESCRIPTION
## Summary

Fixes bubble menus and the Inspector losing the editor selection on click (#3603).

The `FocusScopes` plugin view wiped its entire scope registry in `destroy()`. ProseMirror destroys and recreates plugin views on **every** state reconfiguration, and bubble menus and slash commands register their plugins in mount effects — a reconfiguration that fires right after the `EditorFocusScope` refs registered the menu/Inspector elements. After mount, only the editor's own `view.dom` remained registered, so clicking any bubble-menu sub-control or Inspector field was treated as focus leaving the editor: the menu closed, the selection collapsed, and focus went to `<body>`.

## Changes

- The scope registry now survives reconfigurations. Full cleanup runs only when the plugin is actually removed from the editor state, or when the editor emits `destroy`.
- The cleanup intentionally doesn't rely on the `if (!editor.isDestroyed) return` guard suggested in the issue: ProseMirror destroys plugin views *before* `docView` is nulled, so `isDestroyed` is still `false` at that point and the guard would make cleanup unreachable (leaking listeners). The editor `destroy` event covers real teardown instead.
- Added regression tests: scopes survive a plugin reconfiguration (fails on the previous code), focus tracking stops when the plugin is unregistered, and scope registration is torn down on editor destroy.
- Added a changeset (patch).

## Testing

- `pnpm vitest run --project unit` in `packages/editor` → 496 passed / 1 skipped; `tsc --noEmit` and `biome check` clean.
- Reverting only the source (keeping the tests) makes the new reconfiguration test fail.
- Manually verified the issue's exact repro on the `apps/web` full-email-builder example in a real browser: the node-selector dropdown opens and applies without closing the bubble menu, the Inspector keeps the selection while its inputs are focused, and blur to elements outside all scopes still clears the selection as before.

Closes #3603

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes bubble menus and the Inspector losing the editor selection by keeping focus scopes registered across ProseMirror reconfigurations in `@react-email/editor`. Selection now stays while interacting with menu/Inspector controls.

- **Bug Fixes**
  - Keep the scope registry across reconfigs; only clean up when the plugin is actually removed or the editor is destroyed.
  - Use the editor `destroy` event for teardown; make register/unregister no-ops after cleanup to prevent re-adding scopes.
  - Add regression tests for reconfig survival, plugin unregistration behavior, and destroy cleanup.

<sup>Written for commit 2410fb1a8f1fd8418902693feb7915e2a0920a32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

