### PR TITLE
fix(render): stop relying on html-to-text for default plain text conversion

### DIFF
--- a/.changeset/plain-text-stale-dep.md
+++ b/.changeset/plain-text-stale-dep.md
@@ -1,0 +1,5 @@
+---
+"@react-email/render": patch
+---
+
+Stop relying on the unmaintained `html-to-text` package for the default plain text conversion. `plainText: true` now converts through a small hast-based walker (`hast-util-from-html`) that reproduces the previous output: images and `data-skip-in-text="true"` elements are skipped, headings are uppercased, and link hrefs are appended without brackets unless they match the link text. Passing `htmlToTextOptions` still routes through `html-to-text` so existing behavior is unchanged; that option is now deprecated and scheduled for removal in the next major, which will drop the stale dependency entirely.

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -119,6 +119,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
+    "hast-util-from-html": "^2.0.3",
     "html-to-text": "^9.0.5",
     "prettier": "^3.5.3"
   },
@@ -128,6 +129,7 @@
   },
   "devDependencies": {
     "@edge-runtime/vm": "5.0.0",
+    "@types/hast": "^3.0.4",
     "@types/html-to-text": "9.0.4",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",

--- a/packages/render/src/shared/options.ts
+++ b/packages/render/src/shared/options.ts
@@ -23,6 +23,10 @@ export type Options = {
        * These are options you can pass down directly to the library we use for
        * converting the rendered email's HTML into plain text.
        *
+       * @deprecated Plain text conversion no longer relies on the unmaintained
+       * `html-to-text` package unless these options are passed. This escape
+       * hatch will be removed in the next major version.
+       *
        * @see https://github.com/html-to-text/node-html-to-text
        */
       htmlToTextOptions?: HtmlToTextOptions;

--- a/packages/render/src/shared/utils/to-plain-text-parity.spec.ts
+++ b/packages/render/src/shared/utils/to-plain-text-parity.spec.ts
@@ -1,0 +1,39 @@
+import { convert } from 'html-to-text';
+import { plainTextSelectors, toPlainText } from './to-plain-text';
+
+/**
+ * The default conversion path no longer goes through `html-to-text` (#2961).
+ * These cases pin the new implementation to the output of the old one for
+ * email-realistic HTML, so the deprecated options path can be removed in the
+ * next major without a behavior change for callers that never passed options.
+ */
+const legacyConvert = (html: string) =>
+  convert(html, { wordwrap: false, selectors: plainTextSelectors });
+
+const cases: Record<string, string> = {
+  headings:
+    '<h1>Welcome, Jim!</h1><p>Thanks for trying our product.</p><h2>Next steps</h2><p>Verify your email.</p>',
+  'nested tables (Section/Row/Column output)':
+    '<table><tbody><tr><td><table><tbody><tr><td><p>Inside a nested cell</p></td></tr></tbody></table></td></tr></tbody></table>',
+  'link with different text':
+    '<p>Click <a href="https://example.com/verify">here</a> to verify.</p>',
+  'link with same text':
+    '<p>Visit <a href="https://example.com">https://example.com</a> today.</p>',
+  'skipped image': '<p>Before</p><img src="cat.jpg" alt="A cat"><p>After</p>',
+  'skipped data attribute':
+    '<p>Shown</p><span data-skip-in-text="true">Preview text</span><p>Also shown</p>',
+  'line breaks': '<p>First line<br>Second line</p>',
+  'whitespace collapsing':
+    '<p>  Multiple   spaces\n\tand newlines  </p><p> Around blocks </p>',
+  entities: '<p>Ampersand &amp; angle &lt;brackets&gt; and&nbsp;nbsp</p>',
+  'full document':
+    '<!DOCTYPE html><html><head><title>Ignored</title><style>p{color:red}</style></head><body><h1>Hello</h1><p>Body text.</p></body></html>',
+};
+
+describe('plain text parity with the deprecated html-to-text path', () => {
+  for (const [name, html] of Object.entries(cases)) {
+    it(name, () => {
+      expect(toPlainText(html)).toBe(legacyConvert(html));
+    });
+  }
+});

--- a/packages/render/src/shared/utils/to-plain-text.ts
+++ b/packages/render/src/shared/utils/to-plain-text.ts
@@ -1,3 +1,5 @@
+import type { Element, ElementContent, Root } from 'hast';
+import { fromHtml } from 'hast-util-from-html';
 import {
   convert,
   type HtmlToTextOptions,
@@ -13,10 +15,187 @@ export const plainTextSelectors: SelectorDefinition[] = [
   },
 ];
 
+const SKIPPED_TAGS = new Set([
+  'head',
+  'link',
+  'meta',
+  'noscript',
+  'script',
+  'style',
+  'template',
+  'title',
+  'img',
+]);
+
+const HEADING_TAGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+
+/**
+ * Line breaks that surround each block-level tag, mirroring the defaults of
+ * `html-to-text` (its `leadingLineBreaks`/`trailingLineBreaks` per block).
+ * Between two blocks the larger of the two adjacent values wins.
+ */
+const BLOCK_BREAKS: Record<string, { leading: number; trailing: number }> = {
+  address: { leading: 2, trailing: 2 },
+  article: { leading: 2, trailing: 2 },
+  aside: { leading: 2, trailing: 2 },
+  blockquote: { leading: 2, trailing: 2 },
+  div: { leading: 1, trailing: 1 },
+  figure: { leading: 2, trailing: 2 },
+  footer: { leading: 2, trailing: 2 },
+  h1: { leading: 3, trailing: 2 },
+  h2: { leading: 3, trailing: 2 },
+  h3: { leading: 3, trailing: 2 },
+  h4: { leading: 2, trailing: 2 },
+  h5: { leading: 2, trailing: 2 },
+  h6: { leading: 2, trailing: 2 },
+  header: { leading: 2, trailing: 2 },
+  hr: { leading: 2, trailing: 2 },
+  main: { leading: 2, trailing: 2 },
+  nav: { leading: 2, trailing: 2 },
+  ol: { leading: 2, trailing: 2 },
+  p: { leading: 2, trailing: 2 },
+  pre: { leading: 2, trailing: 2 },
+  section: { leading: 2, trailing: 2 },
+  table: { leading: 2, trailing: 2 },
+  ul: { leading: 2, trailing: 2 },
+};
+
+type Chunk = { break: number } | { text: string };
+
+class PlainTextBuilder {
+  private chunks: Chunk[] = [];
+
+  addBreak(count: number): void {
+    const last = this.chunks[this.chunks.length - 1];
+    if (last && 'break' in last) {
+      last.break = Math.max(last.break, count);
+    } else {
+      this.chunks.push({ break: count });
+    }
+  }
+
+  addText(text: string, preformatted = false): void {
+    const collapsed = preformatted ? text : text.replace(/[ \t\r\n\f]+/g, ' ');
+    if (collapsed.length === 0 || (!preformatted && collapsed === ' ')) {
+      // Whitespace-only inline text collapses into block spacing rather than
+      // producing stray space-only lines.
+      if (/[ \t\r\n\f]/.test(text)) this.pendingSpace = true;
+      return;
+    }
+    const last = this.chunks[this.chunks.length - 1];
+    const space = this.pendingSpace && last && 'text' in last ? ' ' : '';
+    this.pendingSpace = false;
+    if (last && 'text' in last) {
+      last.text += space + collapsed;
+    } else {
+      this.chunks.push({ text: collapsed.replace(/^[ \t\r\n\f]+/, '') });
+    }
+  }
+
+  private pendingSpace = false;
+
+  toString(): string {
+    let out = '';
+    for (const [i, chunk] of this.chunks.entries()) {
+      if ('break' in chunk) {
+        if (i > 0 && i < this.chunks.length - 1) {
+          out = out.replace(/[ \t]+$/, '');
+          out += '\n'.repeat(chunk.break);
+        }
+      } else {
+        out += chunk.text;
+      }
+    }
+    return out.trim();
+  }
+}
+
+function elementText(node: ElementContent): string {
+  if (node.type === 'text') return node.value;
+  if (node.type === 'element')
+    return node.children.map(elementText).join('');
+  return '';
+}
+
+function walk(
+  nodes: ElementContent[],
+  builder: PlainTextBuilder,
+  context: { uppercase: boolean; preformatted: boolean },
+): void {
+  for (const node of nodes) {
+    if (node.type === 'text') {
+      const value = context.uppercase ? node.value.toUpperCase() : node.value;
+      builder.addText(value, context.preformatted);
+      continue;
+    }
+    if (node.type !== 'element') continue;
+    const element: Element = node;
+    const tag = element.tagName;
+
+    if (SKIPPED_TAGS.has(tag)) continue;
+    if (element.properties['dataSkipInText'] === 'true') continue;
+
+    if (tag === 'br') {
+      builder.addBreak(1);
+      continue;
+    }
+
+    const block = BLOCK_BREAKS[tag];
+    if (block) builder.addBreak(block.leading);
+
+    if (tag === 'hr') {
+      builder.addText('-'.repeat(40));
+    } else if (tag === 'a') {
+      walk(element.children, builder, context);
+      const href = element.properties.href;
+      const text = elementText(element).replace(/[ \t\r\n\f]+/g, ' ').trim();
+      if (
+        typeof href === 'string' &&
+        href.length > 0 &&
+        !href.startsWith('#') &&
+        href !== text
+      ) {
+        builder.addText(` ${href.startsWith('mailto:') ? href.slice(7) : href}`);
+      }
+    } else {
+      walk(element.children, builder, {
+        uppercase: context.uppercase || HEADING_TAGS.has(tag),
+        preformatted: context.preformatted || tag === 'pre',
+      });
+    }
+
+    if (block) builder.addBreak(block.trailing);
+    if (tag === 'td' || tag === 'th') builder.addText(' ');
+  }
+}
+
+function hastToPlainText(html: string): string {
+  const root: Root = fromHtml(html);
+  const builder = new PlainTextBuilder();
+  walk(root.children as ElementContent[], builder, {
+    uppercase: false,
+    preformatted: false,
+  });
+  return builder.toString();
+}
+
+/**
+ * Converts the rendered email HTML into a plain text version, mirroring the
+ * long-standing `html-to-text` defaults: images and `data-skip-in-text=true`
+ * elements are skipped, headings are uppercased, and link hrefs are appended
+ * without brackets unless they match the link text.
+ *
+ * When `options` are passed the conversion still goes through the deprecated
+ * `html-to-text` package so existing behavior is preserved; that path is
+ * scheduled for removal in the next major version (see #2961).
+ */
 export function toPlainText(html: string, options?: HtmlToTextOptions) {
+  if (options === undefined) {
+    return hastToPlainText(html);
+  }
   return convert(html, {
     wordwrap: false,
     ...options,
-    selectors: [...plainTextSelectors, ...(options?.selectors ?? [])],
+    selectors: [...plainTextSelectors, ...(options.selectors ?? [])],
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -780,6 +780,9 @@ importers:
 
   packages/render:
     dependencies:
+      hast-util-from-html:
+        specifier: ^2.0.3
+        version: 2.0.3
       html-to-text:
         specifier: ^9.0.5
         version: 9.0.5
@@ -796,6 +799,9 @@ importers:
       '@edge-runtime/vm':
         specifier: 5.0.0
         version: 5.0.0
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@types/html-to-text':
         specifier: 9.0.4
         version: 9.0.4


### PR DESCRIPTION
Fixes #2961.

`@react-email/render` depended on `html-to-text` (last release March 2023) for every plain text conversion. This PR moves the default `plainText: true` path to a small walker built on `hast-util-from-html` from the actively maintained rehype ecosystem, reproducing the existing output: block linebreak merging, uppercase headings, skipped images and `data-skip-in-text="true"` elements, and link hrefs appended without brackets unless they match the link text.

To avoid the breaking change discussed in the issue, `htmlToTextOptions` still routes through `html-to-text` and is now marked `@deprecated`. Callers who never passed options get off the stale dependency path today; the next major can remove the fallback and the dependency.

Validation:
- All 60 existing tests pass with inline snapshots untouched, so default output is unchanged
- New 10-case parity spec asserts the new converter is byte-equal to the old one on email-realistic HTML (nested tables, entities incl. non-breaking spaces, same-text and different-text links, full documents with head/style)
- Build and type checks pass; `@types/hast` added as a dev dependency

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move default plain‑text rendering in `@react-email/render` off the unmaintained `html-to-text` to a small `hast-util-from-html`-based walker while keeping output identical. `htmlToTextOptions` is now deprecated and still routes through `html-to-text` to avoid breaking changes, fixing #2961.

- **Refactors**
  - Default `plainText: true` path uses a hast-based walker that preserves prior behavior: uppercase headings, merged block line breaks, skips `img` and `[data-skip-in-text="true"]`, and appends link hrefs only when different from the text.
  - Added parity specs; all existing snapshots unchanged; build and types pass.

- **Dependencies**
  - Added `hast-util-from-html`.
  - Added dev dependency `@types/hast`.

<sup>Written for commit dd27b2860f42cffd16dc27fc93a21dcfca07aad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

