### PR TITLE
fix(preview): avoid OOM when hot-reloading a shared component

### DIFF
--- a/.changeset/hot-reload-shared-component-oom.md
+++ b/.changeset/hot-reload-shared-component-oom.md
@@ -1,0 +1,5 @@
+---
+"@react-email/ui": patch
+---
+
+Fix out-of-memory crashes when saving a shared component during `email dev`. Hot reload now re-renders only the preview you have open and invalidates the cache for the other affected templates, instead of eagerly re-rendering every dependent template on each save.

--- a/packages/ui/src/actions/render-email-by-path.spec.ts
+++ b/packages/ui/src/actions/render-email-by-path.spec.ts
@@ -1,6 +1,10 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { renderEmailByPath } from './render-email-by-path';
+import {
+  invalidateEmailRenderingCache,
+  renderEmailByPath,
+} from './render-email-by-path';
 
 describe('renderEmailByPath() with raw .html templates', () => {
   const emailsRoot = path.resolve(__dirname, '../utils/testing');
@@ -65,5 +69,64 @@ describe('renderEmailByPath() with raw .html templates', () => {
     );
 
     expect('error' in result).toBe(true);
+  });
+});
+
+describe('invalidateEmailRenderingCache()', () => {
+  const emailsRoot = path.resolve(__dirname, '../utils/testing');
+  const temporaryHtmlPath = path.join(
+    emailsRoot,
+    '.invalidate-cache-email.html',
+  );
+
+  let previousEnvValue: string | undefined;
+
+  beforeAll(() => {
+    previousEnvValue =
+      process.env.REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH;
+    process.env.REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH = emailsRoot;
+  });
+
+  afterAll(() => {
+    if (previousEnvValue === undefined) {
+      delete process.env.REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH;
+    } else {
+      process.env.REACT_EMAIL_INTERNAL_EMAILS_DIR_ABSOLUTE_PATH =
+        previousEnvValue;
+    }
+    if (fs.existsSync(temporaryHtmlPath)) {
+      fs.rmSync(temporaryHtmlPath);
+    }
+  });
+
+  const markupOf = (result: Awaited<ReturnType<typeof renderEmailByPath>>) => {
+    if ('error' in result) throw new Error(result.error.message);
+    return result.markup;
+  };
+
+  it('drops the cached render so the next render reflects new content', async () => {
+    fs.writeFileSync(temporaryHtmlPath, '<h1>first</h1>', 'utf-8');
+    // Populate the cache (first render).
+    expect(markupOf(await renderEmailByPath(temporaryHtmlPath))).toContain(
+      'first',
+    );
+
+    fs.writeFileSync(temporaryHtmlPath, '<h1>second</h1>', 'utf-8');
+    // Without invalidation the cached (stale) markup is returned.
+    expect(markupOf(await renderEmailByPath(temporaryHtmlPath))).toContain(
+      'first',
+    );
+
+    await invalidateEmailRenderingCache(temporaryHtmlPath);
+    // After invalidation the next render re-reads the file.
+    expect(markupOf(await renderEmailByPath(temporaryHtmlPath))).toContain(
+      'second',
+    );
+  });
+
+  it('is a no-op for paths outside the configured emails directory', async () => {
+    await expect(
+      invalidateEmailRenderingCache('/etc/passwd'),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/ui/src/actions/render-email-by-path.tsx
+++ b/packages/ui/src/actions/render-email-by-path.tsx
@@ -47,6 +47,11 @@ export type EmailRenderingResult =
 
 const cache = new Map<string, EmailRenderingResult>();
 
+export const invalidateEmailRenderingCache = async (emailPath: string) => {
+  if (!isPathWithinEmailsDirectory(emailPath)) return;
+  cache.delete(emailPath);
+};
+
 const createLogBufferer = (
   originalLogger: (...args: any[]) => void,
   overwriteLogger: (logger: (...args: any[]) => void) => void,

--- a/packages/ui/src/hooks/use-email-rendering-result.ts
+++ b/packages/ui/src/hooks/use-email-rendering-result.ts
@@ -2,11 +2,12 @@ import { useState } from 'react';
 import { getEmailPathFromSlug } from '../actions/get-email-path-from-slug';
 import {
   type EmailRenderingResult,
+  invalidateEmailRenderingCache,
   renderEmailByPath,
 } from '../actions/render-email-by-path';
 import { isBuilding, isPreviewDevelopment } from '../app/env';
 import { useEmails } from '../contexts/emails';
-import { containsEmailTemplate } from '../utils/contains-email-template';
+import { planHotReloadRerender } from '../utils/plan-hot-reload-rerender';
 import { useHotreload } from './use-hot-reload';
 
 export const useEmailRenderingResult = (
@@ -21,37 +22,19 @@ export const useEmailRenderingResult = (
 
   if (!isBuilding && !isPreviewDevelopment) {
     useHotreload(async (changes) => {
-      for await (const change of changes) {
-        const relativePathForChangedFile =
-          // ex: apple-receipt.tsx
-          // it will be the path relative to the emails directory, so it is already
-          // going to be equivalent to the slug
-          change.filename;
+      const { pathToRerender, pathsToInvalidate } = await planHotReloadRerender(
+        changes,
+        emailPath,
+        emailsDirectoryMetadata,
+        getEmailPathFromSlug,
+      );
 
-        if (
-          !containsEmailTemplate(
-            relativePathForChangedFile,
-            emailsDirectoryMetadata,
-          )
-        ) {
-          continue;
-        }
+      for (const staleEmailPath of pathsToInvalidate) {
+        await invalidateEmailRenderingCache(staleEmailPath);
+      }
 
-        const pathForChangedEmail = await getEmailPathFromSlug(
-          relativePathForChangedFile,
-        );
-        if (!pathForChangedEmail) {
-          continue;
-        }
-
-        const newRenderingResult = await renderEmailByPath(
-          pathForChangedEmail,
-          true,
-        );
-
-        if (pathForChangedEmail === emailPath) {
-          setRenderingResult(newRenderingResult);
-        }
+      if (pathToRerender) {
+        setRenderingResult(await renderEmailByPath(pathToRerender, true));
       }
     });
   }

--- a/packages/ui/src/utils/plan-hot-reload-rerender.spec.ts
+++ b/packages/ui/src/utils/plan-hot-reload-rerender.spec.ts
@@ -1,0 +1,86 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { EmailsDirectory } from './get-emails-directory-metadata';
+import { planHotReloadRerender } from './plan-hot-reload-rerender';
+import type { HotReloadChange } from './types/hot-reload-change';
+
+const emailsDir = path.resolve('/emails');
+
+const metadata: EmailsDirectory = {
+  absolutePath: emailsDir,
+  relativePath: '',
+  directoryName: 'emails',
+  emailFilenames: ['email-001', 'email-002', 'email-003', 'email-004'],
+  subDirectories: [],
+};
+
+const resolveEmailPathFromSlug = async (slug: string) =>
+  path.join(emailsDir, slug);
+
+const pathOf = (filename: string) => path.join(emailsDir, filename);
+
+// Mirrors what the CLI watcher emits when a shared component under `_components`
+// is saved: the component itself plus one change per dependent template.
+const sharedComponentSaveChanges: HotReloadChange[] = [
+  { event: 'change', filename: '_components/button.tsx' },
+  { event: 'change', filename: 'email-001.tsx' },
+  { event: 'change', filename: 'email-002.tsx' },
+  { event: 'change', filename: 'email-003.tsx' },
+  { event: 'change', filename: 'email-004.tsx' },
+];
+
+describe('planHotReloadRerender()', () => {
+  it('re-renders only the open preview and invalidates the other dependents', async () => {
+    const { pathToRerender, pathsToInvalidate } = await planHotReloadRerender(
+      sharedComponentSaveChanges,
+      pathOf('email-001.tsx'),
+      metadata,
+      resolveEmailPathFromSlug,
+    );
+
+    expect(pathToRerender).toBe(pathOf('email-001.tsx'));
+    expect(pathsToInvalidate).toEqual([
+      pathOf('email-002.tsx'),
+      pathOf('email-003.tsx'),
+      pathOf('email-004.tsx'),
+    ]);
+  });
+
+  it('ignores changes that are not email templates (the shared component itself)', async () => {
+    const { pathToRerender, pathsToInvalidate } = await planHotReloadRerender(
+      [{ event: 'change', filename: '_components/button.tsx' }],
+      pathOf('email-001.tsx'),
+      metadata,
+      resolveEmailPathFromSlug,
+    );
+
+    expect(pathToRerender).toBeNull();
+    expect(pathsToInvalidate).toEqual([]);
+  });
+
+  it('does not re-render anything when the open preview is unaffected', async () => {
+    const { pathToRerender, pathsToInvalidate } = await planHotReloadRerender(
+      [{ event: 'change', filename: 'email-002.tsx' }],
+      pathOf('email-001.tsx'),
+      metadata,
+      resolveEmailPathFromSlug,
+    );
+
+    expect(pathToRerender).toBeNull();
+    expect(pathsToInvalidate).toEqual([pathOf('email-002.tsx')]);
+  });
+
+  it('deduplicates repeated changes for the same template', async () => {
+    const { pathsToInvalidate } = await planHotReloadRerender(
+      [
+        { event: 'change', filename: 'email-002.tsx' },
+        { event: 'change', filename: 'email-002.tsx' },
+      ],
+      pathOf('email-001.tsx'),
+      metadata,
+      resolveEmailPathFromSlug,
+    );
+
+    expect(pathsToInvalidate).toEqual([pathOf('email-002.tsx')]);
+  });
+});

--- a/packages/ui/src/utils/plan-hot-reload-rerender.ts
+++ b/packages/ui/src/utils/plan-hot-reload-rerender.ts
@@ -1,0 +1,50 @@
+import { containsEmailTemplate } from './contains-email-template';
+import type { EmailsDirectory } from './get-emails-directory-metadata';
+import type { HotReloadChange } from './types/hot-reload-change';
+
+export interface HotReloadRerenderPlan {
+  pathToRerender: string | null;
+  // Only their stale cache is dropped, not re-rendered here: eagerly rendering
+  // every dependent of a shared component is what exhausts the Node heap.
+  pathsToInvalidate: string[];
+}
+
+export const planHotReloadRerender = async (
+  changes: HotReloadChange[],
+  currentEmailPath: string,
+  emailsDirectoryMetadata: EmailsDirectory,
+  resolveEmailPathFromSlug: (slug: string) => Promise<string | undefined>,
+): Promise<HotReloadRerenderPlan> => {
+  let pathToRerender: string | null = null;
+  const pathsToInvalidate: string[] = [];
+
+  for (const change of changes) {
+    // ex: apple-receipt.tsx — the path relative to the emails directory, which
+    // is equivalent to the slug.
+    const relativePathForChangedFile = change.filename;
+
+    if (
+      !containsEmailTemplate(
+        relativePathForChangedFile,
+        emailsDirectoryMetadata,
+      )
+    ) {
+      continue;
+    }
+
+    const pathForChangedEmail = await resolveEmailPathFromSlug(
+      relativePathForChangedFile,
+    );
+    if (!pathForChangedEmail) {
+      continue;
+    }
+
+    if (pathForChangedEmail === currentEmailPath) {
+      pathToRerender = pathForChangedEmail;
+    } else if (!pathsToInvalidate.includes(pathForChangedEmail)) {
+      pathsToInvalidate.push(pathForChangedEmail);
+    }
+  }
+
+  return { pathToRerender, pathsToInvalidate };
+};


### PR DESCRIPTION
Closes #3612.

Saving a component imported by many templates during `email dev` made the open preview re-render **every** dependent template server-side — even with a single preview page open — discarding all but the one being viewed and retaining each render's markup in the module-level cache. With enough templates or heavy markup, repeated saves exhausted the Node heap (`FATAL ERROR: Ineffective mark-compacts near heap limit`).

The CLI watcher correctly emits a change for the edited file plus every transitive dependent so clients know which previews went stale. The bug was on the client: `useEmailRenderingResult` rendered all of them.

Hot reload now re-renders only the currently-open preview and merely **invalidates** the cache for the other affected templates, so they re-render lazily and fresh on next navigation. This collapses N renders → 1 per open preview and keeps the cache bounded, with no staleness regression on navigation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OOM crashes during hot reload when saving a shared component in `email dev`. We now re-render only the open preview and invalidate caches for other affected templates to keep memory bounded. Fixes #3612.

- **Bug Fixes**
  - Update `useEmailRenderingResult` to re-render the current preview only; mark other impacted templates stale for lazy re-render on navigation.
  - Add `planHotReloadRerender` to pick a single rerender and a deduped set to invalidate; ignore non-template changes.
  - Add `invalidateEmailRenderingCache` (with tests) to drop stale markup; no-op for paths outside the emails directory; prevents unbounded render cache growth.

<sup>Written for commit 47e7652d6f8053c1e91c77a76478dd657aa58348. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

