### PR TITLE
fix(react-email): make Body inherit lang and dir from Html

### DIFF
--- a/.changeset/body-inherits-html-lang-dir.md
+++ b/.changeset/body-inherits-html-lang-dir.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+`<Body>` now inherits `lang` and `dir` from `<Html>` instead of always defaulting to `lang="en" dir="ltr"`. Explicit values on `<Body>` still take precedence.

--- a/apps/docs/components/body.mdx
+++ b/apps/docs/components/body.mdx
@@ -1,0 +1,69 @@
+---
+title: "Body"
+sidebarTitle: "Body"
+description: "A React body component to wrap the contents of an email."
+"og:image": "https://react.email/static/covers/components.png"
+icon: "window-maximize"
+---
+
+import Support from '/snippets/support.mdx'
+
+## Install
+
+Install component from your command line.
+
+<CodeGroup>
+
+```sh npm
+npm install react-email -E
+```
+
+```sh yarn
+yarn add react-email -E
+```
+
+```sh pnpm
+pnpm add react-email -E
+```
+
+</CodeGroup>
+
+## Getting started
+
+Add the component to your email template. Include styles where needed.
+
+```jsx
+import { Html, Body, Button } from "react-email";
+
+const Email = () => {
+  return (
+    <Html lang="en" dir="ltr">
+      <Body style={{ backgroundColor: "#ffffff" }}>
+        <Button href="https://example.com" style={{ color: "#61dafb" }}>
+          Click me
+        </Button>
+      </Body>
+    </Html>
+  );
+};
+```
+
+## Props
+
+<ResponseField name="lang" type="string">
+  Identify the language of text content on the email. Inherits the value set
+  on `Html`, falling back to `en`.
+</ResponseField>
+<ResponseField name="dir" type="string">
+  Identify the direction of text content on the email. Inherits the value set
+  on `Html`, falling back to `ltr`.
+</ResponseField>
+
+<Info>
+  `Body` also applies `lang` and `dir` to an inner table cell that wraps your
+  content. Some email clients, such as Gmail and Yahoo, strip the `<html>` and
+  `<body>` tags, so this keeps the language metadata available to screen
+  readers.
+</Info>
+
+<Support/>

--- a/apps/docs/components/html.mdx
+++ b/apps/docs/components/html.mdx
@@ -49,10 +49,12 @@ const Email = () => {
 ## Props
 
 <ResponseField name="lang" type="string" default="en">
-  Identify the language of text content on the email
+  Identify the language of text content on the email. Also inherited by
+  `Body`, unless it sets its own value.
 </ResponseField>
 <ResponseField name="dir" type="string" default="ltr">
-  Identify the direction of text content on the email
+  Identify the direction of text content on the email. Also inherited by
+  `Body`, unless it sets its own value.
 </ResponseField>
 
 <Support/>

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -73,6 +73,7 @@
             "pages": [
               "components/html",
               "components/head",
+              "components/body",
               "components/button",
               "components/container",
               "components/code-block",

--- a/packages/react-email/src/components/body/body.spec.tsx
+++ b/packages/react-email/src/components/body/body.spec.tsx
@@ -1,4 +1,5 @@
 import { render } from '@react-email/render';
+import { Html } from '../html/index.js';
 import { Body } from './index.js';
 import { marginProperties, paddingProperties } from './margin-properties.js';
 
@@ -25,6 +26,38 @@ describe('<Body> component', () => {
     expect(actualOutput).toMatchInlineSnapshot(
       `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><body dir="ltr" lang="en"><!--$--><!--body--><table border="0" width="100%" cellPadding="0" cellSpacing="0" role="presentation" align="center"><tbody><tr><td dir="ltr" lang="en">Lorem ipsum</td></tr></tbody></table><!--/$--></body>"`,
     );
+  });
+
+  it('inherits lang and dir from <Html>', async () => {
+    const html = await render(
+      <Html lang="pl" dir="rtl">
+        <Body>Cześć</Body>
+      </Html>,
+    );
+    expect(html).toContain('<body dir="rtl" lang="pl"');
+    expect(html).toContain('<td dir="rtl" lang="pl"');
+  });
+
+  it('prefers its own lang and dir over the ones from <Html>', async () => {
+    const html = await render(
+      <Html lang="pl" dir="rtl">
+        <Body lang="en" dir="ltr">
+          Test
+        </Body>
+      </Html>,
+    );
+    const bodyTag = html.match(/<body[^>]*>/)?.[0] ?? '';
+    const tdTag = html.match(/<td[^>]*>/)?.[0] ?? '';
+    expect(bodyTag).toContain('lang="en"');
+    expect(bodyTag).toContain('dir="ltr"');
+    expect(tdTag).toContain('lang="en"');
+    expect(tdTag).toContain('dir="ltr"');
+  });
+
+  it('defaults to lang="en" and dir="ltr" without <Html>', async () => {
+    const html = await render(<Body>Test</Body>);
+    expect(html).toContain('<body dir="ltr" lang="en"');
+    expect(html).toContain('<td dir="ltr" lang="en"');
   });
 
   describe('margin resetting behavior', () => {

--- a/packages/react-email/src/components/body/body.tsx
+++ b/packages/react-email/src/components/body/body.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { markAsElement } from '../element-marker.js';
-import { HtmlContext } from '../html/html-context.js';
+import { useHtmlContext } from '../html/html-context.js';
 import { marginProperties, paddingProperties } from './margin-properties.js';
 
 export type BodyProps = Readonly<React.HtmlHTMLAttributes<HTMLBodyElement>>;
 
 export const Body = React.forwardRef<HTMLBodyElement, BodyProps>(
   ({ children, style, ...props }, ref) => {
-    const htmlContext = React.useContext(HtmlContext);
+    const htmlContext = useHtmlContext();
     const dir = props.dir ?? htmlContext.dir ?? 'ltr';
     const lang = props.lang ?? htmlContext.lang ?? 'en';
     const bodyStyle: Record<string, string | number | undefined> = {

--- a/packages/react-email/src/components/body/body.tsx
+++ b/packages/react-email/src/components/body/body.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
 import { markAsElement } from '../element-marker.js';
+import { HtmlContext } from '../html/html-context.js';
 import { marginProperties, paddingProperties } from './margin-properties.js';
 
 export type BodyProps = Readonly<React.HtmlHTMLAttributes<HTMLBodyElement>>;
 
 export const Body = React.forwardRef<HTMLBodyElement, BodyProps>(
   ({ children, style, ...props }, ref) => {
+    const htmlContext = React.useContext(HtmlContext);
+    const dir = props.dir ?? htmlContext.dir ?? 'ltr';
+    const lang = props.lang ?? htmlContext.lang ?? 'en';
     const bodyStyle: Record<string, string | number | undefined> = {
       background: style?.background,
       backgroundColor: style?.backgroundColor,
@@ -20,13 +24,7 @@ export const Body = React.forwardRef<HTMLBodyElement, BodyProps>(
       }
     }
     return (
-      <body
-        {...props}
-        dir={props.dir ?? 'ltr'}
-        lang={props.lang ?? 'en'}
-        style={bodyStyle}
-        ref={ref}
-      >
+      <body {...props} dir={dir} lang={lang} style={bodyStyle} ref={ref}>
         <table
           border={0}
           width="100%"
@@ -43,11 +41,7 @@ export const Body = React.forwardRef<HTMLBodyElement, BodyProps>(
 
                 See https://github.com/resend/react-email/issues/662.
               */}
-              <td
-                dir={props.dir ?? 'ltr'}
-                lang={props.lang ?? 'en'}
-                style={style}
-              >
+              <td dir={dir} lang={lang} style={style}>
                 {children}
               </td>
             </tr>

--- a/packages/react-email/src/components/html/html-context.ts
+++ b/packages/react-email/src/components/html/html-context.ts
@@ -5,4 +5,17 @@ export interface HtmlContextValue {
   dir?: string;
 }
 
-export const HtmlContext = React.createContext<HtmlContextValue>({});
+// React's react-server builds don't include createContext/useContext, so in
+// server components there is no inheritance and Body keeps its own defaults.
+export const HtmlContext: React.Context<HtmlContextValue> | undefined =
+  'createContext' in React
+    ? React.createContext<HtmlContextValue>({})
+    : undefined;
+
+export const useHtmlContext = (): HtmlContextValue => {
+  if (HtmlContext === undefined || !('useContext' in React)) {
+    return {};
+  }
+  // biome-ignore lint/correctness/useHookAtTopLevel: the branch is constant for a given React build, so hook order never changes between renders
+  return React.useContext(HtmlContext);
+};

--- a/packages/react-email/src/components/html/html-context.ts
+++ b/packages/react-email/src/components/html/html-context.ts
@@ -1,0 +1,8 @@
+import * as React from 'react';
+
+export interface HtmlContextValue {
+  lang?: string;
+  dir?: string;
+}
+
+export const HtmlContext = React.createContext<HtmlContextValue>({});

--- a/packages/react-email/src/components/html/html.tsx
+++ b/packages/react-email/src/components/html/html.tsx
@@ -4,13 +4,19 @@ import { HtmlContext } from './html-context.js';
 export type HtmlProps = Readonly<React.ComponentPropsWithoutRef<'html'>>;
 
 export const Html = React.forwardRef<HTMLHtmlElement, HtmlProps>(
-  ({ children, lang = 'en', dir = 'ltr', ...props }, ref) => (
-    <HtmlContext.Provider value={{ lang, dir }}>
+  ({ children, lang = 'en', dir = 'ltr', ...props }, ref) => {
+    const html = (
       <html {...props} dir={dir} lang={lang} ref={ref}>
         {children}
       </html>
-    </HtmlContext.Provider>
-  ),
+    );
+    if (HtmlContext === undefined) {
+      return html;
+    }
+    return (
+      <HtmlContext.Provider value={{ lang, dir }}>{html}</HtmlContext.Provider>
+    );
+  },
 );
 
 Html.displayName = 'Html';

--- a/packages/react-email/src/components/html/html.tsx
+++ b/packages/react-email/src/components/html/html.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react';
+import { HtmlContext } from './html-context.js';
 
 export type HtmlProps = Readonly<React.ComponentPropsWithoutRef<'html'>>;
 
 export const Html = React.forwardRef<HTMLHtmlElement, HtmlProps>(
   ({ children, lang = 'en', dir = 'ltr', ...props }, ref) => (
-    <html {...props} dir={dir} lang={lang} ref={ref}>
-      {children}
-    </html>
+    <HtmlContext.Provider value={{ lang, dir }}>
+      <html {...props} dir={dir} lang={lang} ref={ref}>
+        {children}
+      </html>
+    </HtmlContext.Provider>
   ),
 );
 

--- a/packages/react-email/src/components/tailwind/tailwind.spec.tsx
+++ b/packages/react-email/src/components/tailwind/tailwind.spec.tsx
@@ -118,6 +118,19 @@ describe('Tailwind component', () => {
     );
   });
 
+  it('keeps <Body> inheriting lang and dir from <Html>', async () => {
+    const actualOutput = await render(
+      <Tailwind>
+        <Html lang="pl" dir="rtl">
+          <Head />
+          <Body className="bg-white">Cześć</Body>
+        </Html>
+      </Tailwind>,
+    );
+    expect(actualOutput).toContain('<body dir="rtl" lang="pl"');
+    expect(actualOutput).toContain('<td dir="rtl" lang="pl"');
+  });
+
   it("works properly with 'no-underline'", async () => {
     const actualOutput = await render(
       <Html>


### PR DESCRIPTION
## Summary

`<Body>` hardcoded `lang="en" dir="ltr"` on the `<body>` tag and the inner `<td>` (added in resend/react-email#3546 as accessibility defaults), so rendering `<Html lang="pl">` produced `<html lang="pl">` with a contradictory `<body lang="en">` — wrong metadata for screen readers on non-English emails.

`<Html>` now shares its `lang`/`dir` through a React context, and `<Body>` uses those values as its defaults for both the `<body>` tag and the inner `<td>` (the element that survives Gmail/Yahoo stripping `<html>`/`<body>`). Precedence: explicit `Body` props → `Html` values → `en`/`ltr`. Output is unchanged when `Body` is rendered without an `Html` ancestor, and the Tailwind tree-mapping path is covered by a test since it invokes components outside React's renderer.

Also adds the missing docs page for `Body` and notes the inheritance on the `Html` page.

Fixes resend/react-email#3652

---

## Summary by cubic

`<Body>` now inherits `lang` and `dir` from `<Html>` to fix conflicting language metadata in non-English emails in `react-email`. Context use is guarded for React Server builds to prevent crashes; added `Body` docs and noted inheritance on the `Html` page.

* **Bug Fixes**
  * `Html` provides `lang`/`dir` via context; `Body` uses them on `<body>` and the inner `<td>`.
  * Precedence: `Body` props → `Html` values → defaults `en`/`ltr`.
  * Behavior unchanged without an `Html` ancestor; tests cover Tailwind rendering.
  * Guarded context creation/consumption for React Server builds; falls back to `Body` defaults when context is unavailable.

Written for commit 3a980d4b2168a49fb9d0195be37b2a969835ead5. Summary will update on new commits.

[![Review in cubic](https://uploads.linear.app/cb0ab4b6-77ee-42b8-a07e-7ddb22cfd0d1/eedab2c7-eb4b-4919-9664-fa08fceecefe/86ef8694-0fff-457d-91ea-9c08f7940773?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2NiMGFiNGI2LTc3ZWUtNDJiOC1hMDdlLTdkZGIyMmNmZDBkMS9lZWRhYjJjNy1lYjRiLTQ5MTktOTY2NC1mYTA4ZmNlZWNlZmUvODZlZjg2OTQtMGZmZi00NTdkLTkxZWEtOWMwOGY3OTQwNzczIiwiaWF0IjoxNzg0MTQ5NDA1LCJleHAiOjE4MTU3MTk5NjV9.tQ1OOSC3jbgvTvvQMJL5jwoj8XU0IMumbZ7Sy2FUeIs)](<https://cubic.dev/pr/resend/react-email/pull/3660?utm_source=github>)