### PR TITLE
fix(react-email): resolve output file tracing root for nested-workspace monorepos

### DIFF
--- a/.changeset/vercel-nested-workspace-tracing-root.md
+++ b/.changeset/vercel-nested-workspace-tracing-root.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Fix `email build` computing the wrong output file tracing root in nested-workspace monorepos (e.g. a package one or more directories below the true repo root), which caused Vercel deploys to fail with an ENOENT error on the routes manifest.

--- a/packages/react-email/src/cli/commands/build.ts
+++ b/packages/react-email/src/cli/commands/build.ts
@@ -1,13 +1,13 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { getPackages } from '@manypkg/get-packages';
 import logSymbols from 'log-symbols';
 import { installDependencies, runScript } from 'nypm';
 import {
   type EmailsDirectory,
   getEmailsDirectoryMetadata,
 } from '../utils/get-emails-directory-metadata.js';
+import { getTracingRootDir } from '../utils/get-tracing-root-dir.js';
 import { getUiLocation } from '../utils/get-ui-location.js';
 import { registerSpinnerAutostopping } from '../utils/register-spinner-autostopping.js';
 import { createSpinner, stopSpinnerAndPersist } from '../utils/spinner.js';
@@ -25,16 +25,13 @@ const setNextEnvironmentVariablesForBuild = async (
   builtPreviewAppPath: string,
   usersProjectLocation: string,
 ) => {
-  let rootDir = 'userProjectLocation';
-  if (isInReactEmailMonorepo) {
-    rootDir = `'${await getPackages(usersProjectLocation).then((p) => p.rootDir.replaceAll('\\', '/'))}'`;
-  }
+  const rootDir = await getTracingRootDir(usersProjectLocation);
   const nextConfigContents = `
 import path from 'path';
 const emailsDirRelativePath = path.normalize('${emailsDirRelativePath}');
 const userProjectLocation = '${process.cwd().replaceAll('\\', '/')}';
 const previewServerLocation = '${builtPreviewAppPath.replaceAll('\\', '/')}';
-const rootDir = ${rootDir};
+const rootDir = '${rootDir}';
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   env: {

--- a/packages/react-email/src/cli/utils/get-tracing-root-dir.spec.ts
+++ b/packages/react-email/src/cli/utils/get-tracing-root-dir.spec.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getTracingRootDir } from './get-tracing-root-dir.js';
+
+const mkTempDir = () =>
+  fs.mkdtempSync(path.join(os.tmpdir(), 'get-tracing-root-dir-'));
+
+const writeJson = (filePath: string, contents: unknown) =>
+  fs.writeFileSync(filePath, JSON.stringify(contents));
+
+test('resolves to the project directory itself for a standalone package', async () => {
+  const projectDir = mkTempDir();
+  writeJson(path.join(projectDir, 'package.json'), { name: 'standalone' });
+
+  expect(await getTracingRootDir(projectDir)).toBe(
+    projectDir.replaceAll('\\', '/'),
+  );
+
+  fs.rmSync(projectDir, { recursive: true });
+});
+
+test('resolves to the workspace root for a package nested inside a pnpm workspace', async () => {
+  const repoRoot = mkTempDir();
+  const packageDir = path.join(repoRoot, 'packages', 'transactional');
+  fs.mkdirSync(packageDir, { recursive: true });
+
+  writeJson(path.join(repoRoot, 'package.json'), { name: 'monorepo-root' });
+  fs.writeFileSync(
+    path.join(repoRoot, 'pnpm-workspace.yaml'),
+    'packages:\n  - "packages/*"\n',
+  );
+  writeJson(path.join(packageDir, 'package.json'), { name: 'transactional' });
+
+  expect(await getTracingRootDir(packageDir)).toBe(
+    repoRoot.replaceAll('\\', '/'),
+  );
+
+  fs.rmSync(repoRoot, { recursive: true });
+});
+
+test('falls back to the project directory when no package.json can be found', async () => {
+  const projectDir = fs.realpathSync(mkTempDir());
+
+  expect(await getTracingRootDir(projectDir)).toBe(
+    projectDir.replaceAll('\\', '/'),
+  );
+
+  fs.rmSync(projectDir, { recursive: true });
+});

--- a/packages/react-email/src/cli/utils/get-tracing-root-dir.ts
+++ b/packages/react-email/src/cli/utils/get-tracing-root-dir.ts
@@ -1,0 +1,13 @@
+import { getPackages } from '@manypkg/get-packages';
+
+// Walks up from `usersProjectLocation` to the true workspace root (Yarn/npm/pnpm/Bolt/Lerna/Rush),
+// falling back to the nearest package.json, so nested monorepo packages trace files from the real
+// repo root instead of their own package directory.
+export const getTracingRootDir = async (usersProjectLocation: string) => {
+  try {
+    const { rootDir } = await getPackages(usersProjectLocation);
+    return rootDir.replaceAll('\\', '/');
+  } catch {
+    return usersProjectLocation.replaceAll('\\', '/');
+  }
+};

--- a/packages/react-email/src/cli/utils/tree.spec.ts
+++ b/packages/react-email/src/cli/utils/tree.spec.ts
@@ -20,6 +20,8 @@ test('tree(__dirname, 2)', async () => {
     ├── email-clients.ts
     ├── get-emails-directory-metadata.spec.ts
     ├── get-emails-directory-metadata.ts
+    ├── get-tracing-root-dir.spec.ts
+    ├── get-tracing-root-dir.ts
     ├── get-ui-location.ts
     ├── index.ts
     ├── packageJson.ts


### PR DESCRIPTION
## Summary

- `email build` only used `getPackages()` to find the true monorepo root when the CLI itself was running from source (`isInReactEmailMonorepo`). For real installs (npm/pnpm/yarn), that's always false, so `outputFileTracingRoot`/`turbopack.root` fell back to the invoking package's own directory instead of the workspace root.
- This breaks Vercel deploys when `email build` runs inside a package nested one or more levels below the actual repo root (e.g. `packages/transactional` in a Turborepo/Nx + npm/pnpm/yarn workspace) — exactly the layout react-email's own docs recommend (`getting-started/monorepo-setup/*`). The deploy fails with `ENOENT: ... routes-manifest(-deterministic).json`.
- Fix: always resolve the tracing root via `getPackages()` (now extracted into `getTracingRootDir`), falling back to the project's own directory if it throws. Standalone (non-monorepo) projects are unaffected since `getPackages` resolves to the same directory in that case.
- Verified end-to-end on real Vercel infrastructure: deployed a nested-workspace repro repo with the same project settings reported in the issue (Root Directory = `packages/transactional`, Build Command = `turbo run build --filter=transactional`, Output Directory = `.react-email/.next`) — pre-fix reproduced the exact reported error (`ENOENT: ... /vercel/path0/.react-email/.next/routes-manifest-deterministic.json`), post-fix deployed successfully.

Closes #3623 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `email build` resolving the wrong tracing root in nested-workspace monorepos, preventing Vercel failures for packages below the repo root. Builds now trace from the actual workspace root across npm/yarn/pnpm setups.

- **Bug Fixes**
  - Always resolve the tracing root with `@manypkg/get-packages` via `getTracingRootDir`, falling back to the project directory if needed (standalone projects unaffected).
  - Inject the resolved root into Next config (`outputFileTracingRoot`/`turbopack.root`) during build.
  - Add tests for standalone and pnpm-workspace cases and update the utils tree; verified successful deploys on Vercel with a nested workspace layout.

<sup>Written for commit 709d5023e09046b8af390f80ed2ae689e5f4ca3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

