### PR TITLE
chore: sync prs to linear with latest workflow

### DIFF
--- a/.github/workflows/sync-prs-to-linear.yml
+++ b/.github/workflows/sync-prs-to-linear.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@9dd949340245057c074a4c0c96d9d7a7df22b655
+      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@f6bdeec8e632f07b158cd1e3cd3ac70f59463288
         with:
           linear-api-key: ${{ secrets.LINEAR_API_KEY }}
           linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update the daily PR-to-Linear sync workflow
- pin the shared action to `f6bdeec8e632f07b158cd1e3cd3ac70f59463288`

## Validation
- `actionlint` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49f07314-f970-4325-9ba4-6ccfb12955e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49f07314-f970-4325-9ba4-6ccfb12955e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the daily PR-to-Linear sync to use the latest `resend/public-shared-workflows/.github/actions/sync_prs_to_linear`. Pins the action to a specific revision for consistent, reproducible runs.

<sup>Written for commit 4e8260c2e3bd6211c04a9ff9e27a711096f689de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

