### PR TITLE
fix(react-email): extract media-query variants with tailwindcss 4.3.3+

### DIFF
--- a/.changeset/tailwind-4-3-3-media-variants.md
+++ b/.changeset/tailwind-4-3-3-media-variants.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Fix `<Tailwind>` dropping `dark:` and other media-query variants with `tailwindcss@4.3.3`+, where the conditional value was inlined as the base style and the `@media` rule never reached the `<head>`

--- a/packages/react-email/src/components/tailwind/utils/css/constants.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/constants.ts
@@ -1,11 +1,5 @@
-// At-rules whose contents are conditional and therefore can never be inlined
-// onto an element (e.g. `@media (prefers-color-scheme: dark)`).
-//
-// Single source of truth shared by the two passes that must agree on it:
-//   - extract-rules-per-class.ts marks rules found inside these wrappers as
-//     non-inlinable (rather than inlining their conditional declarations).
-//   - downlevel-for-email-clients.ts hoists these wrappers back out of nested
-//     rules, since email clients don't support CSS nesting.
-// If a wrapper were marked non-inlinable here but not hoistable there, it would
-// reach the <style> block still nested and fail to render — so they share this.
+// At-rules whose contents are conditional, so their declarations can't be
+// inlined onto an element (e.g. `@media (prefers-color-scheme: dark)`). Shared
+// so the "mark non-inlinable" (extract-rules-per-class) and "hoist out of the
+// rule" (downlevel-for-email-clients) passes can't disagree on the set.
 export const NON_INLINABLE_ATRULES = new Set(['media', 'supports']);

--- a/packages/react-email/src/components/tailwind/utils/css/constants.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/constants.ts
@@ -1,0 +1,11 @@
+// At-rules whose contents are conditional and therefore can never be inlined
+// onto an element (e.g. `@media (prefers-color-scheme: dark)`).
+//
+// Single source of truth shared by the two passes that must agree on it:
+//   - extract-rules-per-class.ts marks rules found inside these wrappers as
+//     non-inlinable (rather than inlining their conditional declarations).
+//   - downlevel-for-email-clients.ts hoists these wrappers back out of nested
+//     rules, since email clients don't support CSS nesting.
+// If a wrapper were marked non-inlinable here but not hoistable there, it would
+// reach the <style> block still nested and fail to render — so they share this.
+export const NON_INLINABLE_ATRULES = new Set(['media', 'supports']);

--- a/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/downlevel-for-email-clients.ts
@@ -26,6 +26,7 @@ import {
   type StyleSheet,
   walk,
 } from 'css-tree';
+import { NON_INLINABLE_ATRULES } from './constants.js';
 
 /**
  * css-tree 3.x introduced new AST node types for query-related at-rules that
@@ -114,7 +115,7 @@ function unnestMediaQueries(styleSheet: StyleSheet): void {
       rule.block.children.forEach((child) => {
         if (
           child.type === 'Atrule' &&
-          (child.name === 'media' || child.name === 'supports')
+          NON_INLINABLE_ATRULES.has(child.name.toLowerCase())
         ) {
           nestedAtrules.push(child);
         } else {

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
@@ -207,12 +207,8 @@ describe('extractRulesPerClass()', async () => {
     `);
   });
 
-  // Tailwind >=4.3.3 changed the shape of variant utilities: instead of nesting
-  // the `@media` inside the class rule (`.dark\:bg-black { @media ... {} }`), it
-  // now wraps the class rule with the `@media` (`@media ... { .dark\:bg-black {} }`).
-  // The extractor must still treat these as non-inlinable — otherwise the `dark:`
-  // value gets inlined as the base style and the media query is dropped from
-  // <head>.
+  // Wrapped shape emitted by Tailwind >=4.3.3.
+  // See https://github.com/resend/react-email/issues/3662
   it('treats @media-wrapped rules (Tailwind >=4.3.3) as non-inlinable', () => {
     const classes = [
       'bg-white',
@@ -258,10 +254,8 @@ describe('extractRulesPerClass()', async () => {
     `);
   });
 
-  // The counterpart to the test above: the old (Tailwind <=4.3.2) shape nests
-  // the `@media` inside the class rule. This must keep producing the exact same
-  // classification as the wrapped shape, so the 4.3.3 normalization stays a
-  // no-op for existing behavior.
+  // Nested shape emitted by Tailwind <=4.3.2; must classify identically.
+  // See https://github.com/resend/react-email/issues/3662
   it('treats @media-nested rules (Tailwind <=4.3.2) as non-inlinable', () => {
     const classes = [
       'bg-white',

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
@@ -214,7 +214,12 @@ describe('extractRulesPerClass()', async () => {
   // value gets inlined as the base style and the media query is dropped from
   // <head>.
   it('treats @media-wrapped rules (Tailwind >=4.3.3) as non-inlinable', () => {
-    const classes = ['bg-white', 'text-black', 'dark:bg-black', 'dark:text-white'];
+    const classes = [
+      'bg-white',
+      'text-black',
+      'dark:bg-black',
+      'dark:text-white',
+    ];
     const stylesheet = parse(`
 @layer utilities {
   .bg-white { background-color: rgb(255, 255, 255); }
@@ -258,7 +263,12 @@ describe('extractRulesPerClass()', async () => {
   // classification as the wrapped shape, so the 4.3.3 normalization stays a
   // no-op for existing behavior.
   it('treats @media-nested rules (Tailwind <=4.3.2) as non-inlinable', () => {
-    const classes = ['bg-white', 'text-black', 'dark:bg-black', 'dark:text-white'];
+    const classes = [
+      'bg-white',
+      'text-black',
+      'dark:bg-black',
+      'dark:text-white',
+    ];
     const stylesheet = parse(`
 @layer utilities {
   .bg-white { background-color: rgb(255, 255, 255); }

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
@@ -1,4 +1,4 @@
-import { generate, type Rule } from 'css-tree';
+import { generate, parse, type Rule, type StyleSheet } from 'css-tree';
 import { setupTailwind } from '../tailwindcss/setup-tailwind.js';
 import { extractRulesPerClass } from './extract-rules-per-class.js';
 
@@ -202,6 +202,94 @@ describe('extractRulesPerClass()', async () => {
       {
         "btn": [
           ".btn{&:hover{color:red}}",
+        ],
+      }
+    `);
+  });
+
+  // Tailwind >=4.3.3 changed the shape of variant utilities: instead of nesting
+  // the `@media` inside the class rule (`.dark\:bg-black { @media ... {} }`), it
+  // now wraps the class rule with the `@media` (`@media ... { .dark\:bg-black {} }`).
+  // The extractor must still treat these as non-inlinable — otherwise the `dark:`
+  // value gets inlined as the base style and the media query is dropped from
+  // <head>.
+  it('treats @media-wrapped rules (Tailwind >=4.3.3) as non-inlinable', () => {
+    const classes = ['bg-white', 'text-black', 'dark:bg-black', 'dark:text-white'];
+    const stylesheet = parse(`
+@layer utilities {
+  .bg-white { background-color: rgb(255, 255, 255); }
+  .text-black { color: rgb(0, 0, 0); }
+  @media (prefers-color-scheme: dark) {
+    .dark\\:bg-black { background-color: rgb(0, 0, 0); }
+    .dark\\:text-white { color: rgb(255, 255, 255); }
+  }
+}
+`) as StyleSheet;
+
+    const { inlinable, nonInlinable } = extractRulesPerClass(
+      stylesheet,
+      classes,
+    );
+
+    expect(convertToComparable(inlinable)).toMatchInlineSnapshot(`
+      {
+        "bg-white": [
+          ".bg-white{background-color:rgb(255,255,255)}",
+        ],
+        "text-black": [
+          ".text-black{color:rgb(0,0,0)}",
+        ],
+      }
+    `);
+    expect(convertToComparable(nonInlinable)).toMatchInlineSnapshot(`
+      {
+        "dark:bg-black": [
+          ".dark\\:bg-black{@media (prefers-color-scheme:dark){background-color:rgb(0,0,0)}}",
+        ],
+        "dark:text-white": [
+          ".dark\\:text-white{@media (prefers-color-scheme:dark){color:rgb(255,255,255)}}",
+        ],
+      }
+    `);
+  });
+
+  // The counterpart to the test above: the old (Tailwind <=4.3.2) shape nests
+  // the `@media` inside the class rule. This must keep producing the exact same
+  // classification as the wrapped shape, so the 4.3.3 normalization stays a
+  // no-op for existing behavior.
+  it('treats @media-nested rules (Tailwind <=4.3.2) as non-inlinable', () => {
+    const classes = ['bg-white', 'text-black', 'dark:bg-black', 'dark:text-white'];
+    const stylesheet = parse(`
+@layer utilities {
+  .bg-white { background-color: rgb(255, 255, 255); }
+  .text-black { color: rgb(0, 0, 0); }
+  .dark\\:bg-black { @media (prefers-color-scheme: dark) { background-color: rgb(0, 0, 0); } }
+  .dark\\:text-white { @media (prefers-color-scheme: dark) { color: rgb(255, 255, 255); } }
+}
+`) as StyleSheet;
+
+    const { inlinable, nonInlinable } = extractRulesPerClass(
+      stylesheet,
+      classes,
+    );
+
+    expect(convertToComparable(inlinable)).toMatchInlineSnapshot(`
+      {
+        "bg-white": [
+          ".bg-white{background-color:rgb(255,255,255)}",
+        ],
+        "text-black": [
+          ".text-black{color:rgb(0,0,0)}",
+        ],
+      }
+    `);
+    expect(convertToComparable(nonInlinable)).toMatchInlineSnapshot(`
+      {
+        "dark:bg-black": [
+          ".dark\\:bg-black{@media (prefers-color-scheme:dark){background-color:rgb(0,0,0)}}",
+        ],
+        "dark:text-white": [
+          ".dark\\:text-white{@media (prefers-color-scheme:dark){color:rgb(255,255,255)}}",
         ],
       }
     `);

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
@@ -1,6 +1,60 @@
-import { type CssNode, type Rule, string, walk } from 'css-tree';
+import {
+  type Atrule,
+  clone,
+  type CssNode,
+  List,
+  type Rule,
+  string,
+  walk,
+} from 'css-tree';
 import { isRuleInlinable } from './is-rule-inlinable.js';
 import { splitMixedRule } from './split-mixed-rule.js';
+
+// At-rules whose contents are conditional and therefore can never be inlined
+// onto an element (e.g. `@media (prefers-color-scheme: dark)`).
+const NON_INLINABLE_ATRULES = new Set(['media', 'supports']);
+
+/**
+ * Rebuild a rule that Tailwind emitted *inside* a non-inlinable at-rule wrapper
+ * so the at-rule(s) are nested back *inside* the rule instead.
+ *
+ * Tailwind <=4.3.2 nested the at-rule within the rule:
+ *   `.dark\:bg-black { @media (prefers-color-scheme: dark) { ... } }`
+ * Tailwind >=4.3.3 inverted it, wrapping the rule with the at-rule:
+ *   `@media (prefers-color-scheme: dark) { .dark\:bg-black { ... } }`
+ *
+ * Normalizing to the older shape keeps the rest of the pipeline
+ * (`downlevelForEmailClients`, etc.) working the same for every Tailwind
+ * version.
+ */
+function nestAtRulesInsideRule(rule: Rule, enclosingAtRules: Atrule[]): Rule {
+  const ruleClone = clone(rule) as Rule;
+  let children = ruleClone.block.children;
+
+  // Wrap from the innermost enclosing at-rule outward.
+  for (let i = enclosingAtRules.length - 1; i >= 0; i--) {
+    const atRule = enclosingAtRules[i]!;
+    const wrapped: Atrule = {
+      type: 'Atrule',
+      name: atRule.name,
+      prelude: atRule.prelude ? (clone(atRule.prelude) as Atrule['prelude']) : null,
+      block: {
+        type: 'Block',
+        children,
+      },
+    };
+    children = new List<CssNode>().fromArray([wrapped]);
+  }
+
+  return {
+    type: 'Rule',
+    prelude: clone(rule.prelude) as Rule['prelude'],
+    block: {
+      type: 'Block',
+      children,
+    },
+  };
+}
 
 export function extractRulesPerClass(root: CssNode, classes: string[]) {
   const classSet = new Set(classes);
@@ -23,52 +77,90 @@ export function extractRulesPerClass(root: CssNode, classes: string[]) {
     }
   };
 
-  walk(root, {
-    visit: 'Rule',
-    enter(rule) {
-      // A nested rule (e.g. group/peer's `&:is(:where(.group):hover *)`) belongs
-      // to its parent utility; processing it standalone emits a bare, parentless
-      // `&` rule into the <style> block, so skip it here.
-      const firstSelector =
-        rule.prelude.type === 'SelectorList'
-          ? rule.prelude.children.first
-          : null;
-      if (
-        firstSelector?.type === 'Selector' &&
-        firstSelector.children.first?.type === 'NestingSelector'
-      ) {
-        return;
-      }
+  // Chain of enclosing at-rules that force their contents to be non-inlinable.
+  // Tailwind >=4.3.3 emits variant utilities (e.g. `dark:`) as class rules
+  // nested inside these wrappers, so a rule found here must be treated as
+  // non-inlinable even though the rule itself looks plain.
+  const enclosingAtRules: Atrule[] = [];
 
-      // Only the prelude names the class that owns the rule; classes referenced
-      // inside the block (e.g. `.group` in `:where(.group)`) must not key it.
-      const selectorClasses: string[] = [];
-      walk(rule.prelude, {
-        visit: 'ClassSelector',
-        enter(classSelector) {
-          selectorClasses.push(string.decode(classSelector.name));
-        },
-      });
-      if (isRuleInlinable(rule)) {
-        for (const className of selectorClasses) {
-          if (classSet.has(className)) {
-            appendRule(inlinableRules, className, rule);
-          }
+  const handleRule = (rule: Rule) => {
+    // A nested rule (e.g. group/peer's `&:is(:where(.group):hover *)`) belongs
+    // to its parent utility; processing it standalone emits a bare, parentless
+    // `&` rule into the <style> block, so skip it here.
+    const firstSelector =
+      rule.prelude.type === 'SelectorList'
+        ? rule.prelude.children.first
+        : null;
+    if (
+      firstSelector?.type === 'Selector' &&
+      firstSelector.children.first?.type === 'NestingSelector'
+    ) {
+      return;
+    }
+
+    // Only the prelude names the class that owns the rule; classes referenced
+    // inside the block (e.g. `.group` in `:where(.group)`) must not key it.
+    const selectorClasses: string[] = [];
+    walk(rule.prelude, {
+      visit: 'ClassSelector',
+      enter(classSelector) {
+        selectorClasses.push(string.decode(classSelector.name));
+      },
+    });
+
+    // The rule sits inside an @media/@supports wrapper (Tailwind >=4.3.3). The
+    // declarations only apply in that condition, so treat the whole thing as
+    // non-inlinable after normalizing it to the nested-at-rule shape.
+    if (enclosingAtRules.length > 0) {
+      const nonInlinablePart = nestAtRulesInsideRule(rule, enclosingAtRules);
+      for (const className of selectorClasses) {
+        if (classSet.has(className)) {
+          appendRule(nonInlinableRules, className, nonInlinablePart);
         }
-      } else {
-        const { inlinablePart, nonInlinablePart } = splitMixedRule(rule);
-        for (const className of selectorClasses) {
-          if (!classSet.has(className)) continue;
-          if (inlinablePart) {
-            appendRule(inlinableRules, className, inlinablePart);
-          }
-          if (nonInlinablePart) {
-            appendRule(nonInlinableRules, className, nonInlinablePart);
-          }
+      }
+      return;
+    }
+
+    if (isRuleInlinable(rule)) {
+      for (const className of selectorClasses) {
+        if (classSet.has(className)) {
+          appendRule(inlinableRules, className, rule);
         }
+      }
+    } else {
+      const { inlinablePart, nonInlinablePart } = splitMixedRule(rule);
+      for (const className of selectorClasses) {
+        if (!classSet.has(className)) continue;
+        if (inlinablePart) {
+          appendRule(inlinableRules, className, inlinablePart);
+        }
+        if (nonInlinablePart) {
+          appendRule(nonInlinableRules, className, nonInlinablePart);
+        }
+      }
+    }
+  };
+
+  walk(root, {
+    enter(node) {
+      if (node.type === 'Atrule') {
+        if (NON_INLINABLE_ATRULES.has(node.name.toLowerCase())) {
+          enclosingAtRules.push(node);
+        }
+      } else if (node.type === 'Rule') {
+        handleRule(node);
+      }
+    },
+    leave(node) {
+      if (
+        node.type === 'Atrule' &&
+        NON_INLINABLE_ATRULES.has(node.name.toLowerCase())
+      ) {
+        enclosingAtRules.pop();
       }
     },
   });
+
   return {
     inlinable: inlinableRules,
     nonInlinable: nonInlinableRules,

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
@@ -1,7 +1,7 @@
 import {
   type Atrule,
-  clone,
   type CssNode,
+  clone,
   List,
   type Rule,
   string,
@@ -37,7 +37,9 @@ function nestAtRulesInsideRule(rule: Rule, enclosingAtRules: Atrule[]): Rule {
     const wrapped: Atrule = {
       type: 'Atrule',
       name: atRule.name,
-      prelude: atRule.prelude ? (clone(atRule.prelude) as Atrule['prelude']) : null,
+      prelude: atRule.prelude
+        ? (clone(atRule.prelude) as Atrule['prelude'])
+        : null,
       block: {
         type: 'Block',
         children,
@@ -88,9 +90,7 @@ export function extractRulesPerClass(root: CssNode, classes: string[]) {
     // to its parent utility; processing it standalone emits a bare, parentless
     // `&` rule into the <style> block, so skip it here.
     const firstSelector =
-      rule.prelude.type === 'SelectorList'
-        ? rule.prelude.children.first
-        : null;
+      rule.prelude.type === 'SelectorList' ? rule.prelude.children.first : null;
     if (
       firstSelector?.type === 'Selector' &&
       firstSelector.children.first?.type === 'NestingSelector'

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
@@ -12,10 +12,9 @@ import { isRuleInlinable } from './is-rule-inlinable.js';
 import { splitMixedRule } from './split-mixed-rule.js';
 
 /**
- * Tailwind >=4.3.3 wraps a rule with its variant at-rule
- * (`@media (...) { .dark\:x { ... } }`) where <=4.3.2 nested it inside
- * (`.dark\:x { @media (...) { ... } }`). Re-nest to the older shape so the rest
- * of the pipeline stays version-agnostic.
+ * Re-nest the at-rule(s) back inside the rule so the pipeline stays
+ * version-agnostic across Tailwind's variant shape change.
+ * See https://github.com/resend/react-email/issues/3662
  */
 function nestAtRulesInsideRule(rule: Rule, enclosingAtRules: Atrule[]): Rule {
   const ruleClone = clone(rule) as Rule;
@@ -69,8 +68,8 @@ export function extractRulesPerClass(root: CssNode, classes: string[]) {
     }
   };
 
-  // Enclosing at-rule wrappers (Tailwind >=4.3.3); a plain-looking rule inside
-  // one is still conditional and must not be inlined.
+  // A plain-looking rule inside these wrappers is still conditional and must
+  // not be inlined. See https://github.com/resend/react-email/issues/3662
   const enclosingAtRules: Atrule[] = [];
 
   const handleRule = (rule: Rule) => {

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
@@ -12,17 +12,10 @@ import { isRuleInlinable } from './is-rule-inlinable.js';
 import { splitMixedRule } from './split-mixed-rule.js';
 
 /**
- * Rebuild a rule that Tailwind emitted *inside* a non-inlinable at-rule wrapper
- * so the at-rule(s) are nested back *inside* the rule instead.
- *
- * Tailwind <=4.3.2 nested the at-rule within the rule:
- *   `.dark\:bg-black { @media (prefers-color-scheme: dark) { ... } }`
- * Tailwind >=4.3.3 inverted it, wrapping the rule with the at-rule:
- *   `@media (prefers-color-scheme: dark) { .dark\:bg-black { ... } }`
- *
- * Normalizing to the older shape keeps the rest of the pipeline
- * (`downlevelForEmailClients`, etc.) working the same for every Tailwind
- * version.
+ * Tailwind >=4.3.3 wraps a rule with its variant at-rule
+ * (`@media (...) { .dark\:x { ... } }`) where <=4.3.2 nested it inside
+ * (`.dark\:x { @media (...) { ... } }`). Re-nest to the older shape so the rest
+ * of the pipeline stays version-agnostic.
  */
 function nestAtRulesInsideRule(rule: Rule, enclosingAtRules: Atrule[]): Rule {
   const ruleClone = clone(rule) as Rule;
@@ -76,10 +69,8 @@ export function extractRulesPerClass(root: CssNode, classes: string[]) {
     }
   };
 
-  // Chain of enclosing at-rules that force their contents to be non-inlinable.
-  // Tailwind >=4.3.3 emits variant utilities (e.g. `dark:`) as class rules
-  // nested inside these wrappers, so a rule found here must be treated as
-  // non-inlinable even though the rule itself looks plain.
+  // Enclosing at-rule wrappers (Tailwind >=4.3.3); a plain-looking rule inside
+  // one is still conditional and must not be inlined.
   const enclosingAtRules: Atrule[] = [];
 
   const handleRule = (rule: Rule) => {
@@ -105,9 +96,6 @@ export function extractRulesPerClass(root: CssNode, classes: string[]) {
       },
     });
 
-    // The rule sits inside an @media/@supports wrapper (Tailwind >=4.3.3). The
-    // declarations only apply in that condition, so treat the whole thing as
-    // non-inlinable after normalizing it to the nested-at-rule shape.
     if (enclosingAtRules.length > 0) {
       const nonInlinablePart = nestAtRulesInsideRule(rule, enclosingAtRules);
       for (const className of selectorClasses) {

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
@@ -7,17 +7,9 @@ import {
   string,
   walk,
 } from 'css-tree';
+import { NON_INLINABLE_ATRULES } from './constants.js';
 import { isRuleInlinable } from './is-rule-inlinable.js';
 import { splitMixedRule } from './split-mixed-rule.js';
-
-// At-rules whose contents are conditional and therefore can never be inlined
-// onto an element (e.g. `@media (prefers-color-scheme: dark)`).
-//
-// Keep this in sync with the at-rules `unnestMediaQueries` hoists in
-// downlevel-for-email-clients.ts — those are the only wrappers email clients
-// can render once un-nested, so we must not mark a wrapper non-inlinable here
-// that the downlevel pass can't later hoist out of the rule.
-const NON_INLINABLE_ATRULES = new Set(['media', 'supports']);
 
 /**
  * Rebuild a rule that Tailwind emitted *inside* a non-inlinable at-rule wrapper

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
@@ -12,6 +12,11 @@ import { splitMixedRule } from './split-mixed-rule.js';
 
 // At-rules whose contents are conditional and therefore can never be inlined
 // onto an element (e.g. `@media (prefers-color-scheme: dark)`).
+//
+// Keep this in sync with the at-rules `unnestMediaQueries` hoists in
+// downlevel-for-email-clients.ts — those are the only wrappers email clients
+// can render once un-nested, so we must not mark a wrapper non-inlinable here
+// that the downlevel pass can't later hoist out of the rule.
 const NON_INLINABLE_ATRULES = new Set(['media', 'supports']);
 
 /**


### PR DESCRIPTION
## Problem

With `tailwindcss@4.3.3`+, `<Tailwind>` stops extracting media-query variants (e.g. `dark:`) into the `<head>` `<style>` block. Instead, the conditional value is inlined as the **base** style and the `@media` rule is dropped entirely — so `dark:` colors apply unconditionally and dark-mode switching never happens.

## Root cause

Tailwind changed the shape of the CSS it generates for variant utilities between `4.3.2` and `4.3.3`.

**≤4.3.2** nests the `@media` *inside* the class rule:

```css
.dark\:bg-black { @media (prefers-color-scheme: dark) { background-color: #000 } }
```

**≥4.3.3** inverts it — the `@media` *wraps* the class rule:

```css
@media (prefers-color-scheme: dark) { .dark\:bg-black { background-color: #000 } }
```

`extractRulesPerClass` walks each `Rule` node in isolation. With the new shape, the inner `.dark\:bg-black` rule looks like a plain class with a single declaration — no `@media`, no pseudo — so `isRuleInlinable()` returns `true`, the value gets inlined, and the `@media` wrapper is never emitted.

## Fix

Track the chain of enclosing `@media`/`@supports` at-rules while walking. When a rule is found inside one, treat it as non-inlinable and normalize it back to the older nested-at-rule shape, so the rest of the pipeline (`downlevelForEmailClients`, etc.) behaves identically across Tailwind versions. This keeps compatibility going forward rather than capping the supported Tailwind range.

## Tests

Added two companion tests to `extract-rules-per-class.spec.ts` that assert both CSS shapes produce identical classification:

- `treats @media-nested rules (Tailwind <=4.3.2) as non-inlinable`
- `treats @media-wrapped rules (Tailwind >=4.3.3) as non-inlinable`

Both are parsed directly (version-independent) since the repo is pinned to `tailwindcss@4.1.18`, which only emits the old shape. Full tailwind suite passes (139), typecheck and lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes <Tailwind> dropping `dark:` and other media-query variants with `tailwindcss@4.3.3+`. Conditional styles are extracted into the <head> again so dark mode and other media-based variants work as expected.

- **Bug Fixes**
  - Track enclosing `@media`/`@supports` at-rules while walking CSS and treat inner class rules as non-inlinable.
  - Re-nest wrapped rules back to the older nested shape for consistent downstream processing.
  - Added tests to ensure both wrapped (≥`4.3.3`) and nested (≤`4.3.2`) shapes produce identical extraction.

- **Refactors**
  - Centralized `NON_INLINABLE_ATRULES` in `constants.ts` and shared it between the extractor and downlevel passes to keep behavior aligned.
  - Comments reference issue `#3662` for context.

<sup>Written for commit c8b7a104d08d32312d4bc1ef4168105ae4186d9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

