### PR TITLE
fix(editor): use mark inline styles on the code block

### DIFF
--- a/.changeset/code-mark-inline-styles.md
+++ b/.changeset/code-mark-inline-styles.md
@@ -1,0 +1,7 @@
+---
+"@react-email/editor": patch
+---
+
+fix: apply inline styles stored on the `code` mark when composing the email
+
+The `code` mark's serializer only read styles from the text node's attrs, so inline CSS captured on the mark itself (e.g. background, padding, or font styles imported from existing HTML) was dropped from the composed email. The mark's `style` attr is now merged into the rendered `<code>` element.

--- a/packages/editor/src/extensions/code.tsx
+++ b/packages/editor/src/extensions/code.tsx
@@ -2,8 +2,17 @@ import CodeBase from '@tiptap/extension-code';
 import { EmailMark } from '../core/serializer/email-mark';
 import { inlineCssToJs } from '../utils/styles';
 
-export const Code = EmailMark.from(CodeBase, ({ children, node, style }) => (
-  <code style={{ ...style, ...inlineCssToJs(node.attrs?.style) }}>
-    {children}
-  </code>
-));
+export const Code = EmailMark.from(
+  CodeBase,
+  ({ children, node, style, mark }) => (
+    <code
+      style={{
+        ...style,
+        ...inlineCssToJs(node.attrs?.style),
+        ...inlineCssToJs(mark?.attrs?.style),
+      }}
+    >
+      {children}
+    </code>
+  ),
+);


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure inline styles on the `code` mark are preserved when composing emails in `@react-email/editor`. The serializer now merges `mark.attrs.style` with node styles, fixing lost background, padding, and font styles from imported HTML.

<sup>Written for commit 99717e15e7c3630804d301fcb9bb65af3333c0c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

