### PR TITLE
fix: zeroed composed body margins

### DIFF
--- a/.changeset/plenty-carrots-bow.md
+++ b/.changeset/plenty-carrots-bow.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+Zeroed composed body margins

--- a/packages/editor/src/extensions/container.spec.tsx
+++ b/packages/editor/src/extensions/container.spec.tsx
@@ -276,7 +276,7 @@ describe('Container Node', () => {
             @media (prefers-color-scheme: dark){li::marker{color:#c4c4c4}}
           </style>
         </head>
-        <body dir="ltr" lang="en" style="background-color:#ffffff">
+        <body dir="ltr" lang="en" style="background-color:#ffffff;margin:0;padding:0">
           <!--$--><!--html--><!--head--><!--body-->
           <table
             border="0"
@@ -290,7 +290,7 @@ describe('Container Node', () => {
                 <td
                   dir="ltr"
                   lang="en"
-                  style="font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:1em;min-height:100%;line-height:155%;background-color:#ffffff">
+                  style="margin:0;padding:0;font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:1em;min-height:100%;line-height:155%;background-color:#ffffff">
                   <table
                     align="left"
                     width="100%"
@@ -1389,7 +1389,7 @@ describe('Container Node', () => {
             @media (prefers-color-scheme: dark){li::marker{color:#c4c4c4}}
           </style>
         </head>
-        <body dir="ltr" lang="en">
+        <body dir="ltr" lang="en" style="margin:0;padding:0">
           <!--$--><!--html--><!--head--><!--body-->
           <table
             border="0"
@@ -1403,7 +1403,7 @@ describe('Container Node', () => {
                 <td
                   dir="ltr"
                   lang="en"
-                  style="font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:14px;min-height:100%;line-height:155%">
+                  style="margin:0;padding:0;font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:14px;min-height:100%;line-height:155%">
                   <table
                     align="center"
                     width="100%"
@@ -1507,7 +1507,7 @@ describe('Container Node', () => {
             @media (prefers-color-scheme: dark){li::marker{color:#c4c4c4}}
           </style>
         </head>
-        <body dir="ltr" lang="en">
+        <body dir="ltr" lang="en" style="margin:0;padding:0">
           <!--$--><!--html--><!--head--><!--body-->
           <table
             border="0"
@@ -1521,7 +1521,7 @@ describe('Container Node', () => {
                 <td
                   dir="ltr"
                   lang="en"
-                  style="font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:14px;min-height:100%;line-height:155%">
+                  style="margin:0;padding:0;font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:14px;min-height:100%;line-height:155%">
                   <table
                     align="left"
                     width="100%"
@@ -1593,7 +1593,7 @@ describe('Container Node', () => {
             @media (prefers-color-scheme: dark){li::marker{color:#c4c4c4}}
           </style>
         </head>
-        <body dir="ltr" lang="en" style="background-color:#ffffff">
+        <body dir="ltr" lang="en" style="background-color:#ffffff;margin:0;padding:0">
           <!--$--><!--html--><!--head--><!--body-->
           <table
             border="0"
@@ -1607,7 +1607,7 @@ describe('Container Node', () => {
                 <td
                   dir="ltr"
                   lang="en"
-                  style="font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:1em;min-height:100%;line-height:155%;background-color:#ffffff">
+                  style="margin:0;padding:0;font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:1em;min-height:100%;line-height:155%;background-color:#ffffff">
                   <table
                     align="left"
                     width="100%"

--- a/packages/editor/src/plugins/email-theming/extension.tsx
+++ b/packages/editor/src/plugins/email-theming/extension.tsx
@@ -313,7 +313,15 @@ export const EmailTheming = Extension.create<{
                 <Preview>{previewText}</Preview>
               )}
 
-              <Body style={mergedStyles.body}>{children}</Body>
+              <Body
+                style={{
+                  margin: 0,
+                  padding: 0,
+                  ...mergedStyles.body,
+                }}
+              >
+                {children}
+              </Body>
             </Html>
           );
         },


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Zeroed the composed email body margin and padding in `@react-email/editor` to remove unwanted spacing and ensure consistent theming across email clients.

<sup>Written for commit bcce05923e1a9d4f8b5721482181ed50875c1dae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

