### PR TITLE
fix(react-email): ship per-module output so bundlers can tree-shake unused components

### DIFF
--- a/.changeset/spotty-donuts-argue.md
+++ b/.changeset/spotty-donuts-argue.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Ship per-module build output with `sideEffects: false` so bundlers can tree-shake unused components. Importing a component no longer pulls prismjs, marked, and tailwindcss into the bundle unless `CodeBlock`, `Markdown`, or `Tailwind` is actually used.

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -6,6 +6,7 @@
     "email": "./dist/cli/index.mjs"
   },
   "type": "module",
+  "sideEffects": false,
   "types": "./dist/index.d.mts",
   "scripts": {
     "build": "tsdown",

--- a/packages/react-email/src/components/body/body.tsx
+++ b/packages/react-email/src/components/body/body.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { markAsElement } from '../element-marker.js';
 import { marginProperties, paddingProperties } from './margin-properties.js';
 
 export type BodyProps = Readonly<React.HtmlHTMLAttributes<HTMLBodyElement>>;
@@ -58,3 +59,4 @@ export const Body = React.forwardRef<HTMLBodyElement, BodyProps>(
 );
 
 Body.displayName = 'Body';
+markAsElement(Body);

--- a/packages/react-email/src/components/button/button.tsx
+++ b/packages/react-email/src/components/button/button.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { markAsElement } from '../element-marker.js';
 import { parsePadding } from './utils/parse-padding.js';
 import { pxToPt } from './utils/px-to-pt.js';
 
@@ -110,3 +111,4 @@ export const Button = React.forwardRef<HTMLAnchorElement, ButtonProps>(
 );
 
 Button.displayName = 'Button';
+markAsElement(Button);

--- a/packages/react-email/src/components/code-block/code-block.tsx
+++ b/packages/react-email/src/components/code-block/code-block.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { markAsElement } from '../element-marker.js';
 import type { PrismLanguage } from './languages-available.js';
 import { Prism } from './prism.js';
 import type { Theme } from './themes.js';
@@ -132,3 +133,4 @@ export const CodeBlock = React.forwardRef<HTMLPreElement, CodeBlockProps>(
 );
 
 CodeBlock.displayName = 'CodeBlock';
+markAsElement(CodeBlock);

--- a/packages/react-email/src/components/code-inline/code-inline.tsx
+++ b/packages/react-email/src/components/code-inline/code-inline.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { markAsElement } from '../element-marker.js';
 
 type RootProps = React.ComponentPropsWithoutRef<'code'> &
   React.ComponentPropsWithoutRef<'span'>;
@@ -56,3 +57,4 @@ export const CodeInline = React.forwardRef<HTMLSpanElement, CodeInlineProps>(
 );
 
 CodeInline.displayName = 'CodeInline';
+markAsElement(CodeInline);

--- a/packages/react-email/src/components/column/column.tsx
+++ b/packages/react-email/src/components/column/column.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { markAsElement } from '../element-marker.js';
 
 export type ColumnProps = Readonly<React.ComponentPropsWithoutRef<'td'>>;
 
@@ -13,3 +14,4 @@ export const Column = React.forwardRef<HTMLTableCellElement, ColumnProps>(
 );
 
 Column.displayName = 'Column';
+markAsElement(Column);

--- a/packages/react-email/src/components/container/container.tsx
+++ b/packages/react-email/src/components/container/container.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { markAsElement } from '../element-marker.js';
 
 export type ContainerProps = Readonly<React.ComponentPropsWithoutRef<'table'>>;
 
@@ -55,3 +56,4 @@ export const Container = React.forwardRef<HTMLTableElement, ContainerProps>(
 );
 
 Container.displayName = 'Container';
+markAsElement(Container);

--- a/packages/react-email/src/components/element-marker.ts
+++ b/packages/react-email/src/components/element-marker.ts
@@ -1,0 +1,5 @@
+export const elementMarker = Symbol.for('react-email.element');
+
+export const markAsElement = (component: unknown) => {
+  (component as Record<symbol, boolean>)[elementMarker] = true;
+};

--- a/packages/react-email/src/components/heading/heading.tsx
+++ b/packages/react-email/src/components/heading/heading.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { markAsElement } from '../element-marker.js';
 import type { As } from './utils/as.js';
 import type { Margin } from './utils/spaces.js';
 import { withMargin } from './utils/spaces.js';
@@ -27,3 +28,4 @@ export const Heading = React.forwardRef<
 );
 
 Heading.displayName = 'Heading';
+markAsElement(Heading);

--- a/packages/react-email/src/components/hr/hr.tsx
+++ b/packages/react-email/src/components/hr/hr.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { markAsElement } from '../element-marker.js';
 
 export type HrProps = Readonly<React.ComponentPropsWithoutRef<'hr'>>;
 
@@ -19,3 +20,4 @@ export const Hr = React.forwardRef<HTMLHRElement, HrProps>(
 );
 
 Hr.displayName = 'Hr';
+markAsElement(Hr);

--- a/packages/react-email/src/components/img/img.tsx
+++ b/packages/react-email/src/components/img/img.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { markAsElement } from '../element-marker.js';
 
 export type ImgProps = Readonly<React.ComponentPropsWithoutRef<'img'>>;
 
@@ -23,3 +24,4 @@ export const Img = React.forwardRef<HTMLImageElement, ImgProps>(
 );
 
 Img.displayName = 'Img';
+markAsElement(Img);

--- a/packages/react-email/src/components/link/link.tsx
+++ b/packages/react-email/src/components/link/link.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { markAsElement } from '../element-marker.js';
 
 export type LinkProps = Readonly<React.ComponentPropsWithoutRef<'a'>>;
 
@@ -20,3 +21,4 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
 );
 
 Link.displayName = 'Link';
+markAsElement(Link);

--- a/packages/react-email/src/components/preview/preview.tsx
+++ b/packages/react-email/src/components/preview/preview.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { markAsElement } from '../element-marker.js';
 
 export type PreviewProps = Readonly<
   React.ComponentPropsWithoutRef<'div'> & {
@@ -43,6 +44,7 @@ export const Preview = React.forwardRef<HTMLDivElement, PreviewProps>(
 );
 
 Preview.displayName = 'Preview';
+markAsElement(Preview);
 
 const whiteSpaceCodes = '\xa0\u200C\u200B\u200D\u200E\u200F\uFEFF';
 export const renderWhiteSpace = (text: string) => {

--- a/packages/react-email/src/components/row/row.tsx
+++ b/packages/react-email/src/components/row/row.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { markAsElement } from '../element-marker.js';
 
 export type RowProps = Readonly<
   React.ComponentPropsWithoutRef<'table'> & {
@@ -29,3 +30,4 @@ export const Row = React.forwardRef<HTMLTableElement, RowProps>(
 );
 
 Row.displayName = 'Row';
+markAsElement(Row);

--- a/packages/react-email/src/components/section/section.tsx
+++ b/packages/react-email/src/components/section/section.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { markAsElement } from '../element-marker.js';
 
 export type SectionProps = Readonly<React.ComponentPropsWithoutRef<'table'>>;
 
@@ -55,3 +56,4 @@ export const Section = React.forwardRef<HTMLTableElement, SectionProps>(
 );
 
 Section.displayName = 'Section';
+markAsElement(Section);

--- a/packages/react-email/src/components/tailwind/utils/react/is-component.ts
+++ b/packages/react-email/src/components/tailwind/utils/react/is-component.ts
@@ -1,34 +1,4 @@
-import { Body } from '../../../body/index.js';
-import { Button } from '../../../button/index.js';
-import { CodeBlock } from '../../../code-block/index.js';
-import { CodeInline } from '../../../code-inline/index.js';
-import { Column } from '../../../column/index.js';
-import { Container } from '../../../container/index.js';
-import { Heading } from '../../../heading/index.js';
-import { Hr } from '../../../hr/index.js';
-import { Img } from '../../../img/index.js';
-import { Link } from '../../../link/index.js';
-import { Preview } from '../../../preview/index.js';
-import { Row } from '../../../row/index.js';
-import { Section } from '../../../section/index.js';
-import { Text } from '../../../text/index.js';
-
-const componentsToTreatAsElements: React.ReactElement['type'][] = [
-  Body,
-  Button,
-  CodeBlock,
-  CodeInline,
-  Column,
-  Container,
-  Heading,
-  Hr,
-  Img,
-  Link,
-  Preview,
-  Row,
-  Section,
-  Text,
-];
+import { elementMarker } from '../../../element-marker.js';
 
 export const isComponent = (
   element: React.ReactElement,
@@ -37,6 +7,6 @@ export const isComponent = (
     (typeof element.type === 'function' ||
       // @ts-expect-error - we know this is a component that may have a render function
       element.type.render !== undefined) &&
-    !componentsToTreatAsElements.includes(element.type)
+    !(elementMarker in (element.type as object))
   );
 };

--- a/packages/react-email/src/components/text/text.tsx
+++ b/packages/react-email/src/components/text/text.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { markAsElement } from '../element-marker.js';
 import { computeMargins } from './utils/compute-margins.js';
 
 export type TextProps = Readonly<React.ComponentPropsWithoutRef<'p'>>;
@@ -46,3 +47,4 @@ export const Text = React.forwardRef<HTMLParagraphElement, TextProps>(
 );
 
 Text.displayName = 'Text';
+markAsElement(Text);

--- a/packages/react-email/tsdown.config.ts
+++ b/packages/react-email/tsdown.config.ts
@@ -1,5 +1,27 @@
 import { defineConfig } from 'tsdown';
 
+// css-tree's ESM files load .json data through createRequire(), which breaks
+// once a consumer's bundler inlines them. Its dist bundle is self-contained,
+// so the emitted ESM points there; the CJS output keeps plain 'css-tree',
+// whose CJS build only uses static require() calls that bundlers handle.
+// Only .mjs chunks are rewritten: declaration files must keep the bare
+// specifier, the only module @types/css-tree declares.
+const selfContainedCssTreeEsm = {
+  name: 'self-contained-css-tree-esm',
+  renderChunk(code: string, chunk: { fileName: string }) {
+    if (!chunk.fileName.endsWith('.mjs') || !code.includes('"css-tree"')) {
+      return null;
+    }
+    return {
+      code: code.replaceAll(
+        ' from "css-tree"',
+        ' from "css-tree/dist/csstree.esm"',
+      ),
+      map: null,
+    };
+  },
+};
+
 export default defineConfig([
   {
     dts: false,
@@ -13,19 +35,10 @@ export default defineConfig([
     format: ['esm'],
     outDir: 'dist',
     unbundle: true,
-    // css-tree's ESM files load .json data through createRequire(), which
-    // breaks once a consumer's bundler inlines them. Its dist bundle is
-    // self-contained, so the ESM output points there; the CJS output keeps
-    // plain 'css-tree', whose CJS build only uses static require() calls
-    // that bundlers handle.
-    outputOptions: {
-      paths: {
-        'css-tree': 'css-tree/dist/csstree.esm',
-      },
-    },
     deps: {
       neverBundle: [/^react($|\/)/, /^react-dom($|\/)/],
     },
+    plugins: [selfContainedCssTreeEsm],
   },
   {
     dts: true,

--- a/packages/react-email/tsdown.config.ts
+++ b/packages/react-email/tsdown.config.ts
@@ -1,39 +1,4 @@
-import { createRequire } from 'node:module';
-import url from 'node:url';
 import { defineConfig } from 'tsdown';
-
-// css-tree uses createRequire() to load .json data files, which breaks at
-// runtime in ESM bundles. We bundle it in (noExternal) so we can intercept
-// those require() calls via this plugin and inline the JSON content at build
-// time. See https://github.com/resend/react-email/pull/2425.
-const hoistCreateRequireImports = {
-  name: 'hoist-create-require-imports',
-  async transform(code: string, id: string, meta: Record<string, unknown>) {
-    if (id.includes('css-tree')) {
-      const localizedRequire = createRequire(url.pathToFileURL(id));
-
-      return {
-        code: code
-          .replaceAll("import { createRequire } from 'module';", '')
-          .replaceAll(
-            /(const|var|let)\s+require\s*=\s*createRequire\s*\([^)]*\)\s*;?/g,
-            '',
-          )
-          .replaceAll(
-            /require\s*\(\s*(['"])([^)]+?\.json)\1\s*\)/gm,
-            (_match: string, _quote: string, jsonSpecifier: string) => {
-              return JSON.stringify(
-                localizedRequire(localizedRequire.resolve(jsonSpecifier)),
-                null,
-                2,
-              );
-            },
-          ),
-        ...meta,
-      };
-    }
-  },
-};
 
 export default defineConfig([
   {
@@ -45,12 +10,31 @@ export default defineConfig([
   {
     dts: true,
     entry: ['./src/index.ts'],
-    format: ['esm', 'cjs'],
+    format: ['esm'],
     outDir: 'dist',
+    unbundle: true,
+    // css-tree's ESM files load .json data through createRequire(), which
+    // breaks once a consumer's bundler inlines them. Its dist bundle is
+    // self-contained, so the ESM output points there; the CJS output keeps
+    // plain 'css-tree', whose CJS build only uses static require() calls
+    // that bundlers handle.
+    outputOptions: {
+      paths: {
+        'css-tree': 'css-tree/dist/csstree.esm',
+      },
+    },
     deps: {
-      alwaysBundle: ['css-tree'],
       neverBundle: [/^react($|\/)/, /^react-dom($|\/)/],
     },
-    plugins: [hoistCreateRequireImports],
+  },
+  {
+    dts: true,
+    entry: ['./src/index.ts'],
+    format: ['cjs'],
+    outDir: 'dist',
+    unbundle: true,
+    deps: {
+      neverBundle: [/^react($|\/)/, /^react-dom($|\/)/],
+    },
   },
 ]);


### PR DESCRIPTION
## Summary

Fixes #3556.

The unified `react-email` package compiled its entire source into a single flat `dist/index.mjs`, with eager top-level imports of prismjs, marked, and the tailwindcss compiler. Since tree-shaking is module-granular, importing even one component (`import { Text } from 'react-email'`) pulled all of it into consumer bundles — ~1.5 MB minimum per esbuild trace, reported as ~80 MB serverless functions on Vercel.

Three changes:

1. **Per-module build output + `sideEffects: false`** — the dist now mirrors the source tree (tsdown `unbundle` mode) and the entry is a pure re-export barrel, so bundlers include only the modules a project actually imports. The public API and the dual ESM/CJS exports are unchanged; deep imports were already blocked by the `exports` map, so the dist layout is not observable.
2. **css-tree without the bundling hack** — the ESM output now resolves `css-tree` to its self-contained `dist/csstree.esm` bundle (no `createRequire` JSON loading, safe for consumer bundlers), replacing the build-time JSON-inlining plugin. The CJS output keeps plain `css-tree`, whose CJS build only uses static `require()` calls.
3. **Decoupled `is-component` from every component** — the Tailwind traversal helper imported all 14 "treat as element" components to build an identity list, which alone dragged the 662 KB prism module into every `Tailwind` user's bundle. Components now carry a shared symbol marker instead.

Measured with esbuild bundle tracing (react/react-dom external), before → after:

| import pattern | before | after |
|---|---|---|
| `import { Text }` | 1,510 KB | **2.6 KB** |
| 14 layout components | 1,511 KB | **17.7 KB** |
| `import * as RE` (namespace) | 1,510 KB | **9.4 KB** |
| uses `Markdown` | 1,510 KB | **81 KB** (marked only) |
| uses `Tailwind` | 1,912 KB | **694 KB** (tailwindcss only) |
| uses `CodeBlock` | 1,513 KB | **727 KB** (prismjs only) |
| `import { render }` | 2,090 KB | **575 KB** |

Users of `Markdown`/`Tailwind`/`CodeBlock` keep only their component's own heavy dependency; everyone else drops all of them. Rendered HTML is byte-identical before vs after for every pattern above, plus CJS `require()` (partial, namespace, and Tailwind) and unbundled plain-Node ESM/CJS runtimes. CJS consumed through a bundler still includes the full graph (inherent to `require()` of a barrel, same as before).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `react-email` tree-shakeable by shipping per-module output and setting `sideEffects: false`. Importing one component no longer drags `prismjs`, `marked`, or `tailwindcss`; `import { Text }` drops from ~1.5 MB to ~2.6 KB.

- **Refactors**
  - Per-file build with `tsdown` unbundle; barrel entry; ESM/CJS exports unchanged.
  - Remap `css-tree` to `css-tree/dist/csstree.esm` in .mjs only; keep bare `css-tree` in type declarations; drop the `createRequire` hack. CJS stays on `css-tree`.
  - Use a shared symbol to mark "element" components; Tailwind no longer imports all components.

<sup>Written for commit 8abfd5ae9464ee974dfea87bede69da567d860d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

