### PR TITLE
fix(tailwind): merge duplicate class rules across presets/plugins

### DIFF
--- a/.changeset/tailwind-merge-duplicate-class-rules.md
+++ b/.changeset/tailwind-merge-duplicate-class-rules.md
@@ -2,4 +2,4 @@
 "react-email": patch
 ---
 
-Merge declarations when the same class is defined by multiple Tailwind rules (e.g. a preset and a child config override) instead of keeping only the last rule, so the CSS cascade is preserved when inlining.
+Merge declarations when the same class is defined by multiple Tailwind rules (e.g. a preset and a child config override).

--- a/.changeset/tailwind-merge-duplicate-class-rules.md
+++ b/.changeset/tailwind-merge-duplicate-class-rules.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Merge declarations when the same class is defined by multiple Tailwind rules (e.g. a preset and a child config override) instead of keeping only the last rule, so the CSS cascade is preserved when inlining.

--- a/packages/react-email/src/components/tailwind/inline-styles.spec.ts
+++ b/packages/react-email/src/components/tailwind/inline-styles.spec.ts
@@ -1,0 +1,37 @@
+import { parse, type StyleSheet } from 'css-tree';
+import { inlineStyles } from './inline-styles.js';
+
+describe('inlineStyles()', () => {
+  it('inlines a single rule for a class', () => {
+    const styleSheet = parse(`
+      .box { border-radius: 8px; background-color: white; padding: 16px; }
+    `) as StyleSheet;
+
+    expect(inlineStyles(styleSheet, ['box'])).toMatchInlineSnapshot(`
+      {
+        "backgroundColor": "white",
+        "borderRadius": "8px",
+        "padding": "16px",
+      }
+    `);
+  });
+
+  it('merges declarations when the same class is defined across multiple rules', () => {
+    // Mirrors a Tailwind preset defining `.box` and a child config overriding
+    // only one property of the same class. CSS cascade keeps the untouched
+    // declarations from the earlier rule and lets the later rule win on
+    // conflicting properties.
+    const styleSheet = parse(`
+      .box { border-radius: 8px; background-color: white; padding: 16px; }
+      .box { background-color: red; }
+    `) as StyleSheet;
+
+    expect(inlineStyles(styleSheet, ['box'])).toMatchInlineSnapshot(`
+      {
+        "backgroundColor": "red",
+        "borderRadius": "8px",
+        "padding": "16px",
+      }
+    `);
+  });
+});

--- a/packages/react-email/src/components/tailwind/inline-styles.spec.ts
+++ b/packages/react-email/src/components/tailwind/inline-styles.spec.ts
@@ -17,10 +17,7 @@ describe('inlineStyles()', () => {
   });
 
   it('merges declarations when the same class is defined across multiple rules', () => {
-    // Mirrors a Tailwind preset defining `.box` and a child config overriding
-    // only one property of the same class. CSS cascade keeps the untouched
-    // declarations from the earlier rule and lets the later rule win on
-    // conflicting properties.
+    // Regression for #3628: a Tailwind preset and a child config both defining `.box`.
     const styleSheet = parse(`
       .box { border-radius: 8px; background-color: white; padding: 16px; }
       .box { background-color: red; }
@@ -36,9 +33,6 @@ describe('inlineStyles()', () => {
   });
 
   it("keeps a class's own cascade order when its rules are split by another class", () => {
-    // The two `.box` rules are interleaved with an unrelated `.other` rule.
-    // Collecting `.box`'s rules must not reorder them relative to the
-    // stylesheet, so the later `.box` declaration still wins.
     const styleSheet = parse(`
       .box { color: red; }
       .other { font-weight: bold; }

--- a/packages/react-email/src/components/tailwind/inline-styles.spec.ts
+++ b/packages/react-email/src/components/tailwind/inline-styles.spec.ts
@@ -34,4 +34,22 @@ describe('inlineStyles()', () => {
       }
     `);
   });
+
+  it("keeps a class's own cascade order when its rules are split by another class", () => {
+    // The two `.box` rules are interleaved with an unrelated `.other` rule.
+    // Collecting `.box`'s rules must not reorder them relative to the
+    // stylesheet, so the later `.box` declaration still wins.
+    const styleSheet = parse(`
+      .box { color: red; }
+      .other { font-weight: bold; }
+      .box { color: blue; }
+    `) as StyleSheet;
+
+    expect(inlineStyles(styleSheet, ['box', 'other'])).toMatchInlineSnapshot(`
+      {
+        "color": "blue",
+        "fontWeight": "bold",
+      }
+    `);
+  });
 });

--- a/packages/react-email/src/components/tailwind/inline-styles.ts
+++ b/packages/react-email/src/components/tailwind/inline-styles.ts
@@ -15,7 +15,7 @@ export function inlineStyles(
   const customProperties = getCustomProperties(styleSheet);
 
   return makeInlineStylesFor(
-    Array.from(inlinableRules.values()),
+    Array.from(inlinableRules.values()).flat(),
     customProperties,
   );
 }

--- a/packages/react-email/src/components/tailwind/tailwind.spec.tsx
+++ b/packages/react-email/src/components/tailwind/tailwind.spec.tsx
@@ -784,6 +784,42 @@ describe('Tailwind component', () => {
     });
   });
 
+  describe('with duplicate classes across presets and plugins', () => {
+    it('merges declarations from a preset and a child override for the same class', async () => {
+      const base: TailwindConfig = {
+        plugins: [
+          plugin(({ addComponents }) => {
+            addComponents({ '.box': { '@apply rounded-lg bg-white p-4': {} } });
+          }),
+        ],
+      };
+      const config: TailwindConfig = {
+        presets: [base],
+        plugins: [
+          plugin(({ addComponents }) => {
+            addComponents({ '.box': { '@apply bg-red-500': {} } });
+          }),
+        ],
+      };
+
+      const actualOutput = await render(
+        <Tailwind config={config}>
+          <div className="box">hi</div>
+        </Tailwind>,
+      ).then(pretty);
+
+      expect(actualOutput).toMatchInlineSnapshot(`
+        "<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+        <!--$-->
+        <div style="border-radius:0.5rem;background-color:rgb(251,44,54);padding:1rem">
+          hi
+        </div>
+        <!--/$-->
+        "
+      `);
+    });
+  });
+
   describe('with custom theme config', () => {
     it('supports custom colors', async () => {
       const config: TailwindConfig = {

--- a/packages/react-email/src/components/tailwind/tailwind.tsx
+++ b/packages/react-email/src/components/tailwind/tailwind.tsx
@@ -124,7 +124,7 @@ export function Tailwind({ children, config, theme, utility }: TailwindProps) {
   const nonInlineStyles: StyleSheet = {
     type: 'StyleSheet',
     children: new List<CssNode>().fromArray(
-      Array.from(nonInlinableRules.values()),
+      Array.from(nonInlinableRules.values()).flat(),
     ),
   };
   sanitizeNonInlinableRules(nonInlineStyles);

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
@@ -3,8 +3,12 @@ import { setupTailwind } from '../tailwindcss/setup-tailwind.js';
 import { extractRulesPerClass } from './extract-rules-per-class.js';
 
 describe('extractRulesPerClass()', async () => {
-  function convertToComparable(map: Map<string, Rule>): Record<string, string> {
-    return Object.fromEntries(map.entries().map(([k, v]) => [k, generate(v)]));
+  function convertToComparable(
+    map: Map<string, Rule[]>,
+  ): Record<string, string[]> {
+    return Object.fromEntries(
+      map.entries().map(([k, rules]) => [k, rules.map((rule) => generate(rule))]),
+    );
   }
 
   it('works with just inlinable utilities', async () => {
@@ -21,11 +25,41 @@ describe('extractRulesPerClass()', async () => {
 
     expect(convertToComparable(inlinable)).toMatchInlineSnapshot(`
       {
-        "bg-red-500": ".bg-red-500{background-color:var(--color-red-500)}",
-        "text-center": ".text-center{text-align:center}",
+        "bg-red-500": [
+          ".bg-red-500{background-color:var(--color-red-500)}",
+        ],
+        "text-center": [
+          ".text-center{text-align:center}",
+        ],
       }
     `);
     expect(convertToComparable(nonInlinable)).toMatchInlineSnapshot('{}');
+  });
+
+  it('keeps every rule when a class is defined more than once', async () => {
+    const tailwind = await setupTailwind({
+      config: {
+        plugins: [
+          {
+            handler: (api) => {
+              api.addComponents({
+                '.box': { '@apply rounded-lg bg-white p-4': {} },
+              });
+              api.addComponents({
+                '.box': { '@apply bg-red-500': {} },
+              });
+            },
+          },
+        ],
+      },
+    });
+    const classes = ['box'];
+    tailwind.addUtilities(classes);
+
+    const stylesheet = tailwind.getStyleSheet();
+    const { inlinable } = extractRulesPerClass(stylesheet, classes);
+
+    expect(inlinable.get('box')).toHaveLength(2);
   });
 
   it('handles non-inlinable utilities', async () => {
@@ -43,7 +77,9 @@ describe('extractRulesPerClass()', async () => {
     expect(convertToComparable(inlinable)).toMatchInlineSnapshot('{}');
     expect(convertToComparable(nonInlinable)).toMatchInlineSnapshot(`
       {
-        "lg:w-1/2": ".lg\\:w-1\\/2{@media (width>=64rem){width:calc(1/2*100%)}}",
+        "lg:w-1/2": [
+          ".lg\\:w-1\\/2{@media (width>=64rem){width:calc(1/2*100%)}}",
+        ],
       }
     `);
   });
@@ -66,14 +102,22 @@ describe('extractRulesPerClass()', async () => {
     );
     expect(convertToComparable(inlinable)).toMatchInlineSnapshot(`
       {
-        "bg-red-500": ".bg-red-500{background-color:var(--color-red-500)}",
-        "text-center": ".text-center{text-align:center}",
-        "w-full": ".w-full{width:100%}",
+        "bg-red-500": [
+          ".bg-red-500{background-color:var(--color-red-500)}",
+        ],
+        "text-center": [
+          ".text-center{text-align:center}",
+        ],
+        "w-full": [
+          ".w-full{width:100%}",
+        ],
       }
     `);
     expect(convertToComparable(nonInlinable)).toMatchInlineSnapshot(`
       {
-        "lg:w-1/2": ".lg\\:w-1\\/2{@media (width>=64rem){width:calc(1/2*100%)}}",
+        "lg:w-1/2": [
+          ".lg\\:w-1\\/2{@media (width>=64rem){width:calc(1/2*100%)}}",
+        ],
       }
     `);
   });
@@ -105,12 +149,16 @@ describe('extractRulesPerClass()', async () => {
 
     expect(convertToComparable(inlinable)).toMatchInlineSnapshot(`
       {
-        "text-body": ".text-body{color:green}",
+        "text-body": [
+          ".text-body{color:green}",
+        ],
       }
     `);
     expect(convertToComparable(nonInlinable)).toMatchInlineSnapshot(`
       {
-        "text-body": ".text-body{@media (width>=40rem){color:darkgreen}}",
+        "text-body": [
+          ".text-body{@media (width>=40rem){color:darkgreen}}",
+        ],
       }
     `);
   });
@@ -143,7 +191,9 @@ describe('extractRulesPerClass()', async () => {
     expect(convertToComparable(inlinable)).toMatchInlineSnapshot('{}');
     expect(convertToComparable(nonInlinable)).toMatchInlineSnapshot(`
       {
-        "btn": ".btn{&:hover{color:red}}",
+        "btn": [
+          ".btn{&:hover{color:red}}",
+        ],
       }
     `);
   });

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
@@ -7,7 +7,9 @@ describe('extractRulesPerClass()', async () => {
     map: Map<string, Rule[]>,
   ): Record<string, string[]> {
     return Object.fromEntries(
-      map.entries().map(([k, rules]) => [k, rules.map((rule) => generate(rule))]),
+      map
+        .entries()
+        .map(([k, rules]) => [k, rules.map((rule) => generate(rule))]),
     );
   }
 

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
@@ -61,7 +61,14 @@ describe('extractRulesPerClass()', async () => {
     const stylesheet = tailwind.getStyleSheet();
     const { inlinable } = extractRulesPerClass(stylesheet, classes);
 
-    expect(inlinable.get('box')).toHaveLength(2);
+    expect(convertToComparable(inlinable)).toMatchInlineSnapshot(`
+      {
+        "box": [
+          ".box{border-radius:var(--radius-lg);background-color:var(--color-white);padding:calc(var(--spacing)*4)}",
+          ".box{background-color:var(--color-red-500)}",
+        ],
+      }
+    `);
   });
 
   it('handles non-inlinable utilities', async () => {

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
@@ -12,7 +12,11 @@ export function extractRulesPerClass(root: CssNode, classes: string[]) {
   const inlinableRules = new Map<string, Rule[]>();
   const nonInlinableRules = new Map<string, Rule[]>();
 
-  const appendRule = (map: Map<string, Rule[]>, className: string, rule: Rule) => {
+  const appendRule = (
+    map: Map<string, Rule[]>,
+    className: string,
+    rule: Rule,
+  ) => {
     const existing = map.get(className);
     if (existing) {
       existing.push(rule);

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
@@ -5,8 +5,22 @@ import { splitMixedRule } from './split-mixed-rule.js';
 export function extractRulesPerClass(root: CssNode, classes: string[]) {
   const classSet = new Set(classes);
 
-  const inlinableRules = new Map<string, Rule>();
-  const nonInlinableRules = new Map<string, Rule>();
+  // A class can be targeted by more than one rule (e.g. a base preset and a
+  // child config both defining `.box`). We keep every matching rule, in
+  // document order, so the CSS cascade can be replayed when inlining instead
+  // of the last rule silently clobbering the earlier ones.
+  const inlinableRules = new Map<string, Rule[]>();
+  const nonInlinableRules = new Map<string, Rule[]>();
+
+  const appendRule = (map: Map<string, Rule[]>, className: string, rule: Rule) => {
+    const existing = map.get(className);
+    if (existing) {
+      existing.push(rule);
+    } else {
+      map.set(className, [rule]);
+    }
+  };
+
   walk(root, {
     visit: 'Rule',
     enter(rule) {
@@ -20,7 +34,7 @@ export function extractRulesPerClass(root: CssNode, classes: string[]) {
       if (isRuleInlinable(rule)) {
         for (const className of selectorClasses) {
           if (classSet.has(className)) {
-            inlinableRules.set(className, rule);
+            appendRule(inlinableRules, className, rule);
           }
         }
       } else {
@@ -28,10 +42,10 @@ export function extractRulesPerClass(root: CssNode, classes: string[]) {
         for (const className of selectorClasses) {
           if (!classSet.has(className)) continue;
           if (inlinablePart) {
-            inlinableRules.set(className, inlinablePart);
+            appendRule(inlinableRules, className, inlinablePart);
           }
           if (nonInlinablePart) {
-            nonInlinableRules.set(className, nonInlinablePart);
+            appendRule(nonInlinableRules, className, nonInlinablePart);
           }
         }
       }

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
@@ -5,10 +5,8 @@ import { splitMixedRule } from './split-mixed-rule.js';
 export function extractRulesPerClass(root: CssNode, classes: string[]) {
   const classSet = new Set(classes);
 
-  // A class can be targeted by more than one rule (e.g. a base preset and a
-  // child config both defining `.box`). We keep every matching rule, in
-  // document order, so the CSS cascade can be replayed when inlining instead
-  // of the last rule silently clobbering the earlier ones.
+  // A class can be defined by multiple rules (e.g. a preset and a child config
+  // override), so keep them all to merge instead of the last one clobbering.
   const inlinableRules = new Map<string, Rule[]>();
   const nonInlinableRules = new Map<string, Rule[]>();
 

--- a/packages/react-email/src/components/tailwind/utils/tailwindcss/clone-element-with-inlined-styles.ts
+++ b/packages/react-email/src/components/tailwind/utils/tailwindcss/clone-element-with-inlined-styles.ts
@@ -8,8 +8,8 @@ import { isComponent } from '../react/is-component.js';
 
 export function cloneElementWithInlinedStyles(
   element: React.ReactElement<EmailElementProps>,
-  inlinableRules: Map<string, Rule>,
-  nonInlinableRules: Map<string, Rule>,
+  inlinableRules: Map<string, Rule[]>,
+  nonInlinableRules: Map<string, Rule[]>,
   customProperties: CustomProperties,
 ) {
   const propsToOverwrite: Partial<EmailElementProps> = {};
@@ -21,13 +21,13 @@ export function cloneElementWithInlinedStyles(
 
     const rules: Rule[] = [];
     for (const className of classes) {
-      const rule = inlinableRules.get(className);
-      if (rule) {
-        rules.push(rule);
+      const classRules = inlinableRules.get(className);
+      if (classRules) {
+        rules.push(...classRules);
       }
       if (nonInlinableRules.has(className)) {
         residualClasses.push(className);
-      } else if (!rule) {
+      } else if (!classRules) {
         residualClasses.push(className);
       }
     }


### PR DESCRIPTION
Fixes #3628.

When the same class is defined by multiple Tailwind rules (e.g. a base preset and a child config override), only the last rule was inlined and the earlier declarations were dropped. Now all matching rules are kept in document order and merged, so the CSS cascade is preserved.

**Before:** `.box` → `background-color:rgb(251,44,54)`
**After:** `.box` → `border-radius:0.5rem;background-color:rgb(251,44,54);padding:1rem`

Tests added at the unit (`extract-rules-per-class`, `inline-styles`) and end-to-end (`tailwind.spec`) levels.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the CSS cascade when inlining Tailwind by merging duplicate class rules across presets/plugins. Earlier declarations are kept; later rules only override conflicts, and order is preserved even when rules are interleaved with other selectors.

- **Bug Fixes**
  - `extractRulesPerClass` now returns arrays of rules per class in document order to replay the cascade; `inlineStyles`, `cloneElementWithInlinedStyles`, and `Tailwind` flatten and apply all matching rules for inlinable and non-inlinable styles.
  - Tests: added unit tests for rule merging and interleaved order; updated snapshot helper to assert multiple rules per class; added e2e for preset overrides; included changeset for `react-email`.

- **Refactors**
  - Applied Biome formatting and trimmed internal comments (no functional changes).

<sup>Written for commit 77e10c23de4cbfcfddd768d18a146e9b8f99a663. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

