### PR TITLE
feat(react-email): add prop controls to the props panel

### DIFF
--- a/.changeset/preview-props-controls.md
+++ b/.changeset/preview-props-controls.md
@@ -1,0 +1,5 @@
+---
+"react-email": minor
+---
+
+Add a controls tab to the preview props panel. Templates can declare per-prop controls through a static `PreviewControls` property (text, bounded number, boolean, select, and raw JSON), mirroring how `PreviewProps` is declared; props without a declaration get a control inferred from their value. Edits merge into a single debounced props override, and the JSON editor remains available as an escape hatch.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -39,6 +39,7 @@
     "@radix-ui/react-dropdown-menu": "2.1.16",
     "@radix-ui/react-popover": "catalog:",
     "@radix-ui/react-slot": "catalog:",
+    "@radix-ui/react-switch": "1.3.5",
     "@radix-ui/react-tabs": "catalog:",
     "@radix-ui/react-toggle": "1.1.10",
     "@radix-ui/react-toggle-group": "1.1.11",

--- a/packages/ui/src/actions/render-email-by-path.tsx
+++ b/packages/ui/src/actions/render-email-by-path.tsx
@@ -15,7 +15,12 @@ import { convertStackWithSourceMap } from '../utils/convert-stack-with-sourcemap
 import { createJsxRuntime } from '../utils/create-jsx-runtime';
 import { getEmailComponent } from '../utils/get-email-component';
 import { isPathWithinEmailsDirectory } from '../utils/is-path-within-emails-directory';
+import {
+  type DeclaredPreviewControls,
+  validatePreviewControlsDeclaration,
+} from '../utils/preview-controls/declared-preview-controls';
 import { registerSpinnerAutostopping } from '../utils/register-spinner-autostopping';
+import { isErr } from '../utils/result';
 import {
   createSpinner,
   type Spinner,
@@ -30,6 +35,11 @@ export interface RenderedEmailMetadata {
    * given, otherwise the template's own `PreviewProps`.
    */
   previewProps: Record<string, unknown>;
+  /**
+   * The template's validated `PreviewControls` declaration, when it exports
+   * one. Props without a declared control get one inferred from their value.
+   */
+  previewControls?: DeclaredPreviewControls;
   prettyMarkup: string;
   markup: string;
   /**
@@ -238,6 +248,19 @@ export const renderEmailByPath = async (
   } = componentResult;
 
   const previewProps = previewPropsOverride ?? Email.PreviewProps ?? {};
+
+  const controlsResult = validatePreviewControlsDeclaration(
+    Email.PreviewControls,
+  );
+  let previewControls: DeclaredPreviewControls | undefined;
+  if (isErr(controlsResult)) {
+    console.warn(
+      `Ignoring the invalid \`PreviewControls\` of ${emailFilename}; its controls will be inferred from \`PreviewProps\` instead.\n${controlsResult.error}`,
+    );
+  } else {
+    previewControls = controlsResult.value;
+  }
+
   const EmailComponent = Email as React.FunctionComponent;
   try {
     const timeBeforeEmailRendered = performance.now();
@@ -277,6 +300,7 @@ export const renderEmailByPath = async (
 
     const renderingResult: RenderedEmailMetadata = {
       previewProps: toJsonSafeProps(previewProps),
+      previewControls,
       prettyMarkup,
       // This ensures that no null byte character ends up in the rendered
       // markup making users suspect of any issues. These null byte characters

--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -2,9 +2,13 @@
 
 import type * as React from 'react';
 import { cn } from '../utils';
+import { IconArrowDown } from './icons/icon-arrow-down';
 
 // Shared form-field primitives. They only own the field look; spacing
 // between fields is left to the caller.
+
+const fieldClasses =
+  'w-full appearance-none rounded-lg border border-slate-6 bg-slate-3 px-2 py-1 text-sm text-slate-12 placeholder-slate-10 outline-hidden transition duration-300 ease-in-out focus:ring-1 focus:ring-slate-10 disabled:opacity-60';
 
 export const FieldLabel = ({
   className,
@@ -25,11 +29,21 @@ export const TextInput = ({
   className,
   ...props
 }: React.ComponentProps<'input'>) => (
-  <input
-    className={cn(
-      'w-full appearance-none rounded-lg border border-slate-6 bg-slate-3 px-2 py-1 text-sm text-slate-12 placeholder-slate-10 outline-hidden transition duration-300 ease-in-out focus:ring-1 focus:ring-slate-10 disabled:opacity-60',
-      className,
-    )}
-    {...props}
-  />
+  <input className={cn(fieldClasses, className)} {...props} />
+);
+
+export const SelectInput = ({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<'select'>) => (
+  <div className="relative">
+    <select className={cn(fieldClasses, 'pr-7', className)} {...props}>
+      {children}
+    </select>
+    <IconArrowDown
+      className="pointer-events-none absolute top-1/2 right-1 -translate-y-1/2 text-slate-10"
+      size={16}
+    />
+  </div>
 );

--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import type * as React from 'react';
+import { cn } from '../utils';
+
+// Shared form-field primitives. They only own the field look; spacing
+// between fields is left to the caller.
+
+export const FieldLabel = ({
+  className,
+  htmlFor,
+  children,
+  ...props
+}: React.ComponentProps<'label'> & { htmlFor: string }) => (
+  <label
+    className={cn('block text-xs uppercase text-slate-10', className)}
+    htmlFor={htmlFor}
+    {...props}
+  >
+    {children}
+  </label>
+);
+
+export const TextInput = ({
+  className,
+  ...props
+}: React.ComponentProps<'input'>) => (
+  <input
+    className={cn(
+      'w-full appearance-none rounded-lg border border-slate-6 bg-slate-3 px-2 py-1 text-sm text-slate-12 placeholder-slate-10 outline-hidden transition duration-300 ease-in-out focus:ring-1 focus:ring-slate-10 disabled:opacity-60',
+      className,
+    )}
+    {...props}
+  />
+);

--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type * as React from 'react';
+import * as React from 'react';
 import { cn } from '../utils';
 import { IconArrowDown } from './icons/icon-arrow-down';
 
@@ -25,12 +25,20 @@ export const FieldLabel = ({
   </label>
 );
 
-export const TextInput = ({
-  className,
-  ...props
-}: React.ComponentProps<'input'>) => (
-  <input className={cn(fieldClasses, className)} {...props} />
-);
+// forwardRef so the ref reaches the <input> on React 18, where function
+// components do not receive ref as a regular prop.
+export const TextInput = React.forwardRef<
+  HTMLInputElement,
+  React.ComponentPropsWithoutRef<'input'>
+>(({ className, ...props }, forwardedRef) => (
+  <input
+    className={cn(fieldClasses, className)}
+    ref={forwardedRef}
+    {...props}
+  />
+));
+
+TextInput.displayName = 'TextInput';
 
 export const SelectInput = ({
   className,

--- a/packages/ui/src/components/json-editor.tsx
+++ b/packages/ui/src/components/json-editor.tsx
@@ -1,17 +1,24 @@
 'use client';
 
 import { Highlight } from 'prism-react-renderer';
+import type * as React from 'react';
 import { cn } from '../utils';
 import { codeTheme } from './code';
 
-interface JsonEditorProps {
+// The textarea must always end up with an accessible name: either its own
+// `aria-label` or an `id` a <label htmlFor> points at.
+type JsonEditorLabelling =
+  | { id: string; 'aria-label'?: string }
+  | { id?: string; 'aria-label': string };
+
+type JsonEditorProps = JsonEditorLabelling & {
   value: string;
   onChange: (value: string) => void;
   disabled?: boolean;
   className?: string;
-  'aria-label': string;
+  textareaRef?: React.Ref<HTMLTextAreaElement>;
   'aria-invalid'?: boolean;
-}
+};
 
 // Text metrics must match between the highlighted <pre> and the transparent
 // <textarea> on top of it, or the caret drifts from the characters.
@@ -28,7 +35,8 @@ export const JsonEditor = ({
   onChange,
   disabled = false,
   className,
-  ...ariaProps
+  textareaRef,
+  ...textareaProps
 }: JsonEditorProps) => {
   return (
     <div
@@ -54,7 +62,7 @@ export const JsonEditor = ({
         )}
       </Highlight>
       <textarea
-        {...ariaProps}
+        {...textareaProps}
         className={cn(
           sharedTextClasses,
           'absolute inset-0 h-full w-full resize-none overflow-hidden bg-transparent text-transparent caret-slate-12 outline-none',
@@ -63,6 +71,7 @@ export const JsonEditor = ({
         onChange={(event) => {
           onChange(event.currentTarget.value);
         }}
+        ref={textareaRef}
         spellCheck={false}
         value={value}
       />

--- a/packages/ui/src/components/preview-props-controls.tsx
+++ b/packages/ui/src/components/preview-props-controls.tsx
@@ -1,0 +1,353 @@
+'use client';
+
+import * as Switch from '@radix-ui/react-switch';
+import * as React from 'react';
+import { cn } from '../utils';
+import type { DeclaredPreviewControls } from '../utils/preview-controls/declared-preview-controls';
+import {
+  type ControlDescriptor,
+  resolvePreviewControls,
+} from '../utils/preview-controls/resolve-preview-controls';
+import { unreachable } from '../utils/unreachable';
+import { FieldLabel, SelectInput, TextInput } from './field';
+import { JsonEditor } from './json-editor';
+
+interface PreviewPropsControlsProps {
+  previewProps: Record<string, unknown>;
+  declaredControls: DeclaredPreviewControls | undefined;
+  disabled?: boolean;
+  onChangeProp: (key: string, value: unknown) => void;
+}
+
+/**
+ * A form of per-prop controls as an alternative to editing the raw JSON:
+ * the template's `PreviewControls` declaration first, then controls inferred
+ * from the remaining props. Value edits are reported per key so the editor
+ * can merge them into a single props override.
+ */
+export const PreviewPropsControls = ({
+  previewProps,
+  declaredControls,
+  disabled = false,
+  onChangeProp,
+}: PreviewPropsControlsProps) => {
+  const controls = resolvePreviewControls(previewProps, declaredControls);
+
+  if (controls.length === 0) {
+    return (
+      <p className="text-slate-11">
+        This template has no preview props. Export a{' '}
+        <code className="text-slate-12">PreviewProps</code> object from it to
+        control the preview here.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {controls.map((control) => (
+        <PropField
+          control={control}
+          disabled={disabled}
+          key={control.key}
+          onChange={(value) => {
+            onChangeProp(control.key, value);
+          }}
+          value={previewProps[control.key]}
+        />
+      ))}
+    </div>
+  );
+};
+
+interface ControlProps<Value> {
+  id: string;
+  value: Value;
+  disabled: boolean;
+  onChange: (value: Value) => void;
+}
+
+const PropField = ({
+  control,
+  value,
+  disabled,
+  onChange,
+}: {
+  control: ControlDescriptor;
+  value: unknown;
+  disabled: boolean;
+  onChange: (value: unknown) => void;
+}) => {
+  const id = React.useId();
+
+  // A control's declared type wins over the value's runtime type (the value
+  // may not match after a raw JSON edit, or not exist at all), so each field
+  // coerces the value into what it can render.
+  let field: React.ReactNode;
+  switch (control.type) {
+    case 'boolean':
+      field = (
+        <BooleanControl
+          disabled={disabled}
+          id={id}
+          onChange={onChange}
+          value={value === true}
+        />
+      );
+      break;
+    case 'number':
+      field = (
+        <NumberControl
+          disabled={disabled}
+          id={id}
+          max={control.max}
+          min={control.min}
+          onChange={onChange}
+          step={control.step}
+          value={
+            typeof value === 'number' && Number.isFinite(value)
+              ? value
+              : undefined
+          }
+        />
+      );
+      break;
+    case 'text':
+      field = (
+        <TextControl
+          disabled={disabled}
+          id={id}
+          onChange={onChange}
+          value={typeof value === 'string' ? value : ''}
+        />
+      );
+      break;
+    case 'select':
+      field = (
+        <SelectControl
+          disabled={disabled}
+          id={id}
+          onChange={onChange}
+          options={control.options}
+          value={value}
+        />
+      );
+      break;
+    case 'json':
+      field = (
+        <JsonControl
+          disabled={disabled}
+          id={id}
+          onChange={onChange}
+          value={value}
+        />
+      );
+      break;
+    default:
+      field = unreachable(control);
+  }
+
+  return (
+    <div>
+      <FieldLabel className="mb-1" htmlFor={id}>
+        {control.label}
+      </FieldLabel>
+      {field}
+    </div>
+  );
+};
+
+const BooleanControl = ({
+  id,
+  value,
+  disabled,
+  onChange,
+}: ControlProps<boolean>) => (
+  <Switch.Root
+    checked={value}
+    className={cn(
+      'inline-flex h-5 w-9 shrink-0 items-center rounded-full border border-slate-6 transition duration-200 ease-in-out',
+      'data-[state=checked]:bg-slate-9 data-[state=unchecked]:bg-slate-4',
+      disabled ? 'opacity-60' : 'hover:border-slate-8',
+    )}
+    disabled={disabled}
+    id={id}
+    onCheckedChange={onChange}
+  >
+    <Switch.Thumb
+      className={cn(
+        'block h-3.5 w-3.5 rounded-full bg-slate-12 transition-transform duration-150',
+        'translate-x-0.75 data-[state=checked]:translate-x-4.5',
+      )}
+    />
+  </Switch.Root>
+);
+
+const SelectControl = ({
+  id,
+  value,
+  options,
+  disabled,
+  onChange,
+}: ControlProps<unknown> & { options: (string | number)[] }) => {
+  // Options are indexed rather than stringified so numeric options keep
+  // their type through the round-trip.
+  const selectedIndex = options.indexOf(value as string | number);
+
+  return (
+    <SelectInput
+      disabled={disabled}
+      id={id}
+      onChange={(event) => {
+        const option = options[Number(event.currentTarget.value)];
+        if (option !== undefined) {
+          onChange(option);
+        }
+      }}
+      value={selectedIndex === -1 ? '' : String(selectedIndex)}
+    >
+      {selectedIndex === -1 ? (
+        // The current value (e.g. from a raw JSON edit) is not among the
+        // options; represent it with an empty placeholder instead of
+        // pretending an option is selected.
+        <option disabled value="" />
+      ) : null}
+      {options.map((option, index) => (
+        <option key={option} value={String(index)}>
+          {option}
+        </option>
+      ))}
+    </SelectInput>
+  );
+};
+
+/**
+ * Text-like controls keep a local draft while focused so the input does not
+ * snap back to the last applied value mid-typing; the draft re-syncs from the
+ * applied props once the field loses focus (e.g. after a reset).
+ */
+const useFieldDraft = <Element extends HTMLElement>(
+  appliedText: string,
+  ref: React.RefObject<Element | null>,
+) => {
+  const [draft, setDraft] = React.useState(appliedText);
+
+  React.useEffect(() => {
+    if (document.activeElement !== ref.current) {
+      setDraft(appliedText);
+    }
+  }, [appliedText, ref]);
+
+  return [draft, setDraft] as const;
+};
+
+const TextControl = ({
+  id,
+  value,
+  disabled,
+  onChange,
+}: ControlProps<string>) => {
+  const ref = React.useRef<HTMLInputElement>(null);
+  const [draft, setDraft] = useFieldDraft(value, ref);
+
+  return (
+    <TextInput
+      disabled={disabled}
+      id={id}
+      onChange={(event) => {
+        setDraft(event.currentTarget.value);
+        onChange(event.currentTarget.value);
+      }}
+      ref={ref}
+      spellCheck={false}
+      type="text"
+      value={draft}
+    />
+  );
+};
+
+const NumberControl = ({
+  id,
+  value,
+  disabled,
+  min,
+  max,
+  step,
+  onChange,
+}: ControlProps<number | undefined> & {
+  min?: number;
+  max?: number;
+  step?: number;
+}) => {
+  const ref = React.useRef<HTMLInputElement>(null);
+  const [draft, setDraft] = useFieldDraft(
+    value === undefined ? '' : String(value),
+    ref,
+  );
+
+  return (
+    <TextInput
+      disabled={disabled}
+      id={id}
+      max={max}
+      min={min}
+      onChange={(event) => {
+        const text = event.currentTarget.value;
+        setDraft(text);
+        const parsed = Number(text);
+        if (text.trim() !== '' && Number.isFinite(parsed)) {
+          onChange(parsed);
+        }
+      }}
+      ref={ref}
+      step={step}
+      type="number"
+      value={draft}
+    />
+  );
+};
+
+const isParseableJson = (text: string) => {
+  try {
+    JSON.parse(text);
+    return true;
+  } catch (_exception) {
+    return false;
+  }
+};
+
+const JsonControl = ({
+  id,
+  value,
+  disabled,
+  onChange,
+}: ControlProps<unknown>) => {
+  const ref = React.useRef<HTMLTextAreaElement>(null);
+  const [draft, setDraft] = useFieldDraft(
+    JSON.stringify(value ?? null, null, 2),
+    ref,
+  );
+  const invalid = !isParseableJson(draft);
+
+  return (
+    <JsonEditor
+      aria-invalid={invalid}
+      className={cn(
+        'min-h-20',
+        invalid && 'border-red-9 focus-within:border-red-9',
+      )}
+      disabled={disabled}
+      id={id}
+      onChange={(text) => {
+        setDraft(text);
+        try {
+          onChange(JSON.parse(text) as unknown);
+        } catch (_exception) {
+          // Half-typed JSON stays local until it parses again.
+        }
+      }}
+      textareaRef={ref}
+      value={draft}
+    />
+  );
+};

--- a/packages/ui/src/components/preview-props-editor.tsx
+++ b/packages/ui/src/components/preview-props-editor.tsx
@@ -1,11 +1,23 @@
 'use client';
 
+import * as Tabs from '@radix-ui/react-tabs';
+import { motion } from 'framer-motion';
 import * as React from 'react';
-import { useDebouncedCallback } from 'use-debounce';
 import { isBuilding } from '../app/env';
 import { usePreviewContext } from '../contexts/preview';
+import { useCachedWorkspaceState } from '../hooks/use-cached-workspace-state';
+import { usePreviewPropsCommit } from '../hooks/use-preview-props-commit';
 import { cn } from '../utils';
+import { tabTransition } from '../utils/constants';
 import { JsonEditor } from './json-editor';
+import { PreviewPropsControls } from './preview-props-controls';
+
+type PropsEditorMode = 'controls' | 'json';
+
+const editorModes: { value: PropsEditorMode; label: string }[] = [
+  { value: 'controls', label: 'Controls' },
+  { value: 'json', label: 'JSON' },
+];
 
 export const PreviewPropsEditor = () => {
   const {
@@ -14,56 +26,90 @@ export const PreviewPropsEditor = () => {
     setPreviewPropsOverride,
   } = usePreviewContext();
 
-  const renderedPropsJson = JSON.stringify(
-    renderedEmailMetadata?.previewProps ?? {},
-    null,
-    2,
+  const [cachedMode, setCachedMode] =
+    useCachedWorkspaceState<PropsEditorMode>('props-panel-mode');
+  const [mode, setMode] = React.useState<PropsEditorMode>(
+    cachedMode === 'json' ? 'json' : 'controls',
   );
+
+  const appliedProps =
+    previewPropsOverride ?? renderedEmailMetadata?.previewProps ?? {};
+
+  const renderedPropsJson = JSON.stringify(appliedProps, null, 2);
 
   // The applied override is the source of truth for what renders; the draft
   // only preserves the user's raw text, which can be momentarily invalid
   // JSON or formatted differently than the applied value.
   const [draft, setDraft] = React.useState<string | undefined>(undefined);
-  const [parseError, setParseError] = React.useState<string | undefined>(
-    undefined,
-  );
 
   const hasOverride = previewPropsOverride !== undefined;
 
-  // Applying is debounced because every applied value costs a server render:
-  // per-keystroke applies queue up behind each other and permanently cache
-  // every intermediate state.
-  const applyValue = useDebouncedCallback((newValue: string) => {
-    try {
-      const parsed = JSON.parse(newValue) as unknown;
-      if (
-        parsed === null ||
-        typeof parsed !== 'object' ||
-        Array.isArray(parsed)
-      ) {
-        setParseError('Props must be a JSON object');
-        return;
-      }
-      setParseError(undefined);
-      setPreviewPropsOverride(parsed as Record<string, unknown>);
-    } catch (exception) {
-      setParseError((exception as Error).message);
-    }
-  }, 400);
+  const { parseError, commitProp, commitJson, flushJson, reset } =
+    usePreviewPropsCommit({
+      appliedProps,
+      applyOverride: setPreviewPropsOverride,
+    });
 
-  const handleChange = (newValue: string) => {
+  const handleJsonChange = (newValue: string) => {
     setDraft(newValue);
-    applyValue(newValue);
+    commitJson(newValue);
+  };
+
+  const handleChangeProp = (key: string, value: unknown) => {
+    // A leftover JSON draft would mask this edit on the JSON tab.
+    setDraft(undefined);
+    commitProp(key, value);
+  };
+
+  const handleReset = () => {
+    setDraft(undefined);
+    reset();
+  };
+
+  const handleModeChange = (newMode: PropsEditorMode) => {
+    setMode(newMode);
+    setCachedMode(newMode);
+    flushJson();
+    setDraft(undefined);
   };
 
   return (
-    <div className="flex h-full flex-col gap-3">
+    <Tabs.Root
+      className="flex h-full flex-col gap-3"
+      onValueChange={(value) => {
+        handleModeChange(value as PropsEditorMode);
+      }}
+      value={mode}
+    >
       <div className="flex items-center justify-between gap-3">
-        {isBuilding ? (
-          <p className="text-slate-11">
-            Read-only. This preview was rendered at build time.
-          </p>
-        ) : (
+        <Tabs.List
+          aria-label="Props editing mode"
+          className="flex overflow-hidden rounded-md border border-slate-6 bg-slate-2"
+        >
+          {editorModes.map(({ value, label }) => (
+            <Tabs.Trigger
+              className={cn(
+                'relative px-2 py-1 transition ease-in-out duration-200 hover:text-slate-12',
+                mode === value ? 'text-slate-12' : 'text-slate-11',
+              )}
+              key={value}
+              value={value}
+            >
+              {mode === value ? (
+                <motion.span
+                  animate={{ opacity: 1 }}
+                  className="absolute inset-0 bg-slate-4"
+                  exit={{ opacity: 0 }}
+                  initial={{ opacity: 0 }}
+                  layoutId="props-editor-active-mode"
+                  transition={tabTransition}
+                />
+              ) : null}
+              <span className="relative">{label}</span>
+            </Tabs.Trigger>
+          ))}
+        </Tabs.List>
+        {isBuilding ? null : (
           <button
             className={cn(
               'ml-auto shrink-0 rounded-md border border-slate-6 px-2 py-1 text-slate-11 transition-colors',
@@ -71,31 +117,42 @@ export const PreviewPropsEditor = () => {
               'disabled:opacity-40 disabled:hover:border-slate-6 disabled:hover:text-slate-11',
             )}
             disabled={!hasOverride && draft === undefined}
-            onClick={() => {
-              applyValue.cancel();
-              setDraft(undefined);
-              setParseError(undefined);
-              setPreviewPropsOverride(undefined);
-            }}
+            onClick={handleReset}
             type="button"
           >
             Reset to defaults
           </button>
         )}
       </div>
-      <JsonEditor
-        aria-invalid={parseError !== undefined}
-        aria-label="Preview props JSON"
-        className={cn(
-          parseError !== undefined && 'border-red-9 focus-within:border-red-9',
-        )}
-        disabled={isBuilding}
-        onChange={handleChange}
-        value={draft ?? renderedPropsJson}
-      />
-      {parseError !== undefined ? (
-        <p className="pb-3 text-red-11">{parseError}</p>
+      {isBuilding ? (
+        <p className="text-slate-11">
+          Read-only. This preview was rendered at build time.
+        </p>
       ) : null}
-    </div>
+      <Tabs.Content value="controls">
+        <PreviewPropsControls
+          declaredControls={renderedEmailMetadata?.previewControls}
+          disabled={isBuilding}
+          onChangeProp={handleChangeProp}
+          previewProps={appliedProps}
+        />
+      </Tabs.Content>
+      <Tabs.Content value="json">
+        <JsonEditor
+          aria-invalid={parseError !== undefined}
+          aria-label="Preview props JSON"
+          className={cn(
+            parseError !== undefined &&
+              'border-red-9 focus-within:border-red-9',
+          )}
+          disabled={isBuilding}
+          onChange={handleJsonChange}
+          value={draft ?? renderedPropsJson}
+        />
+        {parseError !== undefined ? (
+          <p className="pb-3 text-red-11">{parseError}</p>
+        ) : null}
+      </Tabs.Content>
+    </Tabs.Root>
   );
 };

--- a/packages/ui/src/components/send.tsx
+++ b/packages/ui/src/components/send.tsx
@@ -3,6 +3,7 @@ import { useId, useState } from 'react';
 import { toast } from 'sonner';
 import { useCachedWorkspaceState } from '../hooks/use-cached-workspace-state';
 import { Button } from './button';
+import { FieldLabel, TextInput } from './field';
 import { Text } from './text';
 
 interface SendProps {
@@ -95,15 +96,12 @@ export const Send = ({ markup, defaultSubject, storageKey }: SendProps) => {
           sideOffset={48}
         >
           <form className="mt-1" onSubmit={(e) => void onFormSubmit(e)}>
-            <label
-              className="mb-2 block text-xs uppercase text-slate-10"
-              htmlFor={toId}
-            >
+            <FieldLabel className="mb-2" htmlFor={toId}>
               Recipient
-            </label>
-            <input
+            </FieldLabel>
+            <TextInput
               autoFocus
-              className="mb-3 w-full appearance-none rounded-lg border border-slate-6 bg-slate-3 px-2 py-1 text-sm text-slate-12 placeholder-slate-10 outline-hidden transition duration-300 ease-in-out focus:ring-1 focus:ring-slate-10"
+              className="mb-3"
               value={to}
               id={toId}
               onChange={(e) => {
@@ -119,14 +117,11 @@ export const Send = ({ markup, defaultSubject, storageKey }: SendProps) => {
               required
               type="email"
             />
-            <label
-              className="mb-2 mt-1 block text-xs uppercase text-slate-10"
-              htmlFor={subjectId}
-            >
+            <FieldLabel className="mb-2 mt-1" htmlFor={subjectId}>
               Subject
-            </label>
-            <input
-              className="mb-3 w-full appearance-none rounded-lg border border-slate-6 bg-slate-3 px-2 py-1 text-sm text-slate-12 placeholder-slate-10 outline-hidden transition duration-300 ease-in-out focus:ring-1 focus:ring-slate-10"
+            </FieldLabel>
+            <TextInput
+              className="mb-3"
               value={subject}
               id={subjectId}
               onChange={(e) => {
@@ -146,10 +141,6 @@ export const Send = ({ markup, defaultSubject, storageKey }: SendProps) => {
               placeholder="My Email"
               required
               type="text"
-            />
-            <input
-              className="appearance-none checked:bg-blue-500"
-              type="checkbox"
             />
             <div className="mt-3 flex items-center justify-between">
               <div className="inline-flex flex-col">

--- a/packages/ui/src/hooks/use-preview-props-commit.ts
+++ b/packages/ui/src/hooks/use-preview-props-commit.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
+import { parsePreviewPropsJson } from '../utils/parse-preview-props-json';
+import { isErr } from '../utils/result';
+
+// Applying is debounced because every applied value costs a server render:
+// per-keystroke applies queue up behind each other and permanently cache
+// every intermediate state.
+const APPLY_DEBOUNCE_MS = 400;
+
+interface UsePreviewPropsCommitOptions {
+  /** The props the preview is currently rendered with. */
+  appliedProps: Record<string, unknown>;
+  /** Applies a new override, or clears it when passed `undefined`. */
+  applyOverride: (props: Record<string, unknown> | undefined) => void;
+}
+
+/**
+ * Owns how props-panel edits become a preview-props override. Both editing
+ * surfaces feed the same debounced apply: `commitProp` merges single-key
+ * edits into one pending object so edits within a debounce window don't drop
+ * each other, and `commitJson` debounces parsing a raw JSON draft so
+ * half-typed JSON doesn't flash errors on every keystroke.
+ */
+export const usePreviewPropsCommit = ({
+  appliedProps,
+  applyOverride,
+}: UsePreviewPropsCommitOptions) => {
+  const [parseError, setParseError] = useState<string | undefined>(undefined);
+
+  const pendingProps = useRef<Record<string, unknown> | undefined>(undefined);
+
+  const apply = useDebouncedCallback((props: Record<string, unknown>) => {
+    applyOverride(props);
+  }, APPLY_DEBOUNCE_MS);
+
+  const commitProp = (key: string, value: unknown) => {
+    pendingProps.current = {
+      ...(pendingProps.current ?? appliedProps),
+      [key]: value,
+    };
+    setParseError(undefined);
+    apply(pendingProps.current);
+    // Discrete edits (e.g. toggling a switch) should not lag behind the
+    // typing debounce.
+    if (typeof value === 'boolean') {
+      apply.flush();
+    }
+  };
+
+  const commitJson = useDebouncedCallback((text: string) => {
+    const result = parsePreviewPropsJson(text);
+    if (isErr(result)) {
+      setParseError(result.error);
+      return;
+    }
+    setParseError(undefined);
+    pendingProps.current = undefined;
+    // Routing through `apply` supersedes any pending single-key apply, so an
+    // older controls edit can't fire afterwards and clobber this one.
+    apply(result.value);
+    apply.flush();
+  }, APPLY_DEBOUNCE_MS);
+
+  /**
+   * Settles a pending JSON draft right away: a valid draft applies now, an
+   * invalid one is abandoned together with its parse error.
+   */
+  const flushJson = () => {
+    commitJson.flush();
+    setParseError(undefined);
+  };
+
+  const reset = () => {
+    apply.cancel();
+    commitJson.cancel();
+    pendingProps.current = undefined;
+    setParseError(undefined);
+    applyOverride(undefined);
+  };
+
+  return { parseError, commitProp, commitJson, flushJson, reset };
+};

--- a/packages/ui/src/utils/humanize-identifier.spec.ts
+++ b/packages/ui/src/utils/humanize-identifier.spec.ts
@@ -1,0 +1,35 @@
+import { humanizeIdentifier } from './humanize-identifier';
+
+describe('humanizeIdentifier()', () => {
+  it('converts camelCase', () => {
+    expect(humanizeIdentifier('inviterName')).toBe('Inviter Name');
+    expect(humanizeIdentifier('itemCount')).toBe('Item Count');
+  });
+
+  it('converts PascalCase', () => {
+    expect(humanizeIdentifier('VerifyPassword')).toBe('Verify Password');
+  });
+
+  it('converts kebab-case and snake_case', () => {
+    expect(humanizeIdentifier('verify-password')).toBe('Verify Password');
+    expect(humanizeIdentifier('verify_password')).toBe('Verify Password');
+  });
+
+  it('capitalizes single words', () => {
+    expect(humanizeIdentifier('username')).toBe('Username');
+  });
+
+  it('preserves acronyms', () => {
+    expect(humanizeIdentifier('APIKey')).toBe('API Key');
+    expect(humanizeIdentifier('userURL')).toBe('User URL');
+    expect(humanizeIdentifier('OAuthToken')).toBe('OAuth Token');
+  });
+
+  it('handles digits within identifiers', () => {
+    expect(humanizeIdentifier('address2Line')).toBe('Address2 Line');
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(humanizeIdentifier('')).toBe('');
+  });
+});

--- a/packages/ui/src/utils/humanize-identifier.ts
+++ b/packages/ui/src/utils/humanize-identifier.ts
@@ -1,0 +1,44 @@
+/**
+ * Converts a code identifier into a human-readable title.
+ *
+ * Handles the most common naming conventions React users reach for:
+ * kebab-case, snake_case, camelCase, and PascalCase. Acronyms (sequences
+ * of consecutive uppercase letters) are preserved as a single word.
+ *
+ * @example
+ *   humanizeIdentifier('inviterName')     // 'Inviter Name'
+ *   humanizeIdentifier('verify_password') // 'Verify Password'
+ *   humanizeIdentifier('APIKey')          // 'API Key'
+ */
+export function humanizeIdentifier(identifier: string): string {
+  const withSeparatorsAsSpaces = identifier.replace(/[-_.]+/g, ' ');
+
+  // Split camelCase/PascalCase boundaries. The first rule covers the
+  // common lowercase/digit -> uppercase transition (e.g. `verifyPassword`).
+  // The second rule preserves acronyms but separates the trailing word
+  // (e.g. `APIKey` -> `API Key`, `MFAEmail` -> `MFA Email`). It requires
+  // at least two leading capitals so PascalCase tokens that happen to
+  // start with two capitals followed by a lowercase letter — like `OAuth`
+  // — aren't mis-split into `O Auth`.
+  const withWordBoundaries = withSeparatorsAsSpaces
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]{2,})([A-Z][a-z])/g, '$1 $2');
+
+  const normalized = withWordBoundaries.replace(/\s+/g, ' ').trim();
+
+  if (normalized.length === 0) {
+    return '';
+  }
+
+  return normalized
+    .split(' ')
+    .map((word) => {
+      // Preserve acronyms (all uppercase, >1 char) so things like `API` stay
+      // intact instead of becoming `Api`.
+      if (word.length > 1 && word === word.toUpperCase()) {
+        return word;
+      }
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(' ');
+}

--- a/packages/ui/src/utils/infer-email-title.ts
+++ b/packages/ui/src/utils/infer-email-title.ts
@@ -1,11 +1,8 @@
 import { removeFilenameExtension } from './contains-email-template';
+import { humanizeIdentifier } from './humanize-identifier';
 
 /**
  * Infers a human-readable title from an email template filename.
- *
- * Handles the most common naming conventions React users reach for:
- * kebab-case, snake_case, camelCase, and PascalCase. Acronyms (sequences
- * of consecutive uppercase letters) are preserved as a single word.
  *
  * @example
  *   inferEmailTitle('verify-password.tsx')      // 'Verify Password'
@@ -16,36 +13,5 @@ import { removeFilenameExtension } from './contains-email-template';
  *   inferEmailTitle('MFAEmail.tsx')             // 'MFA Email'
  */
 export function inferEmailTitle(filename: string): string {
-  const nameWithoutExtension = removeFilenameExtension(filename);
-
-  const withSeparatorsAsSpaces = nameWithoutExtension.replace(/[-_.]+/g, ' ');
-
-  // Split camelCase/PascalCase boundaries. The first rule covers the
-  // common lowercase/digit -> uppercase transition (e.g. `verifyPassword`).
-  // The second rule preserves acronyms but separates the trailing word
-  // (e.g. `APIKey` -> `API Key`, `MFAEmail` -> `MFA Email`). It requires
-  // at least two leading capitals so PascalCase tokens that happen to
-  // start with two capitals followed by a lowercase letter — like `OAuth`
-  // — aren't mis-split into `O Auth`.
-  const withWordBoundaries = withSeparatorsAsSpaces
-    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
-    .replace(/([A-Z]{2,})([A-Z][a-z])/g, '$1 $2');
-
-  const normalized = withWordBoundaries.replace(/\s+/g, ' ').trim();
-
-  if (normalized.length === 0) {
-    return '';
-  }
-
-  return normalized
-    .split(' ')
-    .map((word) => {
-      // Preserve acronyms (all uppercase, >1 char) so things like `API` stay
-      // intact instead of becoming `Api`.
-      if (word.length > 1 && word === word.toUpperCase()) {
-        return word;
-      }
-      return word.charAt(0).toUpperCase() + word.slice(1);
-    })
-    .join(' ');
+  return humanizeIdentifier(removeFilenameExtension(filename));
 }

--- a/packages/ui/src/utils/parse-preview-props-json.spec.ts
+++ b/packages/ui/src/utils/parse-preview-props-json.spec.ts
@@ -1,0 +1,29 @@
+import { parsePreviewPropsJson } from './parse-preview-props-json';
+
+describe('parsePreviewPropsJson()', () => {
+  it('parses a JSON object', () => {
+    expect(
+      parsePreviewPropsJson('{ "userName": "alan", "itemCount": 3 }'),
+    ).toEqual({
+      value: { userName: 'alan', itemCount: 3 },
+    });
+  });
+
+  it('parses an empty object', () => {
+    expect(parsePreviewPropsJson('{}')).toEqual({ value: {} });
+  });
+
+  it('rejects valid JSON that is not an object', () => {
+    for (const text of ['[1, 2]', 'null', '3', '"props"', 'true']) {
+      expect(parsePreviewPropsJson(text)).toEqual({
+        error: 'Props must be a JSON object',
+      });
+    }
+  });
+
+  it('returns the syntax error message for malformed JSON', () => {
+    const result = parsePreviewPropsJson('{ "userName": ');
+    expect(result).toHaveProperty('error');
+    expect((result as { error: string }).error).not.toHaveLength(0);
+  });
+});

--- a/packages/ui/src/utils/parse-preview-props-json.ts
+++ b/packages/ui/src/utils/parse-preview-props-json.ts
@@ -1,0 +1,23 @@
+import { err, ok, type Result } from './result';
+
+/**
+ * Parses a props-panel JSON draft into a props object, rejecting JSON that is
+ * valid but not usable as React props (arrays, primitives, `null`). The error
+ * is the human-readable message shown next to the editor.
+ */
+export const parsePreviewPropsJson = (
+  text: string,
+): Result<Record<string, unknown>, string> => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (exception) {
+    return err((exception as Error).message);
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return err('Props must be a JSON object');
+  }
+
+  return ok(parsed as Record<string, unknown>);
+};

--- a/packages/ui/src/utils/preview-controls/declared-preview-controls.spec.ts
+++ b/packages/ui/src/utils/preview-controls/declared-preview-controls.spec.ts
@@ -1,0 +1,55 @@
+import { validatePreviewControlsDeclaration } from './declared-preview-controls';
+
+describe('validatePreviewControlsDeclaration()', () => {
+  it('accepts a missing declaration', () => {
+    expect(validatePreviewControlsDeclaration(undefined)).toEqual({
+      value: undefined,
+    });
+  });
+
+  it('accepts a declaration using every control type', () => {
+    const declaration = {
+      username: { type: 'text', label: 'Username' },
+      teamSize: { type: 'number', min: 1, max: 500, step: 1 },
+      isTrial: { type: 'boolean' },
+      plan: { type: 'select', options: ['hobby', 'pro', 'enterprise'] },
+      metadata: { type: 'json' },
+    };
+
+    expect(validatePreviewControlsDeclaration(declaration)).toEqual({
+      value: declaration,
+    });
+  });
+
+  it('rejects unknown control types', () => {
+    expect(
+      validatePreviewControlsDeclaration({
+        username: { type: 'color' },
+      }),
+    ).toHaveProperty('error');
+  });
+
+  it('rejects typo`d fields instead of silently ignoring them', () => {
+    expect(
+      validatePreviewControlsDeclaration({
+        username: { type: 'text', lable: 'Username' },
+      }),
+    ).toHaveProperty('error');
+  });
+
+  it('rejects a select without options', () => {
+    expect(
+      validatePreviewControlsDeclaration({
+        plan: { type: 'select', options: [] },
+      }),
+    ).toHaveProperty('error');
+  });
+
+  it('rejects non-object declarations', () => {
+    expect(validatePreviewControlsDeclaration('text')).toHaveProperty('error');
+    expect(validatePreviewControlsDeclaration(null)).toHaveProperty('error');
+    expect(validatePreviewControlsDeclaration(['text'])).toHaveProperty(
+      'error',
+    );
+  });
+});

--- a/packages/ui/src/utils/preview-controls/declared-preview-controls.ts
+++ b/packages/ui/src/utils/preview-controls/declared-preview-controls.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod';
+import { err, ok, type Result } from '../result';
+
+// The vocabulary of controls a template can declare for its preview props
+// through a static `PreviewControls` property, mirroring how `PreviewProps`
+// is declared:
+//
+//   MyEmail.PreviewControls = {
+//     username: { type: 'text', label: 'Username' },
+//     plan: { type: 'select', options: ['hobby', 'pro', 'enterprise'] },
+//     teamSize: { type: 'number', min: 1, max: 500 },
+//   };
+//
+// Objects are strict so a typo'd field fails validation loudly instead of
+// being silently ignored.
+const declaredPreviewControlSchema = z.discriminatedUnion('type', [
+  z.strictObject({
+    type: z.literal('text'),
+    label: z.string().optional(),
+  }),
+  z.strictObject({
+    type: z.literal('number'),
+    label: z.string().optional(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+    step: z.number().positive().optional(),
+  }),
+  z.strictObject({
+    type: z.literal('boolean'),
+    label: z.string().optional(),
+  }),
+  z.strictObject({
+    type: z.literal('select'),
+    label: z.string().optional(),
+    options: z.array(z.union([z.string(), z.number()])).min(1),
+  }),
+  z.strictObject({
+    type: z.literal('json'),
+    label: z.string().optional(),
+  }),
+]);
+
+const declaredPreviewControlsSchema = z.record(
+  z.string(),
+  declaredPreviewControlSchema,
+);
+
+export type DeclaredPreviewControl = z.infer<
+  typeof declaredPreviewControlSchema
+>;
+
+export type DeclaredPreviewControls = z.infer<
+  typeof declaredPreviewControlsSchema
+>;
+
+/**
+ * Validates a template's `PreviewControls` export. A missing declaration is
+ * fine (`ok(undefined)` — every control falls back to inference); an invalid
+ * one errors with a human-readable message so the whole declaration can be
+ * rejected predictably rather than partially applied.
+ */
+export const validatePreviewControlsDeclaration = (
+  declaration: unknown,
+): Result<DeclaredPreviewControls | undefined, string> => {
+  if (declaration === undefined) {
+    return ok(undefined);
+  }
+
+  const parsed = declaredPreviewControlsSchema.safeParse(declaration);
+  if (!parsed.success) {
+    return err(z.prettifyError(parsed.error));
+  }
+
+  return ok(parsed.data);
+};

--- a/packages/ui/src/utils/preview-controls/resolve-preview-controls.spec.ts
+++ b/packages/ui/src/utils/preview-controls/resolve-preview-controls.spec.ts
@@ -1,0 +1,93 @@
+import { resolvePreviewControls } from './resolve-preview-controls';
+
+describe('resolvePreviewControls()', () => {
+  it('returns no controls for empty props and no declaration', () => {
+    expect(resolvePreviewControls({}, undefined)).toEqual([]);
+  });
+
+  it('infers controls from prop values when nothing is declared', () => {
+    expect(
+      resolvePreviewControls(
+        {
+          userName: 'alan',
+          isVip: false,
+          itemCount: 3,
+          items: [1, 2],
+          user: null,
+          ratio: Number.POSITIVE_INFINITY,
+        },
+        undefined,
+      ),
+    ).toEqual([
+      { key: 'userName', label: 'User Name', type: 'text' },
+      { key: 'isVip', label: 'Is Vip', type: 'boolean' },
+      { key: 'itemCount', label: 'Item Count', type: 'number' },
+      { key: 'items', label: 'Items', type: 'json' },
+      { key: 'user', label: 'User', type: 'json' },
+      { key: 'ratio', label: 'Ratio', type: 'json' },
+    ]);
+  });
+
+  it('puts declared controls first, in declaration order', () => {
+    const controls = resolvePreviewControls(
+      { userName: 'alan', plan: 'pro', isVip: true },
+      {
+        plan: { type: 'select', options: ['hobby', 'pro'] },
+        userName: { type: 'text' },
+      },
+    );
+
+    expect(controls.map((control) => control.key)).toEqual([
+      'plan',
+      'userName',
+      'isVip',
+    ]);
+  });
+
+  it('keeps declared fields like options and number bounds', () => {
+    expect(
+      resolvePreviewControls(
+        { teamSize: 3 },
+        { teamSize: { type: 'number', min: 1, max: 500, step: 1 } },
+      ),
+    ).toEqual([
+      {
+        key: 'teamSize',
+        label: 'Team Size',
+        type: 'number',
+        min: 1,
+        max: 500,
+        step: 1,
+      },
+    ]);
+  });
+
+  it('prefers a declared label and humanizes the key otherwise', () => {
+    expect(
+      resolvePreviewControls(
+        { userName: 'alan', inviterName: 'ada' },
+        { userName: { type: 'text', label: 'Customer' } },
+      ),
+    ).toEqual([
+      { key: 'userName', label: 'Customer', type: 'text' },
+      { key: 'inviterName', label: 'Inviter Name', type: 'text' },
+    ]);
+  });
+
+  it('resolves declared controls even when the prop has no value', () => {
+    expect(resolvePreviewControls({}, { promoCode: { type: 'text' } })).toEqual(
+      [{ key: 'promoCode', label: 'Promo Code', type: 'text' }],
+    );
+  });
+
+  it('lets a declaration override what a value would have inferred', () => {
+    expect(
+      resolvePreviewControls(
+        { plan: 'pro' },
+        { plan: { type: 'select', options: ['hobby', 'pro'] } },
+      ),
+    ).toEqual([
+      { key: 'plan', label: 'Plan', type: 'select', options: ['hobby', 'pro'] },
+    ]);
+  });
+});

--- a/packages/ui/src/utils/preview-controls/resolve-preview-controls.ts
+++ b/packages/ui/src/utils/preview-controls/resolve-preview-controls.ts
@@ -1,0 +1,67 @@
+import { humanizeIdentifier } from '../humanize-identifier';
+import type {
+  DeclaredPreviewControl,
+  DeclaredPreviewControls,
+} from './declared-preview-controls';
+
+/**
+ * A fully resolved control the props panel renders: a declared control (or
+ * one inferred from a prop's value) with its key and final label attached.
+ */
+export type ControlDescriptor = DeclaredPreviewControl & {
+  key: string;
+  label: string;
+};
+
+/**
+ * Maps a prop value to the control its type implies: booleans become
+ * switches, finite numbers become number inputs, strings become text inputs,
+ * and anything else (objects, arrays, null) falls back to a raw JSON field.
+ */
+const inferControl = (value: unknown): DeclaredPreviewControl => {
+  if (typeof value === 'boolean') {
+    return { type: 'boolean' };
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return { type: 'number' };
+  }
+  if (typeof value === 'string') {
+    return { type: 'text' };
+  }
+  return { type: 'json' };
+};
+
+/**
+ * Resolves the controls to render for a set of preview props. Declared
+ * controls come first, in declaration order, so the template author decides
+ * the layout; props without a declaration get a control inferred from their
+ * current value, appended in prop order. Labels default to a humanized form
+ * of the key.
+ */
+export const resolvePreviewControls = (
+  previewProps: Record<string, unknown>,
+  declaredControls: DeclaredPreviewControls | undefined,
+): ControlDescriptor[] => {
+  const descriptors: ControlDescriptor[] = [];
+
+  for (const [key, control] of Object.entries(declaredControls ?? {})) {
+    descriptors.push({
+      ...control,
+      key,
+      label: control.label ?? humanizeIdentifier(key),
+    });
+  }
+
+  for (const [key, value] of Object.entries(previewProps)) {
+    if (declaredControls !== undefined && key in declaredControls) {
+      continue;
+    }
+    descriptors.push({
+      ...inferControl(value),
+      key,
+      label: humanizeIdentifier(key),
+    });
+  }
+
+  return descriptors;
+};

--- a/packages/ui/src/utils/types/email-template.ts
+++ b/packages/ui/src/utils/types/email-template.ts
@@ -1,6 +1,12 @@
 export interface EmailTemplate {
   (props: Record<string, unknown> | Record<string, never>): React.ReactNode;
   PreviewProps?: Record<string, unknown>;
+  /**
+   * Optional per-prop control metadata for the preview props panel; comes
+   * from user code, so it is `unknown` until validated against the schema in
+   * `utils/preview-controls`.
+   */
+  PreviewControls?: unknown;
 }
 
 export const isEmailTemplate = (val: unknown): val is EmailTemplate => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -871,6 +871,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: 'catalog:'
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-switch':
+        specifier: 1.3.5
+        version: 1.3.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-tabs':
         specifier: 'catalog:'
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2725,6 +2728,9 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/primitive@1.1.7':
+    resolution: {integrity: sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==}
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
@@ -2782,6 +2788,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.4':
+    resolution: {integrity: sha512-pWJo6lQAfR6uy1n7ii7PaCc9dLPwTXDYbQpORZU5B548Aqvl2pP1SM1vJGKyxIFqZMHRopRO4CQYX2iXAIB5jA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: 19.2.4
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context@1.1.1':
     resolution: {integrity: sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==}
     peerDependencies:
@@ -2793,6 +2808,15 @@ packages:
 
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: 19.2.4
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.2.1':
+    resolution: {integrity: sha512-EraVbFjiIjibpLr6EjvEDmSCYJU2SlKDMiO+qEK/D9GOWnQoAQlpQo2occGYC1UM9MBeEx5Bek3UtW/Qi57vAg==}
     peerDependencies:
       '@types/react': '*'
       react: 19.2.4
@@ -3040,6 +3064,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.8':
+    resolution: {integrity: sha512-DOlK1BdcIeYYUcFkSYFka4v1h95XTov93b0jCgW1EEiZuIhdwHY2NlE1teLIh+p0uBsuZI5A+voay+iVWpprfA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: 19.2.4
+      react-dom: 19.2.4
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
@@ -3091,6 +3128,28 @@ packages:
       react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.3.1':
+    resolution: {integrity: sha512-Bu/aAQHFFh6/QAvXAeUMurJ9fbW0JUIqlojU/yBXZ7cAVqy75Y7JYYyuCr9zLNF0p4WWoJYV54CTUIf4l7FzTw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: 19.2.4
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.3.5':
+    resolution: {integrity: sha512-e1YrvGvEjIqDhqKjQ4Q+IDkMfiY30u3FPz9CZXZMlQ8mU3kZ2PdeBM8Gssc48CDopPizNorKumGhjySBfO7BDQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: 19.2.4
+      react-dom: 19.2.4
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-tabs@1.1.13':
@@ -3181,8 +3240,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-controllable-state@1.2.5':
+    resolution: {integrity: sha512-UB1dXpxvHjR48poyKdKdTm7jT0kp3elkUKdKQiOkirlbYumqXinSJtrjDsr9maXNPvL12bKI4CDSmydms/9Aeg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: 19.2.4
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-effect-event@0.0.2':
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: 19.2.4
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.4':
+    resolution: {integrity: sha512-XYcfa6wlXDCwQtePuEiPmXLSAhGL4DWtedSyRgGbG3y10mw+OnrLp6SyeY1gJFMiYF0Dx0nMAX9InylKbLEFQQ==}
     peerDependencies:
       '@types/react': '*'
       react: 19.2.4
@@ -3226,6 +3303,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-layout-effect@1.1.3':
+    resolution: {integrity: sha512-rDiah9wvtqihWtWz02XreeRKIxt2EJF8y5D9rtY9l5A2zxePAtcPiOMpDugNRw5bFHz+1/8viVoc7ZVKiJknCw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: 19.2.4
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-previous@1.1.1':
     resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
     peerDependencies:
@@ -3246,6 +3332,15 @@ packages:
 
   '@radix-ui/react-use-size@1.1.1':
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: 19.2.4
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.3':
+    resolution: {integrity: sha512-jJq6tQQLvO/z4uWbztjwPV+1a/+H4rCaWypasLB/ac8DEdd6+p7dIm7o3F6P2KZPGkPMqD4s5424EdAdoU+GLA==}
     peerDependencies:
       '@types/react': '*'
       react: 19.2.4
@@ -11129,6 +11224,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/primitive@1.1.7': {}
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -11178,6 +11275,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-compose-refs@1.1.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-context@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
@@ -11185,6 +11288,12 @@ snapshots:
       '@types/react': 19.2.14
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.2.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:
@@ -11432,6 +11541,15 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-primitive@2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -11498,6 +11616,28 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-slot@1.3.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-switch@1.3.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11588,9 +11728,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-controllable-state@1.2.5(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-use-effect-event': 0.0.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -11621,6 +11777,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-layout-effect@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
@@ -11637,6 +11799,13 @@ snapshots:
   '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14


### PR DESCRIPTION
## Summary

The preview props panel gains a **Controls** tab alongside the raw JSON editor: per-prop form controls for editing a template's preview props without hand-writing JSON.

Templates can declare how each prop should be edited through a static `PreviewControls` property, mirroring how `PreviewProps` is already declared (inspired by Storybook's argTypes):

```tsx
MyEmail.PreviewProps = {
  username: 'alanturing',
  plan: 'pro',
  teamSize: 3,
  isTrial: false,
};

MyEmail.PreviewControls = {
  username: { type: 'text', label: 'Username' },
  plan: { type: 'select', options: ['hobby', 'pro', 'enterprise'] },
  teamSize: { type: 'number', min: 1, max: 500 },
};
```

Props without a declared control get one inferred from their value (boolean → switch, finite number → number input, string → text input, everything else → raw JSON field), so existing templates get working controls with zero configuration.



https://github.com/user-attachments/assets/f8378cdb-a742-4ef4-9922-823313b80a20




## How it works

- The control vocabulary (`text`, `number` with min/max/step, `boolean`, `select`, `json`) lives in one module, `packages/ui/src/utils/preview-controls/`: a zod schema validates the declaration and a pure resolver merges it with inference.
- Validation happens server-side when the template renders; an invalid declaration logs a warning in the terminal and the panel falls back to inference — a typo never breaks the preview. Objects are strict, so misspelled fields fail loudly.
- The validated declaration travels to the client in the rendering metadata and resolves against the applied props, so controls stay in sync with edits and hot reload picks up declaration changes.
- Declared controls render first, in declaration order; labels default to a humanized form of the prop key (`inviterName` → “Inviter Name”).
- Edits from the controls merge into a single debounced props override (booleans apply immediately); the JSON tab remains the escape hatch for values no control can express, and Reset returns to the template's defaults.

## Commits

The branch is structured as three preparatory refactors (shared form-field primitives, identifier humanization, JsonEditor labelling/ref API) followed by the feature: the debounced override-commit hook, the declaration schema + resolver, and the panel itself.

## Testing

- Unit specs for the declaration schema, the resolver (declaration order, label defaults, inference fallback), the JSON draft parser, and identifier humanization; `packages/ui` suite passes (129 tests).
- Verified end-to-end against the preview server: declared controls render with custom labels, select options, and number bounds; undeclared props fall back to a switch and a JSON field; `role="switch"` semantics via Radix Switch.
- `biome check` clean; `tsc` clean apart from pre-existing baseline errors in untouched files.