### PR TITLE
chore(render): document data-skip-in-text

### DIFF
--- a/apps/docs/utilities/render.mdx
+++ b/apps/docs/utilities/render.mdx
@@ -123,6 +123,31 @@ Some title
 Click me [https://example.com]
 ```
 
+### Exclude content from plain-text output
+
+Add `data-skip-in-text="true"` to an element to exclude the element and its contents when using `toPlainText()`. This does not exclude the element from the HTML output.
+
+```jsx
+import { Html, Section, Text } from 'react-email';
+
+export function MyTemplate() {
+  return (
+    <Html>
+      <Text>This content appears in both outputs.</Text>
+      <Section data-skip-in-text="true">
+        <Text>This content appears only in the HTML output.</Text>
+      </Section>
+    </Html>
+  );
+}
+```
+
+The plain-text output will be:
+
+```text
+This content appears in both outputs.
+```
+
 ## Options
 
 <ResponseField name="pretty" type="boolean">


### PR DESCRIPTION
## Description

While reading Discussion #686, I noticed that `data-skip-in-text` is already supported by `toPlainText()`, but the behavior is not currently documented.

This PR adds a short explanation and example to the “Convert to Plain Text” section. It shows that an element and its contents are excluded from the plain-text output while remaining in the HTML output.

Related to #686.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented support for `data-skip-in-text` in the Convert to Plain Text docs. Adds an example and expected output showing elements with `data-skip-in-text="true"` are skipped by `toPlainText()` but still render in HTML.

<sup>Written for commit 14fc6ad1fc4a5db36622dd7dfa1f2fd45a9152b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

