### PR TITLE
fix(template): polish template space and sizing

### DIFF
--- a/apps/demo/emails/04-Arcane/abandoned-cart.tsx
+++ b/apps/demo/emails/04-Arcane/abandoned-cart.tsx
@@ -61,7 +61,7 @@ export const AbandonedCartEmail = ({
 
         <Body className="bg-white m-0 p-0 font-15 font-sans">
           <Preview>Your {companyName} cart is waiting</Preview>
-          <Section className="bg-white m-0 p-0 pt-[92px] mobile:pt-0">
+          <Section className="bg-white m-0 p-0">
             <Container className="bg-bg mx-auto w-full max-w-[640px]">
               <Section className="bg-bg px-[40px] pt-[40px] pb-[24px]">
                 <Img

--- a/apps/demo/emails/04-Arcane/activation.tsx
+++ b/apps/demo/emails/04-Arcane/activation.tsx
@@ -35,7 +35,7 @@ export const ActivationEmail = ({ companyName, url }: ActivationEmailProps) => (
 
       <Body className="bg-white m-0 p-0 font-15 font-sans">
         <Preview>Confirm your email address</Preview>
-        <Section className="bg-white m-0 p-0 pt-[92px] mobile:pt-0">
+        <Section className="bg-white m-0 p-0">
           <Container className="bg-bg mx-auto w-full max-w-[640px]">
             <Section className="bg-bg pt-[40px] pr-[32px] pb-[24px] pl-[40px]">
               <Img

--- a/apps/demo/emails/04-Arcane/newsletter.tsx
+++ b/apps/demo/emails/04-Arcane/newsletter.tsx
@@ -84,7 +84,7 @@ export const NewsletterEmail = ({ companyName, url }: NewsletterEmailProps) => {
 
         <Body className="m-0 bg-white p-0 font-15 font-sans">
           <Preview>The latest from {companyName}</Preview>
-          <Section className="bg-white m-0 w-full p-0 pt-[92px] mobile:pt-0">
+          <Section className="bg-white m-0 w-full p-0">
             <Container className="bg-bg mx-auto w-full max-w-[640px]">
               <Section className="bg-bg mobile:px-6 px-[40px] pt-[40px] pb-[24px]">
                 <Img

--- a/apps/demo/emails/04-Arcane/order-confirmation.tsx
+++ b/apps/demo/emails/04-Arcane/order-confirmation.tsx
@@ -52,7 +52,7 @@ export const OrderConfirmationEmail = ({
 
         <Body className="m-0 bg-white p-0 font-15 font-sans">
           <Preview>Your {companyName} order #1234567890 is confirmed</Preview>
-          <Section className="m-0 bg-white p-0 pt-[92px] mobile:pt-0">
+          <Section className="m-0 bg-white p-0">
             <Container className="bg-bg mx-auto w-full max-w-[640px]">
               <Section className="bg-bg mobile:px-6 px-[40px] pt-[40px] pb-[24px]">
                 <Img

--- a/apps/demo/emails/04-Arcane/order-shipping.tsx
+++ b/apps/demo/emails/04-Arcane/order-shipping.tsx
@@ -73,7 +73,7 @@ export const OrderShippingEmail = ({
 
         <Body className="m-0 bg-white p-0 font-15 font-sans">
           <Preview>Your {companyName} order #1234567890 has shipped</Preview>
-          <Section className="m-0 bg-white p-0 pt-[92px] mobile:pt-0">
+          <Section className="m-0 bg-white p-0">
             <Container className="bg-bg mx-auto w-full max-w-[640px]">
               <Section className="bg-bg mobile:px-6 px-[40px] pt-[40px] pb-[24px]">
                 <Img

--- a/apps/demo/emails/04-Arcane/password-reset.tsx
+++ b/apps/demo/emails/04-Arcane/password-reset.tsx
@@ -38,7 +38,7 @@ export const PasswordResetEmail = ({
 
       <Body className="m-0 bg-white p-0 font-15 font-sans">
         <Preview>Reset your password</Preview>
-        <Section className="m-0 bg-white p-0 pt-[92px] mobile:pt-0">
+        <Section className="m-0 bg-white p-0">
           <Container className="bg-bg mx-auto w-full max-w-[640px]">
             <Section className="bg-bg mobile:px-6 px-[40px] pt-[40px] pb-[24px]">
               <Img

--- a/apps/demo/emails/04-Arcane/promo.tsx
+++ b/apps/demo/emails/04-Arcane/promo.tsx
@@ -61,7 +61,7 @@ export const PromoEmail = ({ companyName, url }: PromoEmailProps) => {
 
         <Body className="m-0 bg-white p-0 font-15 font-sans">
           <Preview>Your {companyName} promo code</Preview>
-          <Section className="m-0 bg-white p-0 pt-[92px] mobile:pt-0">
+          <Section className="m-0 bg-white p-0">
             <Container className="bg-bg mx-auto w-full max-w-[640px]">
               <Section className="bg-bg-2 mobile:px-6 px-[40px] pt-[40px] pb-[24px]">
                 <Img

--- a/apps/demo/emails/04-Arcane/welcome.tsx
+++ b/apps/demo/emails/04-Arcane/welcome.tsx
@@ -59,7 +59,7 @@ export const WelcomeEmail = ({ companyName, url }: WelcomeEmailProps) => {
 
         <Body className="m-0 bg-white p-0 font-15 font-sans">
           <Preview>Welcome to {companyName}</Preview>
-          <Section className="m-0 bg-white p-0 pt-[92px] mobile:pt-0">
+          <Section className="m-0 bg-white p-0">
             <Container className="bg-bg mx-auto w-full max-w-[640px]">
               <Section className="bg-bg mobile:px-6 px-[40px] pt-[40px] pb-[24px]">
                 <Img

--- a/apps/demo/emails/05-Studio/newsletter.tsx
+++ b/apps/demo/emails/05-Studio/newsletter.tsx
@@ -105,8 +105,8 @@ export const TechNewsletterEmail = ({
                 <Img
                   src={techNewsletterCommunity.imageSrc}
                   alt=""
-                  width={608}
-                  className="block w-full max-w-[608px] rounded-t-[10px]"
+                  width={640}
+                  className="block w-full max-w-[640px] rounded-t-[10px]"
                 />
               </Section>
 

--- a/apps/demo/emails/Community/newsletters/codepen-challengers.tsx
+++ b/apps/demo/emails/Community/newsletters/codepen-challengers.tsx
@@ -29,7 +29,7 @@ export const CodepenChallengersEmail = () => (
     <Tailwind config={tailwindConfig}>
       <Body className="font-codepen bg-[#505050] m-0">
         <Preview>#CodePenChallenge: Cubes</Preview>
-        <Section className="w-full bg-[#191919] m-0 mx-auto pb-[30px] z-[999]">
+        <Section className="w-full bg-[#191919] m-0 mx-auto pb-[30px]">
           <Img
             className="mx-auto max-w-full"
             src={`${baseUrl}/static/codepen-challengers.png`}
@@ -37,11 +37,9 @@ export const CodepenChallengersEmail = () => (
             alt="codepen"
           />
         </Section>
-        <Container className="mx-auto w-[648px] max-w-full relative">
-          <Text className="bg-[#505050] text-center py-[10px] text-[13px] absolute w-[648px] max-w-full top-[-28px] m-0 mb-4">
-            <Link className="text-white cursor-pointer">
-              View this Challenge on CodePen
-            </Link>
+        <Container className="mx-auto w-[648px] max-w-full">
+          <Text className="bg-[#505050] text-center py-[10px] text-[13px] m-0 mb-4">
+            <Link className="text-white">View this Challenge on CodePen</Link>
           </Text>
 
           <Heading className="bg-[#f0d361] p-[30px] text-[#191919] font-normal mb-0">
@@ -55,9 +53,7 @@ export const CodepenChallengersEmail = () => (
             <Text className="text-base">
               Last week, we kicked things off with round shapes. We "rounded" up
               the Pens from week one in our{' '}
-              <Link className="text-[#15c] cursor-pointer">
-                #CodePenChallenge: Round
-              </Link>{' '}
+              <Link className="text-[#15c]">#CodePenChallenge: Round</Link>{' '}
               collection.
             </Text>
 
@@ -84,7 +80,7 @@ export const CodepenChallengersEmail = () => (
 
             <Text className="text-base border-[6px] border-solid border-[#ebd473] p-5 m-0 mb-10">
               💪 <strong>Your Challenge:</strong>{' '}
-              <Link className="text-[#15c] cursor-pointer">
+              <Link className="text-[#15c]">
                 create a Pen that includes cube shapes.
               </Link>
             </Text>
@@ -109,7 +105,7 @@ export const CodepenChallengersEmail = () => (
                 front-end designer or developer at any experience level.
               </Text>
 
-              <Button className="bg-[#2138c6] text-white border-0 text-[15px] leading-[18px] cursor-pointer rounded p-3">
+              <Button className="bg-[#2138c6] text-white border-0 text-[15px] leading-[18px] rounded p-3">
                 <strong>Learn More</strong>
               </Button>
             </Section>
@@ -117,26 +113,24 @@ export const CodepenChallengersEmail = () => (
 
           <Text className="bg-[#f5d247] p-[30px] text-lg leading-[1.5]">
             <strong>To participate:</strong>{' '}
-            <Link className="text-[#15c] cursor-pointer">Create a Pen →</Link>{' '}
-            and tag it{' '}
-            <Link className="text-[#15c] cursor-pointer">
+            <Link className="text-[#15c]">Create a Pen →</Link> and tag it{' '}
+            <Link className="text-[#15c]">
               <strong>codepenchallenge</strong>
             </Link>{' '}
             and
-            <Link className="text-[#15c] cursor-pointer">
+            <Link className="text-[#15c]">
               {' '}
               <strong>cpc-cubes</strong>
             </Link>
             . We'll be watching and gathering the Pens into a Collection, and
-            sharing on{' '}
-            <Link className="text-[#15c] cursor-pointer">Twitter</Link> and{' '}
-            <Link className="text-[#15c] cursor-pointer">Instagram</Link> (Use
-            the #CodePenChallenge tag on Twitter and Instagram as well).
+            sharing on <Link className="text-[#15c]">Twitter</Link> and{' '}
+            <Link className="text-[#15c]">Instagram</Link> (Use the
+            #CodePenChallenge tag on Twitter and Instagram as well).
           </Text>
 
           <Section className="m-0 bg-white px-6">
             <Row>
-              <Column className="w-1/2 pr-[10px]">
+              <Column className="w-1/2 pr-[10px] align-top">
                 <Text className="font-black text-lg leading-[1.1]">IDEAS!</Text>
 
                 <Section className="p-5 m-0 mb-5 rounded-[10px] text-[36px] text-center bg-[#fff4c8] border border-solid border-[#f4d247]">
@@ -144,17 +138,11 @@ export const CodepenChallengersEmail = () => (
                   <Text className="text-[13px] text-left">
                     This week we move from 2 dimensions to three! Maybe you
                     could exercise your{' '}
-                    <Link className="text-[#15c] cursor-pointer">
-                      perspective
-                    </Link>{' '}
-                    in CSS to create a 3D cube. Or, you can try out creating 3D
-                    shapes in JavaScript, using{' '}
-                    <Link className="text-[#15c] cursor-pointer">WebGL</Link> or
-                    building a{' '}
-                    <Link className="text-[#15c] cursor-pointer">
-                      Three.js scene
-                    </Link>
-                    .
+                    <Link className="text-[#15c]">perspective</Link> in CSS to
+                    create a 3D cube. Or, you can try out creating 3D shapes in
+                    JavaScript, using <Link className="text-[#15c]">WebGL</Link>{' '}
+                    or building a{' '}
+                    <Link className="text-[#15c]">Three.js scene</Link>.
                   </Text>
                 </Section>
 
@@ -163,16 +151,11 @@ export const CodepenChallengersEmail = () => (
                   <Text className="text-[13px] text-left">
                     There's more to cubes than just six square sides. There are
                     variations on the cube that could be fun to play with this
-                    week:{' '}
-                    <Link className="text-[#15c] cursor-pointer">
-                      cuboid shapes
-                    </Link>{' '}
-                    are hexahedrons with faces that aren't always squares. And
-                    if you want to really push the boundaries of shape, consider
+                    week: <Link className="text-[#15c]">cuboid shapes</Link> are
+                    hexahedrons with faces that aren't always squares. And if
+                    you want to really push the boundaries of shape, consider
                     the 4 dimensional{' '}
-                    <Link className="text-[#15c] cursor-pointer">
-                      tesseract!
-                    </Link>
+                    <Link className="text-[#15c]">tesseract!</Link>
                   </Text>
                 </Section>
 
@@ -181,18 +164,16 @@ export const CodepenChallengersEmail = () => (
                   <Text className="text-[13px] text-left">
                     Here's a mind-bending idea that can combine the round shapes
                     from week one with this week's cube theme:{' '}
-                    <Link className="text-[#15c] cursor-pointer">
-                      Spherical Cubes
-                    </Link>{' '}
-                    😳 Solving longstanding mathematical mysteries is probably
+                    <Link className="text-[#15c]">Spherical Cubes</Link> 😳
+                    Solving longstanding mathematical mysteries is probably
                     outside the scope of a CodePen challenge, but you could use
                     front-end tools to explore fitting spheres into cubes, or
                     vice-versa.
                   </Text>
                 </Section>
               </Column>
-              <Column className="w-1/2 pl-[10px]">
-                <Text className="font-black -mt-10 text-lg leading-[1.1]">
+              <Column className="w-1/2 pl-[10px] align-top">
+                <Text className="font-black text-lg leading-[1.1]">
                   RESOURCES!
                 </Text>
 
@@ -200,15 +181,14 @@ export const CodepenChallengersEmail = () => (
                   📖
                   <Text className="text-[13px] text-left">
                     Learn all about{' '}
-                    <Link className="text-[#15c] cursor-pointer">
+                    <Link className="text-[#15c]">
                       How CSS Perspective Works
                     </Link>{' '}
                     and how to build a 3D CSS cube from scratch in Amit Sheen's
                     in-depth tutorial for CSS-Tricks. Or, check out stunning
                     examples of WebGL cubes from Matthias Hurrle:{' '}
-                    <Link className="text-[#15c] cursor-pointer">Just Ice</Link>{' '}
-                    and{' '}
-                    <Link className="text-[#15c] cursor-pointer">Posing</Link>.
+                    <Link className="text-[#15c]">Just Ice</Link> and{' '}
+                    <Link className="text-[#15c]">Posing</Link>.
                   </Text>
                 </Section>
 
@@ -217,15 +197,11 @@ export const CodepenChallengersEmail = () => (
                   <Text className="text-[13px] text-left">
                     Want to go beyond the square cube? Draw inspiration from
                     EntropyReversed's{' '}
-                    <Link className="text-[#15c] cursor-pointer">
-                      Pulsating Tesseract
-                    </Link>
-                    , Josetxu's{' '}
-                    <Link className="text-[#15c] cursor-pointer">
-                      Rainbow Cuboid Loader
-                    </Link>
-                    , or Ana Tudor's{' '}
-                    <Link className="text-[#15c] cursor-pointer">
+                    <Link className="text-[#15c]">Pulsating Tesseract</Link>,
+                    Josetxu's{' '}
+                    <Link className="text-[#15c]">Rainbow Cuboid Loader</Link>,
+                    or Ana Tudor's{' '}
+                    <Link className="text-[#15c]">
                       Pure CSS cuboid jellyfish
                     </Link>
                     .
@@ -237,17 +213,13 @@ export const CodepenChallengersEmail = () => (
                   <Text className="text-[13px] text-left">
                     Did that spherical cubes concept pique your interest?
                     Explore Ryan Mulligan's{' '}
-                    <Link className="text-[#15c] cursor-pointer">
-                      Cube Sphere
-                    </Link>
-                    , Munir Safi's{' '}
-                    <Link className="text-[#15c] cursor-pointer">
+                    <Link className="text-[#15c]">Cube Sphere</Link>, Munir
+                    Safi's{' '}
+                    <Link className="text-[#15c]">
                       3D Sphere to Cube Animation With Virtual Trackball
                     </Link>{' '}
                     and Ana Tudor's{' '}
-                    <Link className="text-[#15c] cursor-pointer">
-                      Infinitely unpack prism
-                    </Link>{' '}
+                    <Link className="text-[#15c]">Infinitely unpack prism</Link>{' '}
                     for more mindbending cube concepts that test the boundaries
                     of how shapes interact with each other.
                   </Text>
@@ -257,7 +229,7 @@ export const CodepenChallengersEmail = () => (
           </Section>
 
           <Section className="mt-[40px] mb-[120px] text-center">
-            <Button className="text-[26px] text-[#15c] bg-[#222] rounded font-bold cursor-pointer py-[15px] px-[30px]">
+            <Button className="text-[26px] text-[#15c] bg-[#222] rounded font-bold py-[15px] px-[30px]">
               Go to Challenge Page
             </Button>
           </Section>
@@ -265,18 +237,15 @@ export const CodepenChallengersEmail = () => (
           <Section className="bg-white text-[#505050] px-6 mb-12">
             <Text className="text-[13px]">
               You can adjust your{' '}
-              <Link className="underline text-[#505050] cursor-pointer">
+              <Link className="underline text-[#505050]">
                 email preferences
               </Link>{' '}
               any time, or{' '}
-              <Link className="underline text-[#505050] cursor-pointer">
+              <Link className="underline text-[#505050]">
                 instantly opt out
               </Link>{' '}
               of emails of this kind. Need help with anything? Hit up{' '}
-              <Link className="underline text-[#505050] cursor-pointer">
-                support
-              </Link>
-              .
+              <Link className="underline text-[#505050]">support</Link>.
             </Text>
           </Section>
         </Container>


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished spacing and sizing across demo email templates for a cleaner, more consistent layout. Removes unnecessary padding, aligns columns, and standardizes hero image widths.

- **Bug Fixes**
  - Removed extra top padding (`pt-[92px] mobile:pt-0`) from 04-Arcane templates to fix header spacing.
  - Updated 05-Studio newsletter hero image to 640px width and max width for full-bleed rendering.
  - Simplified Community “CodePen Challengers” layout: removed z-index/absolute positioning, dropped `cursor-pointer` on links/buttons, aligned columns top, and tightened copy/spacing for better readability.

<sup>Written for commit 1e1d8bd984ba27f791ae1b9c6c795ed6503c20e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

