### PR TITLE
fix(react-email): inherit lang and dir on <Body> from <Html> without React context

### DIFF
--- a/.changeset/body-inherits-html-lang-dir.md
+++ b/.changeset/body-inherits-html-lang-dir.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Make `<Body>` inherit `lang` and `dir` from `<Html>` instead of always defaulting to `lang="en" dir="ltr"`, so non-English emails no longer end up with contradictory language metadata

--- a/apps/docs/components/html.mdx
+++ b/apps/docs/components/html.mdx
@@ -49,10 +49,12 @@ const Email = () => {
 ## Props
 
 <ResponseField name="lang" type="string" default="en">
-  Identify the language of text content on the email
+  Identify the language of text content on the email. Inherited by `<Body />`,
+  which repeats it for email clients that strip the `<html>` tag.
 </ResponseField>
 <ResponseField name="dir" type="string" default="ltr">
-  Identify the direction of text content on the email
+  Identify the direction of text content on the email. Inherited by `<Body />`,
+  which repeats it for email clients that strip the `<html>` tag.
 </ResponseField>
 
 <Support/>

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -80,6 +80,7 @@
     "next": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "react-server-dom-webpack": "19.2.4",
     "shelljs": "0.10.0",
     "shlex": "3.0.0",
     "tsx": "catalog:",

--- a/packages/react-email/src/components/body/body.spec.tsx
+++ b/packages/react-email/src/components/body/body.spec.tsx
@@ -1,4 +1,6 @@
 import { render } from '@react-email/render';
+import { Html } from '../html/index.js';
+import { Tailwind } from '../tailwind/index.js';
 import { Body } from './index.js';
 import { marginProperties, paddingProperties } from './margin-properties.js';
 
@@ -53,6 +55,103 @@ describe('<Body> component', () => {
     expect(bodyStyle).toContain('background-color:pink');
     expect(bodyStyle).not.toContain('padding:20px');
     expect(tdStyle).toContain('padding:20px');
+  });
+
+  describe('lang and dir inheritance from <Html>', () => {
+    const getAttributes = (html: string, tag: 'html' | 'body' | 'td') => {
+      const attributes = html.match(new RegExp(`<${tag}([^>]*)>`))?.[1] ?? '';
+      return {
+        lang: attributes.match(/lang="([^"]*)"/)?.[1],
+        dir: attributes.match(/dir="([^"]*)"/)?.[1],
+      };
+    };
+
+    it('defaults to lang="en" dir="ltr" without an <Html> parent', async () => {
+      const html = await render(<Body>Test</Body>);
+      expect(getAttributes(html, 'body')).toEqual({ lang: 'en', dir: 'ltr' });
+      expect(getAttributes(html, 'td')).toEqual({ lang: 'en', dir: 'ltr' });
+    });
+
+    it('inherits lang and dir set on <Html>', async () => {
+      const html = await render(
+        <Html lang="ar" dir="rtl">
+          <Body>Test</Body>
+        </Html>,
+      );
+      expect(getAttributes(html, 'body')).toEqual({ lang: 'ar', dir: 'rtl' });
+      expect(getAttributes(html, 'td')).toEqual({ lang: 'ar', dir: 'rtl' });
+    });
+
+    it("inherits <Html>'s defaults when it has no explicit lang/dir", async () => {
+      const html = await render(
+        <Html>
+          <Body>Test</Body>
+        </Html>,
+      );
+      expect(getAttributes(html, 'body')).toEqual({ lang: 'en', dir: 'ltr' });
+    });
+
+    it('lets explicit lang and dir on <Body> win over <Html>', async () => {
+      const html = await render(
+        <Html lang="pl">
+          <Body lang="en" dir="rtl">
+            Test
+          </Body>
+        </Html>,
+      );
+      expect(getAttributes(html, 'html')).toEqual({ lang: 'pl', dir: 'ltr' });
+      expect(getAttributes(html, 'body')).toEqual({ lang: 'en', dir: 'rtl' });
+    });
+
+    it('inherits lang and dir through custom components', async () => {
+      const Content = ({ children }: { children: React.ReactNode }) => {
+        return <Body>{children}</Body>;
+      };
+      const Layout = ({ children }: { children: React.ReactNode }) => {
+        return <Content>{children}</Content>;
+      };
+
+      const html = await render(
+        <Html lang="pl">
+          <Layout>Cześć</Layout>
+        </Html>,
+      );
+      expect(getAttributes(html, 'body')).toEqual({ lang: 'pl', dir: 'ltr' });
+      expect(getAttributes(html, 'td')).toEqual({ lang: 'pl', dir: 'ltr' });
+    });
+
+    it('inherits lang and dir with <Tailwind> in between', async () => {
+      const html = await render(
+        <Html lang="pl">
+          <Tailwind>
+            <Body className="bg-red-500">Cześć</Body>
+          </Tailwind>
+        </Html>,
+      );
+      expect(getAttributes(html, 'body')).toEqual({ lang: 'pl', dir: 'ltr' });
+      expect(html).toContain('background-color');
+    });
+
+    it('inherits lang and dir with <Tailwind> around <Html>', async () => {
+      const html = await render(
+        <Tailwind>
+          <Html lang="pl">
+            <Body className="bg-red-500">Cześć</Body>
+          </Html>
+        </Tailwind>,
+      );
+      expect(getAttributes(html, 'body')).toEqual({ lang: 'pl', dir: 'ltr' });
+      expect(html).toContain('background-color');
+    });
+
+    it('does not leak the private context prop into the markup', async () => {
+      const html = await render(
+        <Html lang="pl">
+          <Body>Test</Body>
+        </Html>,
+      );
+      expect(html.toLowerCase()).not.toContain('reactemailcontexts');
+    });
   });
 
   describe('padding resetting behavior', () => {

--- a/packages/react-email/src/components/body/body.tsx
+++ b/packages/react-email/src/components/body/body.tsx
@@ -1,11 +1,28 @@
 import * as React from 'react';
 import { markAsElement } from '../element-marker.js';
+import {
+  markAsEmailContextConsumer,
+  readEmailContext,
+  stripEmailContexts,
+} from '../email-context/index.js';
+import { htmlContext } from '../html/html-context.js';
 import { marginProperties, paddingProperties } from './margin-properties.js';
 
 export type BodyProps = Readonly<React.HtmlHTMLAttributes<HTMLBodyElement>>;
 
 export const Body = React.forwardRef<HTMLBodyElement, BodyProps>(
   ({ children, style, ...props }, ref) => {
+    // Email clients like Gmail may strip the html tag, so the language
+    // metadata is repeated here. It is inherited from <Html> to avoid
+    // conflicting values in the same document.
+    // See https://github.com/resend/react-email/issues/3652.
+    const inherited = readEmailContext(props, htmlContext);
+    const {
+      dir = inherited.dir ?? 'ltr',
+      lang = inherited.lang ?? 'en',
+      ...restProps
+    } = stripEmailContexts(props);
+
     const bodyStyle: Record<string, string | number | undefined> = {
       background: style?.background,
       backgroundColor: style?.backgroundColor,
@@ -20,13 +37,7 @@ export const Body = React.forwardRef<HTMLBodyElement, BodyProps>(
       }
     }
     return (
-      <body
-        {...props}
-        dir={props.dir ?? 'ltr'}
-        lang={props.lang ?? 'en'}
-        style={bodyStyle}
-        ref={ref}
-      >
+      <body {...restProps} dir={dir} lang={lang} style={bodyStyle} ref={ref}>
         <table
           border={0}
           width="100%"
@@ -43,11 +54,7 @@ export const Body = React.forwardRef<HTMLBodyElement, BodyProps>(
 
                 See https://github.com/resend/react-email/issues/662.
               */}
-              <td
-                dir={props.dir ?? 'ltr'}
-                lang={props.lang ?? 'en'}
-                style={style}
-              >
+              <td dir={dir} lang={lang} style={style}>
                 {children}
               </td>
             </tr>
@@ -60,3 +67,4 @@ export const Body = React.forwardRef<HTMLBodyElement, BodyProps>(
 
 Body.displayName = 'Body';
 markAsElement(Body);
+markAsEmailContextConsumer(Body);

--- a/packages/react-email/src/components/email-context/create-email-context.ts
+++ b/packages/react-email/src/components/email-context/create-email-context.ts
@@ -1,0 +1,106 @@
+import type * as React from 'react';
+import {
+  contextsPropName,
+  type EmailContextMap,
+  markAsEmailContextConsumer,
+  markAsEmailContextProvider,
+} from './markers.js';
+import { propagateEmailContexts } from './propagate-email-contexts.js';
+
+/**
+ * A context meant to be used by the email components, mimicking React
+ * context without relying on it.
+ *
+ * React context cannot be used for the email components because they may be
+ * rendered inside React Server Components, where `createContext` and hooks
+ * are not available, while also being rendered with `react-dom/server` or in
+ * the browser.
+ *
+ * Instead of the value living in the renderer, it is carried through the
+ * element tree itself: a provider component walks its children at render
+ * time and clones every registered consumer element with the value injected
+ * into a private prop (see `propagateEmailContexts` for how component
+ * boundaries are crossed). Consumers then read it with `readEmailContext`,
+ * which is a plain function and not a hook.
+ */
+export interface EmailContext<Value> {
+  id: symbol;
+  defaultValue: Value;
+}
+
+export const createEmailContext = <Value>(
+  name: string,
+  defaultValue: Value,
+): EmailContext<Value> => ({
+  // Registered globally so that duplicated copies of a context's module
+  // (e.g. the CJS and ESM builds loaded in the same process) interoperate.
+  id: Symbol.for(`react-email.email-context.${name}`),
+  defaultValue,
+});
+
+/**
+ * Reads the value provided for `context` from a consumer component's props.
+ *
+ * The component must have been marked with `markAsEmailContextConsumer` for
+ * providers to inject values into it. Falls back to the context's default
+ * value when the component is rendered outside of a provider or when the
+ * propagation could not reach it (see the caveats on
+ * `propagateEmailContexts`).
+ */
+export const readEmailContext = <Value>(
+  props: object,
+  context: EmailContext<Value>,
+): Value => {
+  const contexts = (props as Record<string, unknown>)[contextsPropName] as
+    | EmailContextMap
+    | undefined;
+  if (contexts && context.id in contexts) {
+    return contexts[context.id] as Value;
+  }
+  return context.defaultValue;
+};
+
+/**
+ * Removes the private prop used to carry email context values so that it
+ * doesn't leak into the DOM. Consumers and providers must call this before
+ * spreading their remaining props into a host element.
+ */
+export const stripEmailContexts = <Props extends object>(
+  props: Props,
+): Props => {
+  if (!(contextsPropName in props)) {
+    return props;
+  }
+  const { [contextsPropName]: _contexts, ...rest } = props as Props & {
+    [contextsPropName]?: EmailContextMap;
+  };
+  return rest as unknown as Props;
+};
+
+/**
+ * Provides a value for `context` to all consumer elements found inside
+ * `children`, mimicking what rendering a React context provider would do.
+ *
+ * The component calling this must be marked with
+ * `markAsEmailContextProvider` and pass its own props as `providerProps`:
+ * outer providers stop their propagation at nested provider elements and
+ * inject the values they carry into them, so the nested provider is
+ * responsible for merging its own value over the inherited ones and
+ * continuing the propagation, which is what this function does.
+ */
+export const provideEmailContext = <Value>(
+  context: EmailContext<Value>,
+  value: Value,
+  children: React.ReactNode,
+  providerProps: object,
+): React.ReactNode => {
+  const inherited = (providerProps as Record<string, unknown>)[
+    contextsPropName
+  ] as EmailContextMap | undefined;
+  return propagateEmailContexts(children, {
+    ...inherited,
+    [context.id]: value,
+  });
+};
+
+export { markAsEmailContextConsumer, markAsEmailContextProvider };

--- a/packages/react-email/src/components/email-context/email-context.spec.tsx
+++ b/packages/react-email/src/components/email-context/email-context.spec.tsx
@@ -1,0 +1,269 @@
+import { render } from '@react-email/render';
+import * as React from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import {
+  createEmailContext,
+  markAsEmailContextConsumer,
+  markAsEmailContextProvider,
+  provideEmailContext,
+  readEmailContext,
+} from './index.js';
+
+const valueContext = createEmailContext<string>(
+  'email-context.spec',
+  'default value',
+);
+
+const Consumer = (props: { children?: React.ReactNode }) => {
+  const value = readEmailContext(props, valueContext);
+  return (
+    <span data-value={value} data-testid="consumer">
+      {props.children}
+    </span>
+  );
+};
+markAsEmailContextConsumer(Consumer);
+
+const Provider = (props: { value: string; children?: React.ReactNode }) => {
+  return provideEmailContext(valueContext, props.value, props.children, props);
+};
+markAsEmailContextProvider(Provider);
+
+describe('email contexts', () => {
+  it('provides the default value without a provider', async () => {
+    const html = await render(<Consumer />);
+    expect(html).toContain('data-value="default value"');
+  });
+
+  it('provides values to direct children', async () => {
+    const html = await render(
+      <Provider value="direct">
+        <Consumer />
+      </Provider>,
+    );
+    expect(html).toContain('data-value="direct"');
+  });
+
+  it('provides values through host elements, fragments and arrays', async () => {
+    const html = await render(
+      <Provider value="structural">
+        <div>
+          <>
+            {[
+              <table key="table">
+                <tbody>
+                  <tr>
+                    <td>
+                      <Consumer />
+                    </td>
+                  </tr>
+                </tbody>
+              </table>,
+            ]}
+          </>
+        </div>
+      </Provider>,
+    );
+    expect(html).toContain('data-value="structural"');
+  });
+
+  it('provides values through custom function components', async () => {
+    const Layout = ({ children }: { children: React.ReactNode }) => {
+      return <div className="layout">{children}</div>;
+    };
+    const DeepLayout = () => {
+      return (
+        <Layout>
+          <Consumer />
+        </Layout>
+      );
+    };
+
+    const html = await render(
+      <Provider value="through components">
+        <DeepLayout />
+      </Provider>,
+    );
+    expect(html).toContain('data-value="through components"');
+  });
+
+  it('provides values through components that use hooks', async () => {
+    const Layout = ({ children }: { children: React.ReactNode }) => {
+      const [state] = React.useState('state value');
+      const id = React.useId();
+      return (
+        <div data-state={state} data-id={id}>
+          {children}
+        </div>
+      );
+    };
+
+    const html = await render(
+      <Provider value="with hooks">
+        <Layout>
+          <Consumer />
+        </Layout>
+      </Provider>,
+    );
+    expect(html).toContain('data-value="with hooks"');
+    expect(html).toContain('data-state="state value"');
+  });
+
+  it('provides values through forwardRef and memo components', async () => {
+    const ForwardRefLayout = React.forwardRef<
+      HTMLDivElement,
+      { children: React.ReactNode }
+    >(({ children }, ref) => {
+      return <div ref={ref}>{children}</div>;
+    });
+    const MemoLayout = React.memo(
+      ({ children }: { children: React.ReactNode }) => {
+        return <div>{children}</div>;
+      },
+    );
+
+    const html = await render(
+      <Provider value="exotic components">
+        <ForwardRefLayout>
+          <MemoLayout>
+            <Consumer />
+          </MemoLayout>
+        </ForwardRefLayout>
+      </Provider>,
+    );
+    expect(html).toContain('data-value="exotic components"');
+  });
+
+  it('lets the closest provider win', async () => {
+    const html = await render(
+      <Provider value="outer">
+        <Consumer />
+        <Provider value="inner">
+          <Consumer />
+        </Provider>
+      </Provider>,
+    );
+    expect(html).toContain('data-value="outer"');
+    expect(html).toContain('data-value="inner"');
+  });
+
+  it('keeps values from other contexts when nesting different providers', async () => {
+    const otherContext = createEmailContext<string>(
+      'email-context.spec.other',
+      'other default',
+    );
+    const OtherConsumer = (props: object) => {
+      const value = readEmailContext(props, valueContext);
+      const otherValue = readEmailContext(props, otherContext);
+      return <span data-value={value} data-other-value={otherValue} />;
+    };
+    markAsEmailContextConsumer(OtherConsumer);
+    const OtherProvider = (props: {
+      value: string;
+      children?: React.ReactNode;
+    }) => {
+      return provideEmailContext(
+        otherContext,
+        props.value,
+        props.children,
+        props,
+      );
+    };
+    markAsEmailContextProvider(OtherProvider);
+
+    const html = await render(
+      <Provider value="from outer provider">
+        <OtherProvider value="from inner provider">
+          <OtherConsumer />
+        </OtherProvider>
+      </Provider>,
+    );
+    expect(html).toContain('data-value="from outer provider"');
+    expect(html).toContain('data-other-value="from inner provider"');
+  });
+
+  it('provides values through async components', async () => {
+    const AsyncLayout = async ({ children }: { children: React.ReactNode }) => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      return <div>{children}</div>;
+    };
+
+    const html = await render(
+      <Provider value="through async components">
+        <AsyncLayout>
+          <Consumer />
+        </AsyncLayout>
+      </Provider>,
+    );
+    expect(html).toContain('data-value="through async components"');
+  });
+
+  it('provides values when client-rendered in the browser', () => {
+    const Layout = ({ children }: { children: React.ReactNode }) => {
+      const [state] = React.useState('client state');
+      return <div data-state={state}>{children}</div>;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    flushSync(() => {
+      root.render(
+        <Provider value="client rendered">
+          <Layout>
+            <Consumer />
+          </Layout>
+        </Provider>,
+      );
+    });
+
+    expect(container.innerHTML).toContain('data-value="client rendered"');
+    expect(container.innerHTML).toContain('data-state="client state"');
+    root.unmount();
+  });
+
+  it('does not leak the private prop into the markup', async () => {
+    const html = await render(
+      <Provider value="private">
+        <Consumer />
+      </Provider>,
+    );
+    expect(html.toLowerCase()).not.toContain('reactemailcontexts');
+  });
+
+  it('does not reach consumers inside class components', async () => {
+    class ClassLayout extends React.Component<{
+      children?: React.ReactNode;
+    }> {
+      render() {
+        return <Consumer />;
+      }
+    }
+
+    const html = await render(
+      <Provider value="class component">
+        <ClassLayout />
+      </Provider>,
+    );
+    expect(html).toContain('data-value="default value"');
+  });
+
+  it('still reaches consumers passed as children to class components', async () => {
+    class ClassLayout extends React.Component<{
+      children?: React.ReactNode;
+    }> {
+      render() {
+        return <div>{this.props.children}</div>;
+      }
+    }
+
+    const html = await render(
+      <Provider value="class children">
+        <ClassLayout>
+          <Consumer />
+        </ClassLayout>
+      </Provider>,
+    );
+    expect(html).toContain('data-value="class children"');
+  });
+});

--- a/packages/react-email/src/components/email-context/index.ts
+++ b/packages/react-email/src/components/email-context/index.ts
@@ -1,0 +1,2 @@
+export * from './create-email-context.js';
+export * from './propagate-email-contexts.js';

--- a/packages/react-email/src/components/email-context/markers.ts
+++ b/packages/react-email/src/components/email-context/markers.ts
@@ -1,0 +1,50 @@
+/**
+ * The prop under which email context values are injected into consumer
+ * and provider components. Consumers and providers must strip this prop
+ * (see `stripEmailContexts`) before spreading their props into host elements.
+ */
+export const contextsPropName = '__reactEmailContexts';
+
+/**
+ * A map of context values keyed by each context's unique symbol id.
+ *
+ * Symbols are registered globally (`Symbol.for`) so that duplicated copies of
+ * this module (e.g. the CJS and ESM builds loaded in the same process) remain
+ * compatible with each other.
+ */
+export type EmailContextMap = Record<symbol, unknown>;
+
+export const contextProviderMarker = Symbol.for(
+  'react-email.email-context.provider',
+);
+
+export const contextConsumerMarker = Symbol.for(
+  'react-email.email-context.consumer',
+);
+
+/**
+ * Marks a component as an email context provider. During propagation,
+ * providers receive the inherited context values through their props and
+ * are expected to continue propagation themselves (see `provideEmailContext`)
+ * so that their own value gets merged with the inherited ones.
+ */
+export const markAsEmailContextProvider = (component: unknown) => {
+  (component as Record<symbol, boolean>)[contextProviderMarker] = true;
+};
+
+/**
+ * Marks a component as an email context consumer, making propagation inject
+ * the current context values into its props so they can be read with
+ * `readEmailContext`.
+ */
+export const markAsEmailContextConsumer = (component: unknown) => {
+  (component as Record<symbol, boolean>)[contextConsumerMarker] = true;
+};
+
+export const hasMarker = (type: unknown, marker: symbol): boolean => {
+  return (
+    (typeof type === 'function' ||
+      (typeof type === 'object' && type !== null)) &&
+    marker in (type as object)
+  );
+};

--- a/packages/react-email/src/components/email-context/propagate-email-contexts.tsx
+++ b/packages/react-email/src/components/email-context/propagate-email-contexts.tsx
@@ -1,0 +1,303 @@
+import * as React from 'react';
+import { elementMarker } from '../element-marker.js';
+import {
+  contextConsumerMarker,
+  contextProviderMarker,
+  contextsPropName,
+  type EmailContextMap,
+  hasMarker,
+} from './markers.js';
+
+const forwardRefTypeSymbol = Symbol.for('react.forward_ref');
+const memoTypeSymbol = Symbol.for('react.memo');
+const injectorMarker = Symbol.for('react-email.email-context.injector');
+
+type UnknownProps = Record<string, unknown> & { children?: React.ReactNode };
+
+const isThenable = (value: unknown): value is PromiseLike<unknown> =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as PromiseLike<unknown>).then === 'function';
+
+const unwrapMemo = (type: unknown): unknown => {
+  let current = type;
+  while (
+    typeof current === 'object' &&
+    current !== null &&
+    (current as { $$typeof?: symbol }).$$typeof === memoTypeSymbol
+  ) {
+    current = (current as { type: unknown }).type;
+  }
+  return current;
+};
+
+const isForwardRef = (
+  type: unknown,
+): type is {
+  render: (props: UnknownProps, ref: unknown) => React.ReactNode;
+} => {
+  return (
+    typeof type === 'object' &&
+    type !== null &&
+    (type as { $$typeof?: symbol }).$$typeof === forwardRefTypeSymbol
+  );
+};
+
+const isClassComponent = (type: unknown): boolean => {
+  return (
+    typeof type === 'function' &&
+    type.prototype !== undefined &&
+    type.prototype !== null &&
+    (type.prototype as { isReactComponent?: unknown }).isReactComponent !==
+      undefined
+  );
+};
+
+interface EmailContextInjectorProps {
+  componentType: unknown;
+  componentProps: UnknownProps;
+  contexts: EmailContextMap;
+}
+
+/**
+ * Stands in for a component found during propagation. When React renders it,
+ * it calls the original component the same way React would and continues
+ * propagating the contexts through whatever the component returned, so that
+ * consumers hidden behind component boundaries still receive their values.
+ *
+ * Hooks used by the original component still work because this runs inside
+ * an actual React render, they just get attributed to this component.
+ * Async components (only valid in RSC, where returning a thenable is
+ * supported) are handled by chaining the propagation onto the promise.
+ */
+const EmailContextInjector = ({
+  componentType,
+  componentProps,
+  contexts,
+}: EmailContextInjectorProps): React.ReactNode => {
+  const unwrapped = unwrapMemo(componentType);
+
+  let output: unknown;
+  if (isForwardRef(unwrapped)) {
+    const { ref, ...propsWithoutRef } = componentProps;
+    output = unwrapped.render(propsWithoutRef, ref);
+  } else if (typeof unwrapped === 'function' && !isClassComponent(unwrapped)) {
+    output = (unwrapped as (props: UnknownProps) => React.ReactNode)(
+      componentProps,
+    );
+  } else {
+    // We cannot safely call this component ourselves (e.g. a class component
+    // wrapped in memo), so we let React render it as-is. Contexts will not
+    // reach consumers inside of it, only through its children prop, which
+    // was already handled during propagation.
+    return React.createElement(
+      componentType as React.ElementType,
+      componentProps,
+    );
+  }
+
+  if (isThenable(output)) {
+    return output.then((resolved) =>
+      propagateEmailContexts(resolved as React.ReactNode, contexts),
+    ) as unknown as React.ReactNode;
+  }
+
+  return propagateEmailContexts(output as React.ReactNode, contexts);
+};
+EmailContextInjector.displayName = 'EmailContextInjector';
+(EmailContextInjector as unknown as Record<symbol, boolean>)[injectorMarker] =
+  true;
+
+const cloneWithInjectedContexts = (
+  element: React.ReactElement<UnknownProps>,
+  contexts: EmailContextMap,
+  newChildren?: { value: React.ReactNode },
+) => {
+  const existing = element.props[contextsPropName] as
+    | EmailContextMap
+    | undefined;
+  // Contexts already injected by a previous propagation come from a
+  // provider that is closer to the element, so they take precedence.
+  const merged = existing ? { ...contexts, ...existing } : contexts;
+
+  const overrides: UnknownProps = { [contextsPropName]: merged };
+  if (newChildren) {
+    overrides.children = newChildren.value;
+  }
+
+  return React.cloneElement(element, overrides);
+};
+
+const propagateThroughChildren = (
+  element: React.ReactElement<UnknownProps>,
+  contexts: EmailContextMap,
+): React.ReactNode => {
+  const children = element.props?.children;
+  if (children === undefined || children === null) {
+    return element;
+  }
+
+  const newChildren = propagateEmailContexts(children, contexts);
+  if (newChildren === children) {
+    return element;
+  }
+
+  return React.cloneElement(element, { children: newChildren });
+};
+
+const wrapInInjector = (
+  element: React.ReactElement<UnknownProps>,
+  contexts: EmailContextMap,
+) => {
+  return React.createElement(EmailContextInjector, {
+    key: element.key ?? undefined,
+    componentType: element.type,
+    componentProps: element.props,
+    contexts,
+  });
+};
+
+const propagateThroughElement = (
+  element: React.ReactElement<UnknownProps>,
+  contexts: EmailContextMap,
+): React.ReactNode => {
+  const type = element.type as unknown;
+  const markerTarget = unwrapMemo(type);
+
+  if (hasMarker(markerTarget, injectorMarker)) {
+    const existing = (element.props as unknown as EmailContextInjectorProps)
+      .contexts;
+    return React.cloneElement(element, {
+      contexts: { ...contexts, ...existing },
+    } as Partial<UnknownProps>);
+  }
+
+  if (hasMarker(markerTarget, contextProviderMarker)) {
+    // The provider merges its own value over the inherited ones and
+    // continues the propagation through its subtree by itself, so we hand
+    // the contexts over to it and stop descending.
+    return cloneWithInjectedContexts(element, contexts);
+  }
+
+  if (hasMarker(markerTarget, contextConsumerMarker)) {
+    const children = element.props.children;
+    const newChildren =
+      children === undefined || children === null
+        ? undefined
+        : { value: propagateEmailContexts(children, contexts) };
+    return cloneWithInjectedContexts(element, contexts, newChildren);
+  }
+
+  if (
+    hasMarker(markerTarget, elementMarker) ||
+    typeof type === 'string' ||
+    typeof type === 'symbol'
+  ) {
+    // Host elements (e.g. `td`), symbol-typed elements (e.g. Fragment,
+    // Suspense) and react-email's own primitives just place their children
+    // where they are, so we only need to keep descending through them.
+    return propagateThroughChildren(element, contexts);
+  }
+
+  if (typeof type === 'function') {
+    if (isClassComponent(type)) {
+      // Class components cannot be called inline, so contexts only reach
+      // whatever the user placed inside of their children prop.
+      return propagateThroughChildren(element, contexts);
+    }
+
+    return wrapInInjector(element, contexts);
+  }
+
+  if (typeof type === 'object' && type !== null) {
+    const typeOfType = (type as { $$typeof?: symbol }).$$typeof;
+    if (typeOfType === forwardRefTypeSymbol || typeOfType === memoTypeSymbol) {
+      return wrapInInjector(element, contexts);
+    }
+
+    // Other exotic types, such as React context providers/consumers, lazy
+    // components and RSC client references. The most we can do for these is
+    // keep propagating through the children the user has passed to them.
+    return propagateThroughChildren(element, contexts);
+  }
+
+  return element;
+};
+
+/**
+ * Walks a React node, injecting the given context values into every element
+ * marked as an email context consumer (see `markAsEmailContextConsumer`).
+ *
+ * Since this cannot rely on React context—email templates may be rendered
+ * inside RSC where it is not available—values are carried by cloning
+ * elements with a private prop. Components found along the way are deferred
+ * to render time through `EmailContextInjector`, which continues the
+ * propagation through their output.
+ *
+ * Caveats, by design:
+ * - Only the `children` prop is traversed, so consumers inside other
+ *   element-typed props (e.g. Suspense's `fallback`) don't receive values.
+ * - Consumers rendered inside class components, `React.lazy` components,
+ *   render-prop functions or RSC client references fall back to their
+ *   default values.
+ */
+export function propagateEmailContexts(
+  node: React.ReactNode,
+  contexts: EmailContextMap,
+): React.ReactNode {
+  if (node === null || node === undefined) {
+    return node;
+  }
+
+  const typeOfNode = typeof node;
+  if (
+    typeOfNode === 'string' ||
+    typeOfNode === 'number' ||
+    typeOfNode === 'boolean' ||
+    typeOfNode === 'bigint'
+  ) {
+    return node;
+  }
+
+  if (isThenable(node)) {
+    return node.then((resolved) =>
+      propagateEmailContexts(resolved as React.ReactNode, contexts),
+    ) as unknown as React.ReactNode;
+  }
+
+  if (Array.isArray(node)) {
+    let changed = false as boolean;
+    const mapped = node.map((child) => {
+      const result = propagateEmailContexts(child, contexts);
+      if (result !== child) {
+        changed = true;
+      }
+      return result;
+    });
+    if (!changed) {
+      return node;
+    }
+    // The new array counts as dynamic children, so elements that relied on
+    // being static JSX children need explicit keys, which are assigned by
+    // position the same way React.Children.map does.
+    return mapped.map((child, index) =>
+      React.isValidElement(child) && child.key === null
+        ? React.cloneElement(child, { key: `.${index}` })
+        : child,
+    );
+  }
+
+  if (React.isValidElement<UnknownProps>(node)) {
+    return propagateThroughElement(node, contexts);
+  }
+
+  if (
+    typeof (node as Iterable<React.ReactNode>)[Symbol.iterator] === 'function'
+  ) {
+    return Array.from(node as Iterable<React.ReactNode>).map((child) =>
+      propagateEmailContexts(child, contexts),
+    );
+  }
+
+  return node;
+}

--- a/packages/react-email/src/components/email-context/rsc/render-with-flight.tsx
+++ b/packages/react-email/src/components/email-context/rsc/render-with-flight.tsx
@@ -1,0 +1,60 @@
+/**
+ * Renders email components with React's Flight renderer (the one used for
+ * React Server Components) to prove that email contexts propagate there.
+ *
+ * This is run by rsc-compatibility.spec.ts in a subprocess with
+ * `--conditions=react-server`, the environment where `React.createContext`
+ * and hooks don't exist, which is the reason email contexts exist at all.
+ */
+import assert from 'node:assert';
+import * as React from 'react';
+import { renderToReadableStream } from 'react-server-dom-webpack/server.edge';
+import { Body } from '../../body/index.js';
+import { Html } from '../../html/index.js';
+
+assert.strictEqual(
+  (React as { createContext?: unknown }).createContext,
+  undefined,
+  'Expected React.createContext to not exist, this script must run with --conditions=react-server',
+);
+
+const AsyncLayout = async ({ children }: { children: React.ReactNode }) => {
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  return <>{children}</>;
+};
+
+const stream = renderToReadableStream(
+  <Html lang="pl">
+    <AsyncLayout>
+      <Body>Cześć</Body>
+    </AsyncLayout>
+  </Html>,
+  {},
+);
+
+const flightPayload = await new Response(stream).text();
+
+// Flight encodes host elements as ["$","body",key,{...props}], so the
+// assertions below check the props that ended up on each host element.
+assert.match(
+  flightPayload,
+  /"html",[^,]*,\{[^{]*"lang":"pl"/,
+  `Expected the html element to have lang="pl" in the flight payload:\n${flightPayload}`,
+);
+assert.match(
+  flightPayload,
+  /"body",[^,]*,\{[^{]*"lang":"pl"/,
+  `Expected the body element to inherit lang="pl" in the flight payload:\n${flightPayload}`,
+);
+assert.match(
+  flightPayload,
+  /"td",[^,]*,\{[^{]*"lang":"pl"/,
+  `Expected the td element to inherit lang="pl" in the flight payload:\n${flightPayload}`,
+);
+assert.doesNotMatch(
+  flightPayload,
+  /reactemailcontexts/i,
+  `Expected the private context prop to not leak into the flight payload:\n${flightPayload}`,
+);
+
+console.log('flight rendering worked correctly');

--- a/packages/react-email/src/components/email-context/rsc/rsc-compatibility.spec.ts
+++ b/packages/react-email/src/components/email-context/rsc/rsc-compatibility.spec.ts
@@ -1,0 +1,33 @@
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+const packageRoot = path.resolve(__dirname, '../../../..');
+
+test('email contexts propagate when rendering with the RSC flight renderer', {
+  timeout: 30_000,
+}, async () => {
+  const scriptLocation = path.join(
+    'src',
+    'components',
+    'email-context',
+    'rsc',
+    'render-with-flight.tsx',
+  );
+  const { stdout } = await promisify(execFile)(
+    process.execPath,
+    ['--conditions=react-server', '--import=tsx/esm', scriptLocation],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        // In development, flight payloads include debug metadata that
+        // repeats component props, which would trip up the script's
+        // assertion that the private context prop never gets rendered.
+        NODE_ENV: 'production',
+      },
+    },
+  );
+
+  expect(stdout).toContain('flight rendering worked correctly');
+});

--- a/packages/react-email/src/components/html/html-context.ts
+++ b/packages/react-email/src/components/html/html-context.ts
@@ -1,0 +1,12 @@
+import { createEmailContext } from '../email-context/index.js';
+
+export interface HtmlContextValue {
+  lang?: string;
+  dir?: string;
+}
+
+/**
+ * Carries the language metadata set on `<Html>` down to components that
+ * repeat it for email clients that strip the `<html>` tag, such as `<Body>`.
+ */
+export const htmlContext = createEmailContext<HtmlContextValue>('html', {});

--- a/packages/react-email/src/components/html/html.tsx
+++ b/packages/react-email/src/components/html/html.tsx
@@ -1,13 +1,20 @@
 import * as React from 'react';
+import {
+  markAsEmailContextProvider,
+  provideEmailContext,
+  stripEmailContexts,
+} from '../email-context/index.js';
+import { htmlContext } from './html-context.js';
 
 export type HtmlProps = Readonly<React.ComponentPropsWithoutRef<'html'>>;
 
 export const Html = React.forwardRef<HTMLHtmlElement, HtmlProps>(
   ({ children, lang = 'en', dir = 'ltr', ...props }, ref) => (
-    <html {...props} dir={dir} lang={lang} ref={ref}>
-      {children}
+    <html {...stripEmailContexts(props)} dir={dir} lang={lang} ref={ref}>
+      {provideEmailContext(htmlContext, { lang, dir }, children, props)}
     </html>
   ),
 );
 
 Html.displayName = 'Html';
+markAsEmailContextProvider(Html);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -760,6 +760,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      react-server-dom-webpack:
+        specifier: 19.2.4
+        version: 19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.106.2(esbuild@0.28.0))
       shelljs:
         specifier: 0.10.0
         version: 0.10.0
@@ -4450,6 +4453,10 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-loose@8.5.2:
+    resolution: {integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.11.2:
     resolution: {integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==}
     engines: {node: '>=0.4.0'}
@@ -7642,6 +7649,15 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-server-dom-webpack@19.2.4:
+    resolution: {integrity: sha512-zEhkWv6RhXDctC2N7yEUHg3751nvFg81ydHj8LTTZuukF/IF1gcOKqqAL6Ds+kS5HtDVACYPik0IvzkgYXPhlQ==}
+    engines: {node: '>=0.10.0'}
+    deprecated: High Security Vulnerability in React Server Components
+    peerDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4
+      webpack: ^5.59.0
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
@@ -12890,6 +12906,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  acorn-loose@8.5.2:
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.11.2: {}
 
   acorn@8.16.0: {}
@@ -16663,6 +16683,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.106.2(esbuild@0.28.0)):
+    dependencies:
+      acorn-loose: 8.5.2
+      neo-async: 2.6.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      webpack: 5.106.2(esbuild@0.28.0)
+      webpack-sources: 3.3.4
+
   react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       get-nonce: 1.0.1
@@ -17701,6 +17730,16 @@ snapshots:
 
   term-size@2.2.1: {}
 
+  terser-webpack-plugin@5.3.17(esbuild@0.28.0)(webpack@5.106.2(esbuild@0.28.0)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.37.0
+      webpack: 5.106.2(esbuild@0.28.0)
+    optionalDependencies:
+      esbuild: 0.28.0
+
   terser-webpack-plugin@5.3.17(esbuild@0.28.1)(webpack@5.106.2(esbuild@0.28.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -18265,6 +18304,37 @@ snapshots:
       schema-utils: 4.3.3
       tapable: 2.3.0
       terser-webpack-plugin: 5.3.17(webpack@5.106.2)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.106.2(esbuild@0.28.0):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.20.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.1
+      mime-db: 1.54.0
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.17(esbuild@0.28.0)(webpack@5.106.2(esbuild@0.28.0))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Email contexts: mimicking React context without React context

Fixes #3652.

`<Body>` hardcoded `lang="en" dir="ltr"`, which conflicts with `<Html lang="pl">` in non-English emails. Inheriting them from `<Html>` requires context-like propagation, but React context can't be used: email templates may be rendered inside RSC (no `createContext`, no hooks), with `react-dom/server`, or in the browser.

## The mechanism

This PR adds an internal "email context" primitive (`src/components/email-context/`) that carries values through the element tree itself instead of through the renderer:

- **`createEmailContext(name, defaultValue)`** creates a context keyed by a global symbol (`Symbol.for`), so duplicated CJS/ESM copies of the module interoperate.
- **Providers** (`markAsEmailContextProvider` + `provideEmailContext`) walk their `children` at render time and clone every marked consumer element with the values injected into a private prop (`__reactEmailContexts`).
- **Consumers** (`markAsEmailContextConsumer` + `readEmailContext`) read the value from their props with a plain function — no hooks — and strip the private prop before spreading into host elements.
- **Component boundaries** are crossed lazily: unknown function/forwardRef/memo components found during propagation are replaced with an `EmailContextInjector` element that, when React renders it, calls the original component in place and continues propagating through its output. Because this happens inside an actual React render (unlike Tailwind's eager `mapReactTree`), hooks inside user components keep working — they're just attributed to the injector. Async components (RSC) are handled by chaining the propagation onto the returned thenable.
- **Nested providers** shadow outer ones: outer propagation stops at a nested provider element and hands its values over through the same private prop, and the inner provider merges its own value on top.

Known caveats (documented on `propagateEmailContexts`): only the `children` prop is traversed (e.g. not Suspense's `fallback`), and consumers hidden inside class components, `React.lazy`, render-prop functions or client references fall back to their defaults — the same places where the propagation simply degrades to today's behavior rather than breaking.

## The fix

`<Html>` provides `{ lang, dir }` through an email context and `<Body>` consumes it:

- `<Html lang="pl">` → `<body dir="ltr" lang="pl">` (and the inner `td`), instead of `lang="en"`
- Explicit `lang`/`dir` on `<Body>` still win
- Standalone `<Body>` keeps the `en`/`ltr` defaults

Works with `<Tailwind>` between (or around) `Html` and `Body`, through custom layout components, and through async components.

## Testing

- Unit specs for the mechanism (direct/structural nesting, custom components with hooks, forwardRef/memo, async components, nested providers, client rendering via `createRoot`, no prop leakage, class-component caveats) and for the `Body` inheritance scenarios — all rendered through `@react-email/render` (Fizz).
- An RSC compatibility spec that renders `<Html lang="pl">` → async layout → `<Body>` with the real Flight renderer (`react-server-dom-webpack`, added as a dev dependency) in a subprocess under `--conditions=react-server` — where `React.createContext` doesn't exist — and asserts the body/td host elements carry `lang="pl"` in the flight payload.
- Full `react-email` suite: 45 files / 314 tests passing, plus typecheck, lint and build; verified the issue's exact repro against the built `dist`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0AG3A0TP7W/p1784037151497719?thread_ts=1784037151.497719&cid=C0AG3A0TP7W)

<div><a href="https://cursor.com/agents/bc-eeacc1c5-5f35-5d52-91ba-604f607f04ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eeacc1c5-5f35-5d52-91ba-604f607f04ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make <Body> inherit lang and dir from <Html> without React context, fixing mismatched language metadata in non‑English emails. Works across RSC, server, and client renders.

- **Bug Fixes**
  - <Body> now inherits lang/dir from <Html>; explicit <Body> props still override; standalone <Body> keeps en/ltr defaults.
  - Works through custom layouts, async components, and with <Tailwind>; no private props leak into the DOM.
  - Added a small internal “email context” to propagate values without hooks or React context; updated <Html> docs to note inheritance.

- **Dependencies**
  - Added dev dependency `react-server-dom-webpack@19.2.4` for a Flight-based RSC compatibility test.

<sup>Written for commit 4adf24727b7e1186b8474bead75d89f4e0822ccd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

