### PR TITLE
fix(editor): reset margin/padding on the minimal mode

### DIFF
--- a/.changeset/minimal-theme-body-spacing.md
+++ b/.changeset/minimal-theme-body-spacing.md
@@ -1,0 +1,5 @@
+---
+'@react-email/editor': patch
+---
+
+Make body margin and padding theme-driven instead of hardcoded on the email `<Body>`. The `minimal` theme's body panel now includes a Margin input and defaults its padding inputs to `0`, so body spacing is visible and editable in the inspector and can be overridden per document. The `basic` theme keeps its `margin: 0; padding: 0` body reset with unchanged output.

--- a/packages/editor/src/plugins/email-theming/extension.tsx
+++ b/packages/editor/src/plugins/email-theming/extension.tsx
@@ -313,15 +313,7 @@ export const EmailTheming = Extension.create<{
                 <Preview>{previewText}</Preview>
               )}
 
-              <Body
-                style={{
-                  margin: 0,
-                  padding: 0,
-                  ...mergedStyles.body,
-                }}
-              >
-                {children}
-              </Body>
+              <Body style={mergedStyles.body}>{children}</Body>
             </Html>
           );
         },

--- a/packages/editor/src/plugins/email-theming/themes.ts
+++ b/packages/editor/src/plugins/email-theming/themes.ts
@@ -448,9 +448,17 @@ const THEME_MINIMAL: PanelGroup[] = [
         classReference: 'body',
       },
       {
+        label: 'Margin',
+        type: 'number',
+        value: 0,
+        unit: 'px',
+        prop: 'margin',
+        classReference: 'body',
+      },
+      {
         label: 'Padding Top',
         type: 'number',
-        value: undefined,
+        value: 0,
         unit: 'px',
         prop: 'paddingTop',
         classReference: 'body',
@@ -458,7 +466,7 @@ const THEME_MINIMAL: PanelGroup[] = [
       {
         label: 'Padding Right',
         type: 'number',
-        value: undefined,
+        value: 0,
         unit: 'px',
         prop: 'paddingRight',
         classReference: 'body',
@@ -466,7 +474,7 @@ const THEME_MINIMAL: PanelGroup[] = [
       {
         label: 'Padding Bottom',
         type: 'number',
-        value: undefined,
+        value: 0,
         unit: 'px',
         prop: 'paddingBottom',
         classReference: 'body',
@@ -474,7 +482,7 @@ const THEME_MINIMAL: PanelGroup[] = [
       {
         label: 'Padding Left',
         type: 'number',
-        value: undefined,
+        value: 0,
         unit: 'px',
         prop: 'paddingLeft',
         classReference: 'body',
@@ -669,6 +677,8 @@ const RESET_BASIC: ResetTheme = {
     padding: '0',
   },
   body: {
+    margin: '0',
+    padding: '0',
     fontFamily:
       "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif",
     fontSize: '14px',
@@ -1096,6 +1106,13 @@ export const SUPPORTED_CSS_PROPERTIES: SupportedCssProperties = {
     type: 'color',
     defaultValue: '#000000',
     category: 'appearance',
+  },
+  margin: {
+    label: 'Margin',
+    type: 'number',
+    unit: 'px',
+    defaultValue: 0,
+    category: 'layout',
   },
   padding: {
     label: 'Padding',

--- a/packages/editor/src/plugins/email-theming/types.ts
+++ b/packages/editor/src/plugins/email-theming/types.ts
@@ -75,6 +75,7 @@ export type KnownCssProperties =
   | 'borderRightColor'
   | 'borderBottomColor'
   | 'borderLeftColor'
+  | 'margin'
   | 'padding'
   | 'paddingTop'
   | 'paddingRight'


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make body spacing theme-driven and editable to remove unwanted gaps. Minimal now sets body margin/padding to 0 via theme and adds a Margin control; basic keeps its body reset.

- **Bug Fixes**
  - Removed inline body margin/padding in `@react-email/editor`; `Body` now uses `mergedStyles.body`.
  - Minimal: default body margin/padding to 0 via theme; basic keeps `margin: 0; padding: 0`.

- **New Features**
  - Added a Margin control to the minimal theme’s Body panel; body padding inputs are now visible and editable.
  - Added `margin` to `SUPPORTED_CSS_PROPERTIES` and types (`px`, default 0).

<sup>Written for commit e667cd25514886bdc5ff6f8fac999672046c4f10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

