### PR TITLE
fix(react-email): serve static files with URL-encoded names

### DIFF
--- a/.changeset/bright-assets-decode.md
+++ b/.changeset/bright-assets-decode.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Serve static assets with URL-encoded filenames correctly in the preview server while preventing decoded paths from escaping the static directory.

--- a/packages/react-email/src/cli/utils/preview/serve-static-file.spec.ts
+++ b/packages/react-email/src/cli/utils/preview/serve-static-file.spec.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs';
+import type http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { serveStaticFile } from './serve-static-file.js';
+
+const mkTempDir = () =>
+  fs.mkdtempSync(path.join(os.tmpdir(), 'serve-static-file-'));
+
+const createResponse = () => {
+  let body = '';
+  const response = {
+    statusCode: 200,
+    setHeader: vi.fn(),
+    end: vi.fn((chunk?: string | Buffer) => {
+      if (chunk) body += chunk.toString();
+    }),
+  } as unknown as http.ServerResponse;
+
+  return { response, getBody: () => body };
+};
+
+test('serves static files with URL-encoded characters in their names', async () => {
+  const projectDir = mkTempDir();
+  const staticDir = path.join(projectDir, 'emails', 'static');
+  const contents = 'asset contents';
+  const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(projectDir);
+  const { response, getBody } = createResponse();
+
+  fs.mkdirSync(staticDir, { recursive: true });
+  fs.writeFileSync(path.join(staticDir, 'company logo.txt'), contents);
+
+  await serveStaticFile(response, '/static/company%20logo.txt', 'emails');
+
+  expect(response.statusCode).toBe(200);
+  expect(getBody()).toBe(contents);
+
+  cwdSpy.mockRestore();
+  fs.rmSync(projectDir, { recursive: true });
+});
+
+test('does not serve URL-encoded paths outside the static directory', async () => {
+  const projectDir = mkTempDir();
+  const staticDir = path.join(projectDir, 'emails', 'static');
+  const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(projectDir);
+  const { response } = createResponse();
+
+  fs.mkdirSync(staticDir, { recursive: true });
+  fs.writeFileSync(path.join(projectDir, 'secret.txt'), 'secret contents');
+
+  await serveStaticFile(
+    response,
+    '/static/%2e%2e%2f%2e%2e%2fsecret.txt',
+    'emails',
+  );
+
+  expect(response.statusCode).toBe(403);
+
+  cwdSpy.mockRestore();
+  fs.rmSync(projectDir, { recursive: true });
+});
+
+test('returns a bad request for malformed URL encoding', async () => {
+  const { response } = createResponse();
+
+  await serveStaticFile(response, '/static/image%E0%A4%A.png', 'emails');
+
+  expect(response.statusCode).toBe(400);
+});

--- a/packages/react-email/src/cli/utils/preview/serve-static-file.ts
+++ b/packages/react-email/src/cli/utils/preview/serve-static-file.ts
@@ -8,16 +8,34 @@ export const serveStaticFile = async (
   pathname: string,
   staticDirRelativePath: string,
 ) => {
-  const pathname_ = pathname.replace('/static', './static');
-  const ext = path.parse(pathname_).ext;
+  let decodedPathname: string;
+  try {
+    decodedPathname = decodeURIComponent(pathname);
+  } catch {
+    res.statusCode = 400;
+    res.end();
+    return;
+  }
 
-  const staticBaseDir = path.resolve(process.cwd(), staticDirRelativePath);
-  const fileAbsolutePath = path.resolve(staticBaseDir, pathname_);
-  if (!fileAbsolutePath.startsWith(staticBaseDir)) {
+  const staticBaseDir = path.resolve(
+    process.cwd(),
+    staticDirRelativePath,
+    'static',
+  );
+  const staticFilePath = decodedPathname.replace(/^\/static\/?/, '');
+  const fileAbsolutePath = path.resolve(staticBaseDir, staticFilePath);
+  const relativeFilePath = path.relative(staticBaseDir, fileAbsolutePath);
+
+  if (
+    relativeFilePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeFilePath)
+  ) {
     res.statusCode = 403;
     res.end();
     return;
   }
+
+  const ext = path.extname(fileAbsolutePath);
 
   try {
     const fileHandle = await fs.open(fileAbsolutePath, 'r');

--- a/packages/react-email/src/cli/utils/tree.spec.ts
+++ b/packages/react-email/src/cli/utils/tree.spec.ts
@@ -11,6 +11,7 @@ test('tree(__dirname, 2)', async () => {
     │   ├── hot-reloading
     │   ├── get-env-variables-for-preview-app.ts
     │   ├── index.ts
+    │   ├── serve-static-file.spec.ts
     │   ├── serve-static-file.ts
     │   └── start-dev-server.ts
     ├── types


### PR DESCRIPTION
## Problem

- react-email preview server cannot serve static assets with spaces or URL-encoded characters in their filenames. For example: 

```text
emails/static/image test.png
```

the browser encodes the space and requests:

```text
/static/image%20test.png
```
The preview server currently passes the encoded pathname directly to the filesystem and as a result, it does not decode and looks for a file named  image%20test.png

I reproduced this on the latest version (6.9.0) and it confirmed the issue. Just to give one more example:

Results with 6.9.0:

```text
GET /static/image%20test.png → 404 Not Found
GET /static/image-test.png   → 200 OK
```

Results with my branch/fix:

```text
GET /static/image%20test.png → 200 OK
```

not sure if I missed something - if that's the case, please let me know!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `react-email` preview server to serve static assets with URL-encoded filenames (e.g., spaces). Also adds stricter path checks to prevent traversal outside the static folder.

- **Bug Fixes**
  - Decode request paths before lookup; return 400 on malformed encodings.
  - Resolve within the `static` folder and reject paths that escape it (403).
  - Add tests for encoded filenames, traversal attempts, and bad encodings.

<sup>Written for commit 78b61ff18cc24f2ee8ff825fc2c8d5999d9a0efa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

