### PR TITLE
fix(ui): make toolbar mobile friendly

### DIFF
--- a/.changeset/mobile-toolbar-tabs.md
+++ b/.changeset/mobile-toolbar-tabs.md
@@ -2,4 +2,4 @@
 "@react-email/ui": patch
 ---
 
-Make the preview toolbar and its menus responsive to mobile interactions
+Make the preview toolbar and its menus responsive across desktop and mobile interactions

--- a/.changeset/mobile-toolbar-tabs.md
+++ b/.changeset/mobile-toolbar-tabs.md
@@ -1,0 +1,5 @@
+---
+"@react-email/ui": patch
+---
+
+Make preview toolbar tabs scrollable and prevent toolbar labels from wrapping on mobile

--- a/.changeset/mobile-toolbar-tabs.md
+++ b/.changeset/mobile-toolbar-tabs.md
@@ -2,4 +2,4 @@
 "@react-email/ui": patch
 ---
 
-Make preview toolbar tabs scrollable and prevent toolbar labels from wrapping on mobile
+Make the preview toolbar and Copy for AI menu responsive on mobile

--- a/.changeset/mobile-toolbar-tabs.md
+++ b/.changeset/mobile-toolbar-tabs.md
@@ -2,4 +2,4 @@
 "@react-email/ui": patch
 ---
 
-Make the preview toolbar and Copy for AI menu responsive on mobile
+Make the preview toolbar and its menus responsive to mobile interactions

--- a/packages/ui/src/app/preview/[...slug]/preview.tsx
+++ b/packages/ui/src/app/preview/[...slug]/preview.tsx
@@ -155,7 +155,8 @@ const Preview = ({ emailTitle, className, ...props }: PreviewProps) => {
           'h-[calc(100%-3.5rem-2.375rem)] will-change-[height] flex p-4 transition-[height] duration-300 relative',
           activeView === 'preview' && 'bg-gray-200',
           activeView === 'preview' && isDarkModeEnabled && 'bg-gray-400',
-          toolbarToggled && 'h-[calc(100%-3.5rem-13rem)]',
+          toolbarToggled &&
+            'h-[calc(100%-3.5rem-15.5rem)] sm:h-[calc(100%-3.5rem-13rem)]',
           className,
         )}
         ref={(element) => {

--- a/packages/ui/src/app/preview/[...slug]/preview.tsx
+++ b/packages/ui/src/app/preview/[...slug]/preview.tsx
@@ -155,8 +155,7 @@ const Preview = ({ emailTitle, className, ...props }: PreviewProps) => {
           'h-[calc(100%-3.5rem-2.375rem)] will-change-[height] flex p-4 transition-[height] duration-300 relative',
           activeView === 'preview' && 'bg-gray-200',
           activeView === 'preview' && isDarkModeEnabled && 'bg-gray-400',
-          toolbarToggled &&
-            'h-[calc(100%-3.5rem-15.5rem)] sm:h-[calc(100%-3.5rem-13rem)]',
+          toolbarToggled && 'h-[calc(100%-3.5rem-13rem)]',
           className,
         )}
         ref={(element) => {

--- a/packages/ui/src/components/toolbar.tsx
+++ b/packages/ui/src/components/toolbar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import * as Popover from '@radix-ui/react-popover';
 import * as Tabs from '@radix-ui/react-tabs';
 import { LayoutGroup } from 'framer-motion';
@@ -179,13 +180,28 @@ const ToolbarInner = ({
       'The Resend tab allows you to upload your React Email code using the Resend Templates API.') ||
     'Info';
 
+  const availablePanels: { value: ToolbarTabValue; label: string }[] = [
+    { value: 'linter', label: 'Linter' },
+    ...(isRawHtmlEmail
+      ? []
+      : ([{ value: 'compatibility', label: 'Compatibility' }] as const)),
+    { value: 'spam-assassin', label: 'Spam' },
+    ...(isRawHtmlEmail || isBuilding
+      ? []
+      : ([{ value: 'props', label: 'Props' }] as const)),
+    { value: 'resend', label: 'Resend' },
+  ];
+  const activePanelLabel =
+    availablePanels.find((panel) => panel.value === activeTab)?.label ??
+    'Linter';
+
   return (
     <div
       data-toggled={toggled}
       className={cn(
         'absolute bottom-0 left-0 right-0',
-        'border-t border-slate-6 group/toolbar text-xs text-slate-11 h-62 transition-transform sm:h-52',
-        'data-[toggled=false]:translate-y-52.5 sm:data-[toggled=false]:translate-y-42.5',
+        'border-t border-slate-6 group/toolbar text-xs text-slate-11 h-52 transition-transform',
+        'data-[toggled=false]:translate-y-42.5',
       )}
     >
       <Tabs.Root
@@ -196,8 +212,52 @@ const ToolbarInner = ({
         asChild
       >
         <div className="flex flex-col h-full">
-          <div className="flex w-full shrink-0 flex-col border-b border-solid border-slate-6 px-2 sm:h-10 sm:flex-row sm:items-center sm:px-4">
-            <Tabs.List className="flex h-10 w-full min-w-0 gap-3 overflow-x-auto [scrollbar-width:none] sm:h-full sm:w-auto sm:flex-1 sm:gap-4 [&::-webkit-scrollbar]:hidden">
+          <div className="flex h-10 w-full shrink-0 items-center border-b border-solid border-slate-6 px-2 sm:px-4">
+            <div className="flex h-full min-w-0 flex-1 items-center sm:hidden">
+              <DropdownMenu.Root>
+                <DropdownMenu.Trigger asChild>
+                  <button
+                    type="button"
+                    className="group flex h-full items-center gap-1 px-1 text-slate-11 text-sm transition-colors hover:text-slate-12"
+                  >
+                    {activePanelLabel}
+                    <IconArrowDown
+                      size={20}
+                      className="transition-transform group-data-[state=open]:rotate-180"
+                    />
+                  </button>
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Portal>
+                  <DropdownMenu.Content
+                    align="start"
+                    className="z-50 min-w-44 rounded-md border border-slate-6 bg-black p-1 font-sans"
+                    collisionPadding={8}
+                    side="top"
+                    sideOffset={8}
+                  >
+                    {availablePanels.map((panel) => (
+                      <DropdownMenu.Item
+                        key={panel.value}
+                        onSelect={() => {
+                          setActivePanelValue(panel.value);
+                        }}
+                        className={cn(
+                          'flex cursor-pointer items-center justify-between gap-2 rounded px-3 py-2 text-slate-11 text-sm outline-none',
+                          'data-[highlighted]:bg-white/5 data-[highlighted]:text-slate-12',
+                          activeTab === panel.value && 'text-cyan-11',
+                        )}
+                      >
+                        {panel.label}
+                        {activeTab === panel.value ? (
+                          <IconCheck size={16} />
+                        ) : null}
+                      </DropdownMenu.Item>
+                    ))}
+                  </DropdownMenu.Content>
+                </DropdownMenu.Portal>
+              </DropdownMenu.Root>
+            </div>
+            <Tabs.List className="hidden h-full min-w-0 flex-1 gap-4 sm:flex">
               <LayoutGroup id={`toolbar-${id}`}>
                 <Tabs.Trigger asChild value="linter">
                   <ToolbarButton active={activeTab === 'linter'}>
@@ -230,7 +290,7 @@ const ToolbarInner = ({
                 </Tabs.Trigger>
               </LayoutGroup>
             </Tabs.List>
-            <div className="flex h-10 w-full shrink-0 items-center justify-end gap-1 border-t border-slate-6 sm:ml-4 sm:h-full sm:w-auto sm:border-t-0">
+            <div className="ml-2 flex shrink-0 items-center gap-1 sm:ml-4">
               <CopyForAI
                 lintingRows={lintingRows}
                 compatibilityResults={compatibilityCheckingResults}

--- a/packages/ui/src/components/toolbar.tsx
+++ b/packages/ui/src/components/toolbar.tsx
@@ -152,25 +152,25 @@ const ToolbarInner = ({
 
   const id = React.useId();
   const [isToolbarInfoOpen, setIsToolbarInfoOpen] = React.useState(false);
+  const infoPointerTypeRef = React.useRef('');
   const infoBlurListenerRef = React.useRef<(() => void) | null>(null);
-  const handleToolbarInfoOpenChange = (open: boolean) => {
-    setIsToolbarInfoOpen(open);
-
-    if (open && infoBlurListenerRef.current === null) {
-      // Taps inside the email preview iframe do not reach Radix's dismiss
-      // layer, but they do move focus to the iframe and blur the window.
-      const closeWhenPreviewGetsFocus = () => {
-        if (document.activeElement instanceof HTMLIFrameElement) {
-          handleToolbarInfoOpenChange(false);
-        }
-      };
-      infoBlurListenerRef.current = closeWhenPreviewGetsFocus;
-      window.addEventListener('blur', closeWhenPreviewGetsFocus);
-    } else if (!open && infoBlurListenerRef.current !== null) {
+  const closeToolbarInfo = () => {
+    setIsToolbarInfoOpen(false);
+    if (infoBlurListenerRef.current) {
       window.removeEventListener('blur', infoBlurListenerRef.current);
       infoBlurListenerRef.current = null;
     }
   };
+  // Only a cleanup for when the component unmounts with the popover still
+  // open; opening/closing itself is handled directly in `onOpenChange`.
+  React.useEffect(() => {
+    return () => {
+      if (infoBlurListenerRef.current) {
+        window.removeEventListener('blur', infoBlurListenerRef.current);
+        infoBlurListenerRef.current = null;
+      }
+    };
+  }, []);
 
   const toolbarPanelDescription =
     (activeTab === 'linter' &&
@@ -316,7 +316,25 @@ const ToolbarInner = ({
                 activeTab={activeTab}
               />
               <Popover.Root
-                onOpenChange={handleToolbarInfoOpenChange}
+                onOpenChange={(open) => {
+                  if (!open) {
+                    closeToolbarInfo();
+                    return;
+                  }
+
+                  setIsToolbarInfoOpen(true);
+                  if (infoBlurListenerRef.current === null) {
+                    // Taps inside the email preview iframe do not reach
+                    // Radix's dismiss layer, but they do blur the window.
+                    const closeWhenPreviewGetsFocus = () => {
+                      if (document.activeElement instanceof HTMLIFrameElement) {
+                        closeToolbarInfo();
+                      }
+                    };
+                    infoBlurListenerRef.current = closeWhenPreviewGetsFocus;
+                    window.addEventListener('blur', closeWhenPreviewGetsFocus);
+                  }
+                }}
                 open={isToolbarInfoOpen}
               >
                 <Popover.Trigger asChild>
@@ -326,13 +344,36 @@ const ToolbarInner = ({
                     tooltip={
                       isToolbarInfoOpen ? undefined : toolbarPanelDescription
                     }
+                    onPointerDown={(event) => {
+                      // Read the pointer type from `pointerdown` rather than
+                      // the `click` event: Safari before 18.2 dispatches
+                      // `click` as a plain MouseEvent without `pointerType`.
+                      infoPointerTypeRef.current = event.pointerType;
+                      const clearPointerType = () => {
+                        // Deferred so the `click` for this same interaction
+                        // can still read the pointer type; this also
+                        // self-heals if the pointer is released off the
+                        // button and no `click` ever fires.
+                        setTimeout(() => {
+                          infoPointerTypeRef.current = '';
+                        }, 0);
+                      };
+                      window.addEventListener('pointerup', clearPointerType, {
+                        once: true,
+                        capture: true,
+                      });
+                      window.addEventListener(
+                        'pointercancel',
+                        clearPointerType,
+                        { once: true, capture: true },
+                      );
+                    }}
                     onClick={(event) => {
                       // Mouse users already get this info on hover, so only
                       // touch and keyboard interactions open the popover.
-                      // Click events are PointerEvents in modern browsers,
-                      // with an empty pointerType for keyboard activation.
-                      const { pointerType } = event.nativeEvent as PointerEvent;
-                      if (pointerType === 'mouse') {
+                      // Keyboard activation dispatches `click` without a
+                      // preceding `pointerdown`, leaving the ref empty.
+                      if (infoPointerTypeRef.current === 'mouse') {
                         event.preventDefault();
                       }
                     }}

--- a/packages/ui/src/components/toolbar.tsx
+++ b/packages/ui/src/components/toolbar.tsx
@@ -167,39 +167,41 @@ const ToolbarInner = ({
         asChild
       >
         <div className="flex flex-col h-full">
-          <Tabs.List className="flex gap-4 px-4 border-b border-solid border-slate-6 h-10 w-full shrink-0">
-            <LayoutGroup id={`toolbar-${id}`}>
-              <Tabs.Trigger asChild value="linter">
-                <ToolbarButton active={activeTab === 'linter'}>
-                  Linter
-                </ToolbarButton>
-              </Tabs.Trigger>
-              {isRawHtmlEmail ? null : (
-                <Tabs.Trigger asChild value="compatibility">
-                  <ToolbarButton active={activeTab === 'compatibility'}>
-                    Compatibility
+          <div className="flex h-10 w-full shrink-0 items-center border-b border-solid border-slate-6 px-2 sm:px-4">
+            <Tabs.List className="flex h-full min-w-0 flex-1 gap-2 overflow-x-auto [scrollbar-width:none] sm:gap-4 [&::-webkit-scrollbar]:hidden">
+              <LayoutGroup id={`toolbar-${id}`}>
+                <Tabs.Trigger asChild value="linter">
+                  <ToolbarButton active={activeTab === 'linter'}>
+                    Linter
                   </ToolbarButton>
                 </Tabs.Trigger>
-              )}
-              <Tabs.Trigger asChild value="spam-assassin">
-                <ToolbarButton active={activeTab === 'spam-assassin'}>
-                  Spam
-                </ToolbarButton>
-              </Tabs.Trigger>
-              {isRawHtmlEmail || isBuilding ? null : (
-                <Tabs.Trigger asChild value="props">
-                  <ToolbarButton active={activeTab === 'props'}>
-                    Props
+                {isRawHtmlEmail ? null : (
+                  <Tabs.Trigger asChild value="compatibility">
+                    <ToolbarButton active={activeTab === 'compatibility'}>
+                      Compatibility
+                    </ToolbarButton>
+                  </Tabs.Trigger>
+                )}
+                <Tabs.Trigger asChild value="spam-assassin">
+                  <ToolbarButton active={activeTab === 'spam-assassin'}>
+                    Spam
                   </ToolbarButton>
                 </Tabs.Trigger>
-              )}
-              <Tabs.Trigger asChild value="resend">
-                <ToolbarButton active={activeTab === 'resend'}>
-                  Resend
-                </ToolbarButton>
-              </Tabs.Trigger>
-            </LayoutGroup>
-            <div className="flex items-center gap-1 ml-auto">
+                {isRawHtmlEmail || isBuilding ? null : (
+                  <Tabs.Trigger asChild value="props">
+                    <ToolbarButton active={activeTab === 'props'}>
+                      Props
+                    </ToolbarButton>
+                  </Tabs.Trigger>
+                )}
+                <Tabs.Trigger asChild value="resend">
+                  <ToolbarButton active={activeTab === 'resend'}>
+                    Resend
+                  </ToolbarButton>
+                </Tabs.Trigger>
+              </LayoutGroup>
+            </Tabs.List>
+            <div className="ml-2 flex shrink-0 items-center gap-1 sm:ml-4">
               <CopyForAI
                 lintingRows={lintingRows}
                 compatibilityResults={compatibilityCheckingResults}
@@ -273,7 +275,7 @@ const ToolbarInner = ({
                 />
               </ToolbarButton>
             </div>
-          </Tabs.List>
+          </div>
 
           <div className="grow transition-opacity opacity-100 group-data-[toggled=false]/toolbar:opacity-0 overflow-y-auto pr-3 pl-4 pt-3">
             <Tabs.Content value="linter">

--- a/packages/ui/src/components/toolbar.tsx
+++ b/packages/ui/src/components/toolbar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import * as Popover from '@radix-ui/react-popover';
 import * as Tabs from '@radix-ui/react-tabs';
 import { LayoutGroup } from 'framer-motion';
 import { usePathname, useSearchParams } from 'next/navigation';
@@ -149,6 +150,18 @@ const ToolbarInner = ({
   }
 
   const id = React.useId();
+  const toolbarPanelDescription =
+    (activeTab === 'linter' &&
+      'The Linter tab checks all the images and links for common issues like missing alt text, broken URLs, insecure HTTP methods, and more.') ||
+    (activeTab === 'spam-assassin' &&
+      'The Spam tab will look at the content and use a robust scoring framework to determine if the email is likely to be spam. Powered by SpamAssassin.') ||
+    (activeTab === 'compatibility' &&
+      'The Compatibility tab shows how well the HTML/CSS is supported across mail clients like Outlook, Gmail, etc. Powered by Can I Email.') ||
+    (activeTab === 'props' &&
+      'The Props tab lets you edit the props the preview renders with, to try out different content without changing the template.') ||
+    (activeTab === 'resend' &&
+      'The Resend tab allows you to upload your React Email code using the Resend Templates API.') ||
+    'Info';
 
   return (
     <div
@@ -210,24 +223,24 @@ const ToolbarInner = ({
                 isRawHtmlEmail={isRawHtmlEmail}
                 activeTab={activeTab}
               />
-              <ToolbarButton
-                delayDuration={0}
-                tooltip={
-                  (activeTab === 'linter' &&
-                    'The Linter tab checks all the images and links for common issues like missing alt text, broken URLs, insecure HTTP methods, and more.') ||
-                  (activeTab === 'spam-assassin' &&
-                    'The Spam tab will look at the content and use a robust scoring framework to determine if the email is likely to be spam. Powered by SpamAssassin.') ||
-                  (activeTab === 'compatibility' &&
-                    'The Compatibility tab shows how well the HTML/CSS is supported across mail clients like Outlook, Gmail, etc. Powered by Can I Email.') ||
-                  (activeTab === 'props' &&
-                    'The Props tab lets you edit the props the preview renders with, to try out different content without changing the template.') ||
-                  (activeTab === 'resend' &&
-                    'The Resend tab allows you to upload your React Email code using the Resend Templates API.') ||
-                  'Info'
-                }
-              >
-                <IconInfo size={24} />
-              </ToolbarButton>
+              <Popover.Root>
+                <Popover.Trigger asChild>
+                  <ToolbarButton aria-label="About the current toolbar panel">
+                    <IconInfo size={24} />
+                  </ToolbarButton>
+                </Popover.Trigger>
+                <Popover.Portal>
+                  <Popover.Content
+                    align="end"
+                    className="z-50 w-60 max-w-[calc(100vw-1rem)] rounded-md border border-slate-6 bg-black px-3 py-2 font-sans text-white text-xs"
+                    collisionPadding={8}
+                    side="top"
+                    sideOffset={8}
+                  >
+                    {toolbarPanelDescription}
+                  </Popover.Content>
+                </Popover.Portal>
+              </Popover.Root>
               {isBuilding ||
               activeTab === 'resend' ||
               activeTab === 'props' ? null : (

--- a/packages/ui/src/components/toolbar.tsx
+++ b/packages/ui/src/components/toolbar.tsx
@@ -195,8 +195,8 @@ const ToolbarInner = ({
         asChild
       >
         <div className="flex flex-col h-full">
-          <div className="flex h-10 w-full shrink-0 items-center border-b border-solid border-slate-6 px-2 sm:px-4">
-            <Tabs.List className="flex h-full min-w-0 flex-1 gap-2 overflow-x-auto [scrollbar-width:none] sm:gap-4 [&::-webkit-scrollbar]:hidden">
+          <div className="flex w-full shrink-0 flex-col border-b border-solid border-slate-6 px-2 sm:h-10 sm:flex-row sm:items-center sm:px-4">
+            <Tabs.List className="flex h-10 w-full min-w-0 justify-between gap-2 overflow-x-auto [scrollbar-width:none] sm:h-full sm:w-auto sm:flex-1 sm:justify-start sm:gap-4 [&::-webkit-scrollbar]:hidden">
               <LayoutGroup id={`toolbar-${id}`}>
                 <Tabs.Trigger asChild value="linter">
                   <ToolbarButton active={activeTab === 'linter'}>
@@ -229,7 +229,7 @@ const ToolbarInner = ({
                 </Tabs.Trigger>
               </LayoutGroup>
             </Tabs.List>
-            <div className="ml-2 flex shrink-0 items-center gap-1 sm:ml-4">
+            <div className="flex h-10 w-full shrink-0 items-center justify-end gap-1 border-t border-slate-6 sm:ml-4 sm:h-full sm:w-auto sm:border-t-0">
               <CopyForAI
                 lintingRows={lintingRows}
                 compatibilityResults={compatibilityCheckingResults}

--- a/packages/ui/src/components/toolbar.tsx
+++ b/packages/ui/src/components/toolbar.tsx
@@ -360,6 +360,16 @@ const ToolbarInner = ({
                       // `click` as a plain MouseEvent without `pointerType`.
                       infoPointerTypeRef.current = event.pointerType;
                       const clearPointerType = () => {
+                        window.removeEventListener(
+                          'pointerup',
+                          clearPointerType,
+                          true,
+                        );
+                        window.removeEventListener(
+                          'pointercancel',
+                          clearPointerType,
+                          true,
+                        );
                         // Deferred so the `click` for this same interaction
                         // can still read the pointer type; this also
                         // self-heals if the pointer is released off the
@@ -369,13 +379,12 @@ const ToolbarInner = ({
                         }, 0);
                       };
                       window.addEventListener('pointerup', clearPointerType, {
-                        once: true,
                         capture: true,
                       });
                       window.addEventListener(
                         'pointercancel',
                         clearPointerType,
-                        { once: true, capture: true },
+                        { capture: true },
                       );
                     }}
                     onClick={(event) => {

--- a/packages/ui/src/components/toolbar.tsx
+++ b/packages/ui/src/components/toolbar.tsx
@@ -151,6 +151,7 @@ const ToolbarInner = ({
 
   const id = React.useId();
   const [isToolbarInfoOpen, setIsToolbarInfoOpen] = React.useState(false);
+  const infoPointerTypeRef = React.useRef('');
   React.useEffect(() => {
     if (!isToolbarInfoOpen) return;
 
@@ -249,6 +250,17 @@ const ToolbarInner = ({
                     tooltip={
                       isToolbarInfoOpen ? undefined : toolbarPanelDescription
                     }
+                    onPointerDown={(event) => {
+                      infoPointerTypeRef.current = event.pointerType;
+                    }}
+                    onClick={(event) => {
+                      // Mouse users already get this info on hover, so only
+                      // touch and keyboard interactions open the popover.
+                      if (infoPointerTypeRef.current === 'mouse') {
+                        event.preventDefault();
+                      }
+                      infoPointerTypeRef.current = '';
+                    }}
                   >
                     <IconInfo size={24} />
                   </ToolbarButton>

--- a/packages/ui/src/components/toolbar.tsx
+++ b/packages/ui/src/components/toolbar.tsx
@@ -150,6 +150,21 @@ const ToolbarInner = ({
   }
 
   const id = React.useId();
+  const [isToolbarInfoOpen, setIsToolbarInfoOpen] = React.useState(false);
+  React.useEffect(() => {
+    if (!isToolbarInfoOpen) return;
+
+    // Taps inside the email preview iframe do not reach Radix's dismiss layer.
+    const closeWhenPreviewGetsFocus = () => {
+      if (document.activeElement instanceof HTMLIFrameElement) {
+        setIsToolbarInfoOpen(false);
+      }
+    };
+
+    window.addEventListener('blur', closeWhenPreviewGetsFocus);
+    return () => window.removeEventListener('blur', closeWhenPreviewGetsFocus);
+  }, [isToolbarInfoOpen]);
+
   const toolbarPanelDescription =
     (activeTab === 'linter' &&
       'The Linter tab checks all the images and links for common issues like missing alt text, broken URLs, insecure HTTP methods, and more.') ||
@@ -223,7 +238,10 @@ const ToolbarInner = ({
                 isRawHtmlEmail={isRawHtmlEmail}
                 activeTab={activeTab}
               />
-              <Popover.Root>
+              <Popover.Root
+                onOpenChange={setIsToolbarInfoOpen}
+                open={isToolbarInfoOpen}
+              >
                 <Popover.Trigger asChild>
                   <ToolbarButton aria-label="About the current toolbar panel">
                     <IconInfo size={24} />

--- a/packages/ui/src/components/toolbar.tsx
+++ b/packages/ui/src/components/toolbar.tsx
@@ -243,7 +243,13 @@ const ToolbarInner = ({
                 open={isToolbarInfoOpen}
               >
                 <Popover.Trigger asChild>
-                  <ToolbarButton aria-label="About the current toolbar panel">
+                  <ToolbarButton
+                    aria-label="About the current toolbar panel"
+                    delayDuration={0}
+                    tooltip={
+                      isToolbarInfoOpen ? undefined : toolbarPanelDescription
+                    }
+                  >
                     <IconInfo size={24} />
                   </ToolbarButton>
                 </Popover.Trigger>

--- a/packages/ui/src/components/toolbar.tsx
+++ b/packages/ui/src/components/toolbar.tsx
@@ -196,7 +196,7 @@ const ToolbarInner = ({
       >
         <div className="flex flex-col h-full">
           <div className="flex w-full shrink-0 flex-col border-b border-solid border-slate-6 px-2 sm:h-10 sm:flex-row sm:items-center sm:px-4">
-            <Tabs.List className="flex h-10 w-full min-w-0 justify-between gap-2 overflow-x-auto [scrollbar-width:none] sm:h-full sm:w-auto sm:flex-1 sm:justify-start sm:gap-4 [&::-webkit-scrollbar]:hidden">
+            <Tabs.List className="flex h-10 w-full min-w-0 justify-between overflow-x-auto [scrollbar-width:none] sm:h-full sm:w-auto sm:flex-1 sm:justify-start sm:gap-4 [&::-webkit-scrollbar]:hidden">
               <LayoutGroup id={`toolbar-${id}`}>
                 <Tabs.Trigger asChild value="linter">
                   <ToolbarButton active={activeTab === 'linter'}>

--- a/packages/ui/src/components/toolbar.tsx
+++ b/packages/ui/src/components/toolbar.tsx
@@ -152,19 +152,25 @@ const ToolbarInner = ({
 
   const id = React.useId();
   const [isToolbarInfoOpen, setIsToolbarInfoOpen] = React.useState(false);
-  React.useEffect(() => {
-    if (!isToolbarInfoOpen) return;
+  const infoBlurListenerRef = React.useRef<(() => void) | null>(null);
+  const handleToolbarInfoOpenChange = (open: boolean) => {
+    setIsToolbarInfoOpen(open);
 
-    // Taps inside the email preview iframe do not reach Radix's dismiss layer.
-    const closeWhenPreviewGetsFocus = () => {
-      if (document.activeElement instanceof HTMLIFrameElement) {
-        setIsToolbarInfoOpen(false);
-      }
-    };
-
-    window.addEventListener('blur', closeWhenPreviewGetsFocus);
-    return () => window.removeEventListener('blur', closeWhenPreviewGetsFocus);
-  }, [isToolbarInfoOpen]);
+    if (open && infoBlurListenerRef.current === null) {
+      // Taps inside the email preview iframe do not reach Radix's dismiss
+      // layer, but they do move focus to the iframe and blur the window.
+      const closeWhenPreviewGetsFocus = () => {
+        if (document.activeElement instanceof HTMLIFrameElement) {
+          handleToolbarInfoOpenChange(false);
+        }
+      };
+      infoBlurListenerRef.current = closeWhenPreviewGetsFocus;
+      window.addEventListener('blur', closeWhenPreviewGetsFocus);
+    } else if (!open && infoBlurListenerRef.current !== null) {
+      window.removeEventListener('blur', infoBlurListenerRef.current);
+      infoBlurListenerRef.current = null;
+    }
+  };
 
   const toolbarPanelDescription =
     (activeTab === 'linter' &&
@@ -310,7 +316,7 @@ const ToolbarInner = ({
                 activeTab={activeTab}
               />
               <Popover.Root
-                onOpenChange={setIsToolbarInfoOpen}
+                onOpenChange={handleToolbarInfoOpenChange}
                 open={isToolbarInfoOpen}
               >
                 <Popover.Trigger asChild>

--- a/packages/ui/src/components/toolbar.tsx
+++ b/packages/ui/src/components/toolbar.tsx
@@ -154,13 +154,6 @@ const ToolbarInner = ({
   const [isToolbarInfoOpen, setIsToolbarInfoOpen] = React.useState(false);
   const infoPointerTypeRef = React.useRef('');
   const infoBlurListenerRef = React.useRef<(() => void) | null>(null);
-  const closeToolbarInfo = () => {
-    setIsToolbarInfoOpen(false);
-    if (infoBlurListenerRef.current) {
-      window.removeEventListener('blur', infoBlurListenerRef.current);
-      infoBlurListenerRef.current = null;
-    }
-  };
   // Only a cleanup for when the component unmounts with the popover still
   // open; opening/closing itself is handled directly in `onOpenChange`.
   React.useEffect(() => {
@@ -318,7 +311,14 @@ const ToolbarInner = ({
               <Popover.Root
                 onOpenChange={(open) => {
                   if (!open) {
-                    closeToolbarInfo();
+                    setIsToolbarInfoOpen(false);
+                    if (infoBlurListenerRef.current) {
+                      window.removeEventListener(
+                        'blur',
+                        infoBlurListenerRef.current,
+                      );
+                      infoBlurListenerRef.current = null;
+                    }
                     return;
                   }
 
@@ -327,8 +327,18 @@ const ToolbarInner = ({
                     // Taps inside the email preview iframe do not reach
                     // Radix's dismiss layer, but they do blur the window.
                     const closeWhenPreviewGetsFocus = () => {
-                      if (document.activeElement instanceof HTMLIFrameElement) {
-                        closeToolbarInfo();
+                      if (
+                        !(document.activeElement instanceof HTMLIFrameElement)
+                      ) {
+                        return;
+                      }
+                      setIsToolbarInfoOpen(false);
+                      if (infoBlurListenerRef.current) {
+                        window.removeEventListener(
+                          'blur',
+                          infoBlurListenerRef.current,
+                        );
+                        infoBlurListenerRef.current = null;
                       }
                     };
                     infoBlurListenerRef.current = closeWhenPreviewGetsFocus;

--- a/packages/ui/src/components/toolbar.tsx
+++ b/packages/ui/src/components/toolbar.tsx
@@ -183,8 +183,8 @@ const ToolbarInner = ({
       data-toggled={toggled}
       className={cn(
         'absolute bottom-0 left-0 right-0',
-        'border-t border-slate-6 group/toolbar text-xs text-slate-11 h-52 transition-transform',
-        'data-[toggled=false]:translate-y-42.5',
+        'border-t border-slate-6 group/toolbar text-xs text-slate-11 h-62 transition-transform sm:h-52',
+        'data-[toggled=false]:translate-y-52.5 sm:data-[toggled=false]:translate-y-42.5',
       )}
     >
       <Tabs.Root
@@ -196,7 +196,7 @@ const ToolbarInner = ({
       >
         <div className="flex flex-col h-full">
           <div className="flex w-full shrink-0 flex-col border-b border-solid border-slate-6 px-2 sm:h-10 sm:flex-row sm:items-center sm:px-4">
-            <Tabs.List className="flex h-10 w-full min-w-0 justify-between overflow-x-auto [scrollbar-width:none] sm:h-full sm:w-auto sm:flex-1 sm:justify-start sm:gap-4 [&::-webkit-scrollbar]:hidden">
+            <Tabs.List className="flex h-10 w-full min-w-0 gap-3 overflow-x-auto [scrollbar-width:none] sm:h-full sm:w-auto sm:flex-1 sm:gap-4 [&::-webkit-scrollbar]:hidden">
               <LayoutGroup id={`toolbar-${id}`}>
                 <Tabs.Trigger asChild value="linter">
                   <ToolbarButton active={activeTab === 'linter'}>

--- a/packages/ui/src/components/toolbar.tsx
+++ b/packages/ui/src/components/toolbar.tsx
@@ -152,7 +152,6 @@ const ToolbarInner = ({
 
   const id = React.useId();
   const [isToolbarInfoOpen, setIsToolbarInfoOpen] = React.useState(false);
-  const infoPointerTypeRef = React.useRef('');
   React.useEffect(() => {
     if (!isToolbarInfoOpen) return;
 
@@ -180,20 +179,31 @@ const ToolbarInner = ({
       'The Resend tab allows you to upload your React Email code using the Resend Templates API.') ||
     'Info';
 
+  const panelLabels: Record<ToolbarTabValue, string> = {
+    linter: 'Linter',
+    compatibility: 'Compatibility',
+    'spam-assassin': 'Spam',
+    props: 'Props',
+    resend: 'Resend',
+  };
   const availablePanels: { value: ToolbarTabValue; label: string }[] = [
-    { value: 'linter', label: 'Linter' },
+    { value: 'linter', label: panelLabels.linter },
     ...(isRawHtmlEmail
       ? []
-      : ([{ value: 'compatibility', label: 'Compatibility' }] as const)),
-    { value: 'spam-assassin', label: 'Spam' },
+      : [
+          { value: 'compatibility' as const, label: panelLabels.compatibility },
+        ]),
+    { value: 'spam-assassin', label: panelLabels['spam-assassin'] },
     ...(isRawHtmlEmail || isBuilding
       ? []
-      : ([{ value: 'props', label: 'Props' }] as const)),
-    { value: 'resend', label: 'Resend' },
+      : [{ value: 'props' as const, label: panelLabels.props }]),
+    { value: 'resend', label: panelLabels.resend },
   ];
+  // The label must reflect the URL-selected panel even when that panel is not
+  // offered for this template (e.g. compatibility on a raw HTML email), since
+  // the content area still renders that panel's state.
   const activePanelLabel =
-    availablePanels.find((panel) => panel.value === activeTab)?.label ??
-    'Linter';
+    (activeTab ? panelLabels[activeTab] : undefined) ?? 'Linter';
 
   return (
     <div
@@ -310,16 +320,15 @@ const ToolbarInner = ({
                     tooltip={
                       isToolbarInfoOpen ? undefined : toolbarPanelDescription
                     }
-                    onPointerDown={(event) => {
-                      infoPointerTypeRef.current = event.pointerType;
-                    }}
                     onClick={(event) => {
                       // Mouse users already get this info on hover, so only
                       // touch and keyboard interactions open the popover.
-                      if (infoPointerTypeRef.current === 'mouse') {
+                      // Click events are PointerEvents in modern browsers,
+                      // with an empty pointerType for keyboard activation.
+                      const { pointerType } = event.nativeEvent as PointerEvent;
+                      if (pointerType === 'mouse') {
                         event.preventDefault();
                       }
-                      infoPointerTypeRef.current = '';
                     }}
                   >
                     <IconInfo size={24} />

--- a/packages/ui/src/components/toolbar/copy-for-ai.tsx
+++ b/packages/ui/src/components/toolbar/copy-for-ai.tsx
@@ -297,9 +297,10 @@ export const CopyForAI = ({
 
       <DropdownMenu.Portal>
         <DropdownMenu.Content
-          className="min-w-[260px] rounded-xl p-1.5 shadow-2xl z-50 border border-white/10"
+          className="max-h-[var(--radix-dropdown-menu-content-available-height)] w-80 max-w-[calc(100vw-1rem)] overflow-y-auto rounded-xl p-1.5 shadow-2xl z-50 border border-white/10"
           style={{ backgroundColor: '#0c0c0c' }}
           sideOffset={8}
+          collisionPadding={8}
           align="end"
           side="top"
         >

--- a/packages/ui/src/components/toolbar/copy-for-ai.tsx
+++ b/packages/ui/src/components/toolbar/copy-for-ai.tsx
@@ -285,7 +285,7 @@ export const CopyForAI = ({
         <button
           type="button"
           className={cn(
-            'flex items-center gap-1 h-7 px-2.5 rounded-md text-xs font-medium self-center',
+            'flex shrink-0 items-center gap-1 h-7 whitespace-nowrap px-2.5 rounded-md text-xs font-medium self-center',
             'text-slate-11',
             'hover:text-slate-12 transition-colors',
             'outline-none',

--- a/packages/ui/src/components/toolbar/toolbar-button.tsx
+++ b/packages/ui/src/components/toolbar/toolbar-button.tsx
@@ -25,7 +25,7 @@ export const ToolbarButton = ({
             type="button"
             {...props}
             className={cn(
-              'h-full w-fit font-regular flex text-sm text-slate-10 items-center align-middle justify-center px-1 gap-2 relative',
+              'h-full w-fit shrink-0 whitespace-nowrap font-regular flex text-sm text-slate-10 items-center align-middle justify-center px-1 gap-2 relative',
               'hover:text-slate-12 transition-colors',
               active && 'data-[state=active]:text-cyan-11',
               className,

--- a/packages/ui/src/components/toolbar/toolbar-button.tsx
+++ b/packages/ui/src/components/toolbar/toolbar-button.tsx
@@ -34,7 +34,7 @@ export const ToolbarButton = ({
             {children}
             {active ? (
               <motion.span
-                className="-bottom-px absolute rounded-xs left-0 w-full bg-cyan-11 h-px"
+                className="bottom-0 absolute rounded-xs left-0 w-full bg-cyan-11 h-px"
                 layoutId="active-toolbar-button"
                 transition={{
                   type: 'spring',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- on small screens, replace the toolbar tab strip with a compact dropdown switcher showing the current panel name plus a chevron; the menu lists all available panels with the active one highlighted and checked
- desktop keeps the original single-row text tabs with the animated underline indicator
- keep toolbar labels and the “Copy for AI” action on one line
- constrain the Copy for AI menu to the available viewport width and height
- show toolbar information on desktop hover only (mouse clicks are inert), and as a persistent popover on touch tap or keyboard activation
- dismiss the tap popover after outside interactions, including taps inside the email preview iframe, with a listener that self-clears if the component unmounts while open
- the info popover's open/close logic is fully inlined at the `onOpenChange`/`onClick`/`onPointerDown` handlers (no extracted top-level handler functions); the pointer-type tracking removes both its `pointerup`/`pointercancel` listeners on either terminal event so repeated interactions don't accumulate stale window listeners
- add a patch changeset for `@react-email/ui`

## Testing
- `pnpm exec biome check` on changed files
- `pnpm --filter @react-email/ui test` (105 tests passed)
- Playwright at 375px: dropdown lists all five panels, fits the viewport, selecting Resend opens its panel and updates the trigger label, outside taps close the menu, and the collapsed toolbar shows the switcher strip
- Playwright at 1280px: text tabs render as before, the dropdown is hidden, and clicking tabs switches panels
- Playwright on both Chromium and WebKit: hover shows the info tooltip, a real mouse click stays inert, keyboard Enter opens the persistent popover, and clicking inside the email preview iframe closes it
- Playwright verified no error and normal behavior on a freshly mounted instance after unmounting the toolbar while the info popover was open and dispatching a synthetic `blur`
- Playwright confirmed (by instrumenting `addEventListener`/`removeEventListener`) that 5 real clicks and 5 simulated interrupted presses in a row leave no stray `pointerup`/`pointercancel` listeners on `window`

[Mobile dropdown panel switcher open](https://cursor.com/agents/bc-15b3853b-4550-5054-9f45-1bc4d88fd029/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile-dropdown-open.png)
[Resend panel selected from the dropdown](https://cursor.com/agents/bc-15b3853b-4550-5054-9f45-1bc4d88fd029/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile-dropdown-selected.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0AG3A0TP7W/p1783951155431249?thread_ts=1783951155.431249&cid=C0AG3A0TP7W)

<div><a href="https://cursor.com/agents/bc-15b3853b-4550-5054-9f45-1bc4d88fd029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15b3853b-4550-5054-9f45-1bc4d88fd029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the preview toolbar and `Copy for AI` menu responsive. On small screens, tabs collapse into a dropdown that shows the current panel; the info button uses hover on desktop and a persistent popover on touch/keyboard.

- **Bug Fixes**
  - Mobile dropdown lists available panels, reflects the active panel, and checks it; tabs fit narrow widths.
  - Keep toolbar labels and `Copy for AI` on one line; keep the active-tab underline aligned.
  - Constrain `Copy for AI` and info popover to the viewport with max size, scrolling, and collision padding.
  - Info popover opens only via touch/keyboard (mouse clicks are inert), reads pointer type on `pointerdown` for Safari, registers a blur listener on open, closes when the preview iframe gains focus, and cleans up blur and pointer listeners on close and unmount.

- **Dependencies**
  - Patch changeset for `@react-email/ui`.

<sup>Written for commit 9a809592cf589e4a6b22c0d82f91629c3e2ee721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

