### PR TITLE
fix(ui): toolbar tabs unresponsive on static builds when landing with a toolbar-panel param

### DIFF
--- a/.changeset/toolbar-tabs-static-navigation.md
+++ b/.changeset/toolbar-tabs-static-navigation.md
@@ -1,0 +1,6 @@
+---
+'@react-email/ui': patch
+'react-email': patch
+---
+
+Fixed toolbar tabs not responding on statically built previews when the page was opened with a `toolbar-panel` query param in the URL.

--- a/packages/ui/src/components/toolbar.tsx
+++ b/packages/ui/src/components/toolbar.tsx
@@ -2,7 +2,7 @@
 
 import * as Tabs from '@radix-ui/react-tabs';
 import { LayoutGroup } from 'framer-motion';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 import type { ComponentProps } from 'react';
 import * as React from 'react';
 import { nicenames } from '../actions/email-validation/caniemail-data';
@@ -72,7 +72,6 @@ const ToolbarInner = ({
 }) => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const router = useRouter();
 
   const { hasSetupResendIntegration } = useToolbarContext();
 
@@ -89,7 +88,13 @@ const ToolbarInner = ({
     } else {
       params.set('toolbar-panel', newValue);
     }
-    router.push(`${pathname}?${params.toString()}${location.hash}`);
+    // Not router.push: on static builds it silently no-ops for query-only
+    // navigation when the page was loaded with a query param.
+    window.history.pushState(
+      null,
+      '',
+      `${pathname}?${params.toString()}${location.hash}`,
+    );
   };
 
   const [cachedSpamCheckingResult, setCachedSpamCheckingResult] =


### PR DESCRIPTION
On statically built previews (`email-dev build` + `start`), opening a preview URL that already carries a `?toolbar-panel=...` query param left the toolbar tabs unresponsive: clicking any tab did nothing until a navigation succeeded from a clean URL first. The cause is that `router.push` with a query-only change silently no-ops in that state — the page was prerendered without search params, so the App Router has nothing to re-fetch for the same pathname. The dev server was unaffected.

The toolbar panel is purely client-side UI state, so this switches `setActivePanelValue` to shallow routing via `window.history.pushState`, which Next officially supports and keeps `useSearchParams` in sync. Besides fixing the static-build case, this drops the RSC round-trip and the scroll-to-top that `router.push` incurred on every tab switch.

Verified on a static demo build: landing on `?toolbar-panel=linter` and switching tabs now updates the URL and panel, browser back/forward restores the previous tab, and the dev server behaves the same as before. Full `@react-email/ui` suite passes.

Related: surfaced while testing #3644, which makes the Props tab visible on static builds, but the bug reproduces on canary without it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unresponsive toolbar tabs on statically built previews when the page loads with a `?toolbar-panel=...` param. Switches tab changes to shallow routing via `window.history.pushState`, keeping `useSearchParams` in sync, preserving URL/back/forward, and avoiding an RSC round-trip and scroll-to-top.

<sup>Written for commit af859c27e1ccb5c275ce36e4a32c5a10bbfaefcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

