### PR TITLE
chore: make html/body props docs clearer and cleaner

### DIFF
--- a/apps/docs/components/body.mdx
+++ b/apps/docs/components/body.mdx
@@ -58,7 +58,7 @@ const Email = () => {
 </ResponseField>
 
 <Info>
-  When customizing `lang` and/or `dir`, you should set the same values to the
+  When customizing `lang` and/or `dir`, you should set the same values on the
   [`Html`](/components/html) component. Some email clients strip the `html` or
   `body` tags, so it's necessary to have both.
 </Info>

--- a/apps/docs/components/body.mdx
+++ b/apps/docs/components/body.mdx
@@ -51,19 +51,16 @@ const Email = () => {
 ## Props
 
 <ResponseField name="lang" type="string" default="en">
-  Identify the language of text content on the email. Not inherited from
-  `Html` — for non-English emails, set it on `Body` as well.
+  Identify the language of text content on the email.
 </ResponseField>
 <ResponseField name="dir" type="string" default="ltr">
-  Identify the direction of text content on the email. Not inherited from
-  `Html` — for right-to-left emails, set it on `Body` as well.
+  Identify the direction of text content on the email.
 </ResponseField>
 
 <Info>
-  `Body` sets `lang` and `dir` on the `body` tag and on an inner table cell
-  that wraps your content. Some email clients, such as Gmail and Yahoo, strip
-  the `html` and `body` tags, so the values set on `Html` alone would not
-  reach screen readers — which is why `Body` has its own defaults.
+  When customizing `lang` and/or `dir`, you should set the same values to the
+  [`Html`](/components/html) component. Some email clients strip the `html` or
+  `body` tags, so it's necessary to have both.
 </Info>
 
 <Support/>

--- a/apps/docs/components/html.mdx
+++ b/apps/docs/components/html.mdx
@@ -56,9 +56,9 @@ const Email = () => {
 </ResponseField>
 
 <Info>
-  These values apply only to the `html` tag — they are not passed down to
-  [`Body`](/components/body), which has its own `lang` and `dir` defaults. For
-  non-English or right-to-left emails, set the same values on `Body` too.
+  When customizing `lang` and/or `dir`, you should set the same values to the
+  [`Body`](/components/body) component. Some email clients strip the `html` or
+  `body` tags, so it's necessary to have both.
 </Info>
 
 <Support/>

--- a/apps/docs/components/html.mdx
+++ b/apps/docs/components/html.mdx
@@ -56,7 +56,7 @@ const Email = () => {
 </ResponseField>
 
 <Info>
-  When customizing `lang` and/or `dir`, you should set the same values to the
+  When customizing `lang` and/or `dir`, you should set the same values on the
   [`Body`](/components/body) component. Some email clients strip the `html` or
   `body` tags, so it's necessary to have both.
 </Info>


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified and cleaned up docs for the `Html` and `Body` components: `lang` and `dir` now say to set the same values on both, with cross-links. Notes cover clients that strip `html`/`body` tags, and grammar is fixed.

<sup>Written for commit 734067118ca9322fbb9d7856a76c9d9b9972e1fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

