### PR TITLE
fix(ui): keep sidebar scroll when switching emails

### DIFF
--- a/.changeset/quiet-drawers-linger.md
+++ b/.changeset/quiet-drawers-linger.md
@@ -1,0 +1,5 @@
+---
+'@react-email/ui': patch
+---
+
+Keep the sidebar scroll position, its collapsed state, and open folders when you switch emails.

--- a/packages/ui/src/app/layout.tsx
+++ b/packages/ui/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 
 import type { Metadata } from 'next';
+import { Shell } from '../components/shell';
 import { EmailsProvider } from '../contexts/emails';
 import { WorkspaceProvider } from '../contexts/workspace';
 import { getEmailsDirectoryMetadata } from '../utils/get-emails-directory-metadata';
@@ -42,7 +43,7 @@ export default async function RootLayout({
             <EmailsProvider
               initialEmailsDirectoryMetadata={emailsDirectoryMetadata}
             >
-              {children}
+              <Shell>{children}</Shell>
             </EmailsProvider>
           </WorkspaceProvider>
         </div>

--- a/packages/ui/src/app/page.tsx
+++ b/packages/ui/src/app/page.tsx
@@ -3,7 +3,6 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { Button, Heading, Text } from '../components';
 import CodeSnippet from '../components/code-snippet';
-import { Shell } from '../components/shell';
 import { emailsDirectoryAbsolutePath } from './env';
 import logo from './logo.png';
 
@@ -11,34 +10,32 @@ export default function Home() {
   const baseEmailsDirectoryName = path.basename(emailsDirectoryAbsolutePath);
 
   return (
-    <Shell>
-      <div className="w-full h-full flex items-center justify-center p-8">
-        <div className="-mt-10 relative max-w-lg flex flex-col items-center gap-3 text-center">
-          <Image
-            alt="React Email Icon"
-            className="mb-8"
-            height={144}
-            src={logo}
-            style={{
-              borderRadius: 34,
-              boxShadow: '0 .625rem 12.5rem 1.25rem #2B7CA080',
-            }}
-            width={141}
-          />
-          <Heading as="h2" size="6" weight="medium">
-            Welcome to React Email
-          </Heading>
-          <Text as="p">
-            To start developing your emails, you can create a<br />
-            <CodeSnippet>.jsx</CodeSnippet> or <CodeSnippet>.tsx</CodeSnippet>{' '}
-            file under your <CodeSnippet>{baseEmailsDirectoryName}</CodeSnippet>{' '}
-            folder.
-          </Text>
-          <Button asChild className="mt-3" size="3">
-            <Link href="https://react.email/docs">Check the docs</Link>
-          </Button>
-        </div>
+    <div className="w-full h-full flex items-center justify-center p-8">
+      <div className="-mt-10 relative max-w-lg flex flex-col items-center gap-3 text-center">
+        <Image
+          alt="React Email Icon"
+          className="mb-8"
+          height={144}
+          src={logo}
+          style={{
+            borderRadius: 34,
+            boxShadow: '0 .625rem 12.5rem 1.25rem #2B7CA080',
+          }}
+          width={141}
+        />
+        <Heading as="h2" size="6" weight="medium">
+          Welcome to React Email
+        </Heading>
+        <Text as="p">
+          To start developing your emails, you can create a<br />
+          <CodeSnippet>.jsx</CodeSnippet> or <CodeSnippet>.tsx</CodeSnippet>{' '}
+          file under your <CodeSnippet>{baseEmailsDirectoryName}</CodeSnippet>{' '}
+          folder.
+        </Text>
+        <Button asChild className="mt-3" size="3">
+          <Link href="https://react.email/docs">Check the docs</Link>
+        </Button>
       </div>
-    </Shell>
+    </div>
   );
 }

--- a/packages/ui/src/app/preview/[...slug]/page.tsx
+++ b/packages/ui/src/app/preview/[...slug]/page.tsx
@@ -7,7 +7,6 @@ import {
 } from '../../../actions/email-validation/check-compatibility';
 import { getEmailPathFromSlug } from '../../../actions/get-email-path-from-slug';
 import { renderEmailByPath } from '../../../actions/render-email-by-path';
-import { Shell } from '../../../components/shell';
 import { Toolbar } from '../../../components/toolbar';
 import type { LintingRow } from '../../../components/toolbar/linter';
 import type { SpamCheckingResult } from '../../../components/toolbar/spam-assassin';
@@ -135,23 +134,21 @@ This is most likely not an issue with the preview server. Maybe there was a typo
       emailPath={emailPath}
       serverRenderingResult={serverEmailRenderingResult}
     >
-      <Shell currentEmailOpenSlug={slug}>
-        {/* This suspense is so that this page doesn't throw warnings */}
-        {/* on the build of the preview server de-opting into         */}
-        {/* client-side rendering on build                            */}
-        <Suspense>
-          <Preview emailTitle={path.basename(emailPath)} />
+      {/* This suspense is so that this page doesn't throw warnings */}
+      {/* on the build of the preview server de-opting into         */}
+      {/* client-side rendering on build                            */}
+      <Suspense>
+        <Preview emailTitle={path.basename(emailPath)} />
 
-          <ToolbarProvider hasApiKey={(resendApiKey ?? '').trim().length > 0}>
-            <Toolbar
-              serverLintingRows={lintingRows}
-              serverSpamCheckingResult={spamCheckingResult}
-              serverCompatibilityResults={compatibilityCheckingResults}
-              serverCompatibilityClients={getRelevantEmailClients()}
-            />
-          </ToolbarProvider>
-        </Suspense>
-      </Shell>
+        <ToolbarProvider hasApiKey={(resendApiKey ?? '').trim().length > 0}>
+          <Toolbar
+            serverLintingRows={lintingRows}
+            serverSpamCheckingResult={spamCheckingResult}
+            serverCompatibilityResults={compatibilityCheckingResults}
+            serverCompatibilityClients={getRelevantEmailClients()}
+          />
+        </ToolbarProvider>
+      </Suspense>
     </PreviewProvider>
   );
 }

--- a/packages/ui/src/components/shell.tsx
+++ b/packages/ui/src/components/shell.tsx
@@ -7,7 +7,6 @@ import { Sidebar } from './sidebar';
 
 interface ShellProps {
   children: React.ReactNode;
-  currentEmailOpenSlug?: string;
 }
 
 interface ShellContextValue {
@@ -19,7 +18,7 @@ export const ShellContext = React.createContext<ShellContextValue | undefined>(
   undefined,
 );
 
-export const Shell = ({ children, currentEmailOpenSlug }: ShellProps) => {
+export const Shell = ({ children }: ShellProps) => {
   const [sidebarToggled, setSidebarToggled] = React.useState(true);
 
   return (
@@ -73,7 +72,6 @@ export const Shell = ({ children, currentEmailOpenSlug }: ShellProps) => {
                 'lg:w-0': !sidebarToggled,
               },
             )}
-            currentEmailOpenSlug={currentEmailOpenSlug}
           />
         </React.Suspense>
         <main

--- a/packages/ui/src/components/shell.tsx
+++ b/packages/ui/src/components/shell.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
 import * as React from 'react';
 import { cn } from '../utils';
 import { Logo } from './logo';
@@ -20,6 +21,14 @@ export const ShellContext = React.createContext<ShellContextValue | undefined>(
 
 export const Shell = ({ children }: ShellProps) => {
   const [sidebarToggled, setSidebarToggled] = React.useState(true);
+  const pathname = usePathname();
+
+  // 64rem is the `lg` breakpoint the drawer styles below are keyed to.
+  React.useEffect(() => {
+    if (window.matchMedia('(min-width: 64rem)').matches) return;
+
+    setSidebarToggled(true);
+  }, [pathname]);
 
   return (
     <ShellContext.Provider

--- a/packages/ui/src/components/sidebar/file-tree-directory.tsx
+++ b/packages/ui/src/components/sidebar/file-tree-directory.tsx
@@ -35,6 +35,13 @@ export const FileTreeDirectory = ({
       doesDirectoryContainCurrentEmailOpen,
   );
 
+  React.useEffect(() => {
+    if (!doesDirectoryContainCurrentEmailOpen) return;
+
+    persistedOpenDirectories.add(directoryMetadata.absolutePath);
+    setOpen(true);
+  }, [doesDirectoryContainCurrentEmailOpen, directoryMetadata.absolutePath]);
+
   return (
     <Collapsible.Root
       className={cn('group', className)}

--- a/packages/ui/src/components/sidebar/sidebar.tsx
+++ b/packages/ui/src/components/sidebar/sidebar.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { clsx } from 'clsx';
+import { useParams } from 'next/navigation';
 import { useEmails } from '../../contexts/emails';
 import { cn } from '../../utils';
 import { Logo } from '../logo';
@@ -7,11 +8,14 @@ import { FileTree } from './file-tree';
 
 interface SidebarProps {
   className?: string;
-  currentEmailOpenSlug?: string;
 }
 
-export const Sidebar = ({ className, currentEmailOpenSlug }: SidebarProps) => {
+export const Sidebar = ({ className }: SidebarProps) => {
   const { emailsDirectoryMetadata } = useEmails();
+  const params = useParams();
+  const currentEmailOpenSlug = Array.isArray(params.slug)
+    ? decodeURIComponent(params.slug.join('/'))
+    : undefined;
 
   return (
     <aside


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

## Issue
Navigating between emails remounted Shell on every page, so the sidebar lost its scroll position.

### Fix
Move `Shell` into the root layout so it stays mounted across routes, and derive the active email from useParams() instead of passing currentEmailOpenSlug down the tree.

### Demonstration of the issue
https://github.com/user-attachments/assets/6694aa90-bef2-47e4-a254-267bc976e47b


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the sidebar scroll, collapsed state, and open folders when switching emails. Also closes the mobile drawer on navigation to prevent overlaying the preview on small screens.

- Move `Shell` to `app/layout.tsx`; remove per‑page `Shell` wrappers in `app/page.tsx` and `app/preview/[...slug]/page.tsx`.
- Sidebar derives the active email from `useParams()`; remove the `currentEmailOpenSlug` prop.
- Auto-close the sidebar drawer on route changes below the `lg` breakpoint; keep the collapsed desktop state unchanged.
- Re-open the folder that contains the active email and persist open folders.
- Add a patch changeset for `@react-email/ui`.

<sup>Written for commit b69fbd44f94bcfc18d797a3808c9ddfb1cd230c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

