### PR TITLE
chore: document the Body component and its lang/dir defaults

### DIFF
--- a/apps/docs/components/body.mdx
+++ b/apps/docs/components/body.mdx
@@ -1,0 +1,69 @@
+---
+title: "Body"
+sidebarTitle: "Body"
+description: "A React body component to wrap the contents of an email."
+"og:image": "https://react.email/static/covers/components.png"
+icon: "window-maximize"
+---
+
+import Support from '/snippets/support.mdx'
+
+## Install
+
+Install component from your command line.
+
+<CodeGroup>
+
+```sh npm
+npm install react-email -E
+```
+
+```sh yarn
+yarn add react-email -E
+```
+
+```sh pnpm
+pnpm add react-email -E
+```
+
+</CodeGroup>
+
+## Getting started
+
+Add the component to your email template. Include styles where needed.
+
+```jsx
+import { Html, Body, Button } from "react-email";
+
+const Email = () => {
+  return (
+    <Html lang="en" dir="ltr">
+      <Body lang="en" dir="ltr" style={{ backgroundColor: "#ffffff" }}>
+        <Button href="https://example.com" style={{ color: "#61dafb" }}>
+          Click me
+        </Button>
+      </Body>
+    </Html>
+  );
+};
+```
+
+## Props
+
+<ResponseField name="lang" type="string" default="en">
+  Identify the language of text content on the email. Not inherited from
+  `Html` — for non-English emails, set it on `Body` as well.
+</ResponseField>
+<ResponseField name="dir" type="string" default="ltr">
+  Identify the direction of text content on the email. Not inherited from
+  `Html` — for right-to-left emails, set it on `Body` as well.
+</ResponseField>
+
+<Info>
+  `Body` sets `lang` and `dir` on the `body` tag and on an inner table cell
+  that wraps your content. Some email clients, such as Gmail and Yahoo, strip
+  the `html` and `body` tags, so the values set on `Html` alone would not
+  reach screen readers — which is why `Body` has its own defaults.
+</Info>
+
+<Support/>

--- a/apps/docs/components/html.mdx
+++ b/apps/docs/components/html.mdx
@@ -55,4 +55,10 @@ const Email = () => {
   Identify the direction of text content on the email
 </ResponseField>
 
+<Info>
+  These values apply only to the `html` tag — they are not passed down to
+  [`Body`](/components/body), which has its own `lang` and `dir` defaults. For
+  non-English or right-to-left emails, set the same values on `Body` too.
+</Info>
+
 <Support/>

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -73,6 +73,7 @@
             "pages": [
               "components/html",
               "components/head",
+              "components/body",
               "components/button",
               "components/container",
               "components/code-block",


### PR DESCRIPTION
## Summary

Adds the missing docs page for `Body` — it was the only wrapper component without one. Documents its `lang`/`dir` props and explains why they exist on `Body` at all: some clients (Gmail, Yahoo) strip the `html`/`body` tags, so the values on `Html` alone don't reach screen readers.

Also adds a note on the `Html` page that `lang`/`dir` are not passed down to `Body`, so non-English and RTL emails need them set on both — the surprise reported in resend/react-email#3652 (the behavior change itself is being handled in resend/react-email#3656).

---

## Summary by cubic

Added a docs page for `Body` explaining its independent `lang`/`dir` defaults and why they exist (some clients strip `html`/`body`, so values on `Html` alone may not reach screen readers). Also updated `Html` docs to note these props aren’t passed to `Body`, and added `components/body` to the sidebar.

Written for commit 822f97a2862935e3240527d5e90cbcc688b0defe. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)