### PR TITLE
fix(editor): keep code blocks intact through an email import round-trip

### DIFF
--- a/.changeset/eighty-donkeys-smile.md
+++ b/.changeset/eighty-donkeys-smile.md
@@ -1,0 +1,5 @@
+---
+'@react-email/editor': patch
+---
+
+Fix code blocks losing their theme, language and styling when an email is imported back into the editor.

--- a/packages/editor/src/extensions/__snapshots__/code-block.spec.tsx.snap
+++ b/packages/editor/src/extensions/__snapshots__/code-block.spec.tsx.snap
@@ -4,6 +4,8 @@ exports[`CodeBlockPrism Node > renders React Email properly 1`] = `
 "<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!--$-->
 <pre
+  data-language="javascript"
+  data-theme="dracula"
   style="color:#f8f8f2;background:#282a36;text-shadow:0 1px rgba(0, 0, 0, 0.3);font-family:monospace;text-align:left;white-space:pre;word-spacing:normal;word-break:normal;word-wrap:normal;line-height:1.5;-moz-tab-size:4;-o-tab-size:4;tab-size:4;-webkit-hyphens:none;-moz-hyphens:none;hyphens:none;padding:0.75rem 1rem;margin:.5em 0;overflow:auto;border-radius:0.125rem;width:auto;font-weight:500;font-size:.92em"><code><span style="color:#8be9fd">const</span><span> ‍​x ‍​</span><span style="color:#f8f8f2">=</span><span> ‍​</span><span style="color:#bd93f9">1</span><span style="color:#f8f8f2">;</span><br/></code></pre>
 <!--/$-->
 "

--- a/packages/editor/src/extensions/code-block.spec.tsx
+++ b/packages/editor/src/extensions/code-block.spec.tsx
@@ -99,20 +99,6 @@ describe('CodeBlockPrism Node', () => {
     expect(node?.content?.[0]?.text).toBe(code);
   });
 
-  it('recovers the code when pasting normalized the encoded spaces', async () => {
-    const code = "function helloWorld() {\n  console.log('Hello, world!');\n}";
-    const html = (
-      await composeCodeBlock({
-        attrs: { language: 'javascript', theme: 'dracula' },
-        code,
-      })
-    ).replaceAll('\u00A0\u200D\u200B', ' \u200D\u200B');
-
-    const node = generateJSON(html, importExtensions).content?.[0];
-
-    expect(node?.content?.[0]?.text).toBe(code);
-  });
-
   it('keeps the resolved styles of a composed email through an import', async () => {
     const style =
       'font-family:monospace;border-radius:4px;font-weight:500;font-size:.92em';

--- a/packages/editor/src/extensions/code-block.spec.tsx
+++ b/packages/editor/src/extensions/code-block.spec.tsx
@@ -1,10 +1,39 @@
+import { generateJSON } from '@tiptap/html';
+import StarterKit from '@tiptap/starter-kit';
 import { dracula, render } from 'react-email';
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_STYLES } from '../utils/default-styles';
 import { CodeBlockPrism } from './code-block';
+import { StyleAttribute } from './style-attribute';
 
 // Resolved style matching snapshot: codeBlock only, no reset (theme provides padding/margin)
 const codeBlockStyle = { ...DEFAULT_STYLES.codeBlock };
+
+const importExtensions: Parameters<typeof generateJSON>[1] = [
+  StarterKit.configure({
+    codeBlock: false,
+  }) as (typeof importExtensions)[number],
+  CodeBlockPrism as (typeof importExtensions)[number],
+  StyleAttribute.configure({ types: ['codeBlock'] }),
+];
+
+async function composeCodeBlock(node: {
+  attrs: { language: string; theme: string; style?: string };
+  code: string;
+}) {
+  const Component = CodeBlockPrism.config.renderToReactEmail;
+  return render(
+    <Component
+      node={{
+        type: 'codeBlock',
+        attrs: node.attrs,
+        content: [{ type: 'text', text: node.code }],
+      }}
+      style={codeBlockStyle}
+      extension={CodeBlockPrism}
+    />,
+  );
+}
 
 describe('CodeBlockPrism Node', () => {
   it('renders React Email properly', async () => {
@@ -52,5 +81,56 @@ describe('CodeBlockPrism Node', () => {
       { pretty: true },
     );
     expect(dracula).toStrictEqual(originalTheme);
+  });
+
+  it('recovers the language, the theme and the code from a composed email', async () => {
+    const code =
+      "function helloWorld() {\n  console.log('Hello, world!');\n}\n\nhelloWorld();";
+    const html = await composeCodeBlock({
+      attrs: { language: 'typescript', theme: 'dracula' },
+      code,
+    });
+
+    const node = generateJSON(html, importExtensions).content?.[0];
+
+    expect(node?.type).toBe('codeBlock');
+    expect(node?.attrs?.language).toBe('typescript');
+    expect(node?.attrs?.theme).toBe('dracula');
+    expect(node?.content?.[0]?.text).toBe(code);
+  });
+
+  it('recovers the code when pasting normalized the encoded spaces', async () => {
+    const code = "function helloWorld() {\n  console.log('Hello, world!');\n}";
+    const html = (
+      await composeCodeBlock({
+        attrs: { language: 'javascript', theme: 'dracula' },
+        code,
+      })
+    ).replaceAll('\u00A0\u200D\u200B', ' \u200D\u200B');
+
+    const node = generateJSON(html, importExtensions).content?.[0];
+
+    expect(node?.content?.[0]?.text).toBe(code);
+  });
+
+  it('keeps the resolved styles of a composed email through an import', async () => {
+    const style =
+      'font-family:monospace;border-radius:4px;font-weight:500;font-size:.92em';
+    const composed = await composeCodeBlock({
+      attrs: { language: 'javascript', theme: 'default', style },
+      code: 'const x = 1;',
+    });
+
+    const node = generateJSON(composed, importExtensions).content?.[0];
+    const recomposed = await composeCodeBlock({
+      attrs: {
+        language: node?.attrs?.language,
+        theme: node?.attrs?.theme,
+        style: node?.attrs?.style,
+      },
+      code: node?.content?.[0]?.text,
+    });
+
+    expect(recomposed).toBe(composed);
   });
 });

--- a/packages/editor/src/extensions/code-block.tsx
+++ b/packages/editor/src/extensions/code-block.tsx
@@ -17,42 +17,9 @@ export interface CodeBlockPrismOptions extends CodeBlockOptions {
   defaultTheme: string;
 }
 
-// The email renderer encodes spaces as NBSP + ZWJ + ZWSP so mail clients keep
-// the indentation. Pasting normalizes the NBSP away, so accept either one.
 const ENCODED_SPACE_REGEX = /[\u00A0 ]\u200D\u200B/g;
 
 const TEXT_NODE = 3;
-
-function readCodeFromElement(element: HTMLElement): string {
-  let code = '';
-  let endsOnLineBreak = false;
-
-  const visit = (node: Node) => {
-    if (node.nodeType === TEXT_NODE) {
-      const text = node.nodeValue ?? '';
-      if (text) {
-        code += text;
-        endsOnLineBreak = false;
-      }
-      return;
-    }
-
-    if (node.nodeName === 'BR') {
-      code += '\n';
-      endsOnLineBreak = true;
-      return;
-    }
-
-    node.childNodes.forEach(visit);
-  };
-  element.childNodes.forEach(visit);
-
-  if (endsOnLineBreak) {
-    code = code.slice(0, -1);
-  }
-
-  return code.replace(ENCODED_SPACE_REGEX, ' ');
-}
 
 export const CodeBlockPrism = EmailNode.from(
   CodeBlock.extend<CodeBlockPrismOptions>({
@@ -115,7 +82,34 @@ export const CodeBlockPrism = EmailNode.from(
           tag: 'pre',
           preserveWhitespace: 'full' as const,
           getContent: (element: Node, schema: Schema) => {
-            const code = readCodeFromElement(element as HTMLElement);
+            let code = '';
+            let endsOnLineBreak = false;
+
+            const visit = (node: Node) => {
+              if (node.nodeType === TEXT_NODE) {
+                const text = node.nodeValue ?? '';
+                if (text) {
+                  code += text;
+                  endsOnLineBreak = false;
+                }
+                return;
+              }
+
+              if (node.nodeName === 'BR') {
+                code += '\n';
+                endsOnLineBreak = true;
+                return;
+              }
+
+              node.childNodes.forEach(visit);
+            };
+            element.childNodes.forEach(visit);
+
+            if (endsOnLineBreak) {
+              code = code.slice(0, -1);
+            }
+            code = code.replace(ENCODED_SPACE_REGEX, ' ');
+
             return code ? Fragment.from(schema.text(code)) : Fragment.empty;
           },
         },
@@ -202,24 +196,24 @@ export const CodeBlockPrism = EmailNode.from(
     // Without theme, render a gray code block
     const theme = userTheme
       ? {
-          ...userTheme,
-          base: {
-            ...userTheme.base,
-            borderRadius: '0.125rem',
-            padding: '0.75rem 1rem',
-          },
-        }
+        ...userTheme,
+        base: {
+          ...userTheme.base,
+          borderRadius: '0.125rem',
+          padding: '0.75rem 1rem',
+        },
+      }
       : {
-          base: {
-            color: '#1e293b',
-            background: '#f1f5f9',
-            lineHeight: '1.5',
-            fontFamily:
-              '"Fira Code", "Fira Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace',
-            padding: '0.75rem 1rem',
-            borderRadius: '0.125rem',
-          },
-        };
+        base: {
+          color: '#1e293b',
+          background: '#f1f5f9',
+          lineHeight: '1.5',
+          fontFamily:
+            '"Fira Code", "Fira Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace',
+          padding: '0.75rem 1rem',
+          borderRadius: '0.125rem',
+        },
+      };
 
     return (
       <ReactEmailCodeBlock

--- a/packages/editor/src/extensions/code-block.tsx
+++ b/packages/editor/src/extensions/code-block.tsx
@@ -1,6 +1,7 @@
 import { mergeAttributes } from '@tiptap/core';
 import type { CodeBlockOptions } from '@tiptap/extension-code-block';
 import CodeBlock from '@tiptap/extension-code-block';
+import { Fragment, type Schema } from '@tiptap/pm/model';
 import { TextSelection } from '@tiptap/pm/state';
 import * as ReactEmailComponents from 'react-email';
 import {
@@ -8,11 +9,49 @@ import {
   CodeBlock as ReactEmailCodeBlock,
 } from 'react-email';
 import { EmailNode } from '../core/serializer/email-node';
+import { inlineCssToJs } from '../utils/styles';
 import { PrismPlugin } from './prism-plugin';
 
 export interface CodeBlockPrismOptions extends CodeBlockOptions {
   defaultLanguage: string;
   defaultTheme: string;
+}
+
+// The email renderer encodes spaces as NBSP + ZWJ + ZWSP so mail clients keep
+// the indentation. Pasting normalizes the NBSP away, so accept either one.
+const ENCODED_SPACE_REGEX = /[\u00A0 ]\u200D\u200B/g;
+
+const TEXT_NODE = 3;
+
+function readCodeFromElement(element: HTMLElement): string {
+  let code = '';
+  let endsOnLineBreak = false;
+
+  const visit = (node: Node) => {
+    if (node.nodeType === TEXT_NODE) {
+      const text = node.nodeValue ?? '';
+      if (text) {
+        code += text;
+        endsOnLineBreak = false;
+      }
+      return;
+    }
+
+    if (node.nodeName === 'BR') {
+      code += '\n';
+      endsOnLineBreak = true;
+      return;
+    }
+
+    node.childNodes.forEach(visit);
+  };
+  element.childNodes.forEach(visit);
+
+  if (endsOnLineBreak) {
+    code = code.slice(0, -1);
+  }
+
+  return code.replace(ENCODED_SPACE_REGEX, ' ');
 }
 
 export const CodeBlockPrism = EmailNode.from(
@@ -54,7 +93,7 @@ export const CodeBlockPrism = EmailNode.from(
             const language = languages[0];
 
             if (!language) {
-              return null;
+              return element.getAttribute('data-language');
             }
 
             return language;
@@ -63,9 +102,24 @@ export const CodeBlockPrism = EmailNode.from(
         },
         theme: {
           default: this.options.defaultTheme,
+          parseHTML: (element: HTMLElement | null) =>
+            element?.getAttribute('data-theme') || null,
           rendered: false,
         },
       };
+    },
+
+    parseHTML() {
+      return [
+        {
+          tag: 'pre',
+          preserveWhitespace: 'full' as const,
+          getContent: (element: Node, schema: Schema) => {
+            const code = readCodeFromElement(element as HTMLElement);
+            return code ? Fragment.from(schema.text(code)) : Fragment.empty;
+          },
+        },
+      ];
     },
 
     renderHTML({ node, HTMLAttributes }) {
@@ -170,11 +224,16 @@ export const CodeBlockPrism = EmailNode.from(
     return (
       <ReactEmailCodeBlock
         code={node.content?.[0]?.text ?? ''}
+        // Neither the language nor the theme is recoverable from the rendered
+        // markup, so mark them for whoever imports this email back.
+        data-language={language}
+        data-theme={node.attrs?.theme}
         language={language as PrismLanguage}
         theme={theme}
         style={{
           width: 'auto',
           ...style,
+          ...inlineCssToJs(node.attrs?.style),
         }}
       />
     );

--- a/packages/editor/src/extensions/code-block.tsx
+++ b/packages/editor/src/extensions/code-block.tsx
@@ -17,9 +17,9 @@ export interface CodeBlockPrismOptions extends CodeBlockOptions {
   defaultTheme: string;
 }
 
-const ENCODED_SPACE_REGEX = /[\u00A0 ]\u200D\u200B/g;
-
-const TEXT_NODE = 3;
+// Inverts the NBSP + ZWJ + ZWSP that react-email's CodeBlock writes for every
+// space so Spark Mail keeps the indentation.
+const ENCODED_SPACE_REGEX = /\u00A0\u200D\u200B/g;
 
 export const CodeBlockPrism = EmailNode.from(
   CodeBlock.extend<CodeBlockPrismOptions>({
@@ -86,7 +86,7 @@ export const CodeBlockPrism = EmailNode.from(
             let endsOnLineBreak = false;
 
             const visit = (node: Node) => {
-              if (node.nodeType === TEXT_NODE) {
+              if (node.nodeType === Node.TEXT_NODE) {
                 const text = node.nodeValue ?? '';
                 if (text) {
                   code += text;
@@ -196,24 +196,24 @@ export const CodeBlockPrism = EmailNode.from(
     // Without theme, render a gray code block
     const theme = userTheme
       ? {
-        ...userTheme,
-        base: {
-          ...userTheme.base,
-          borderRadius: '0.125rem',
-          padding: '0.75rem 1rem',
-        },
-      }
+          ...userTheme,
+          base: {
+            ...userTheme.base,
+            borderRadius: '0.125rem',
+            padding: '0.75rem 1rem',
+          },
+        }
       : {
-        base: {
-          color: '#1e293b',
-          background: '#f1f5f9',
-          lineHeight: '1.5',
-          fontFamily:
-            '"Fira Code", "Fira Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace',
-          padding: '0.75rem 1rem',
-          borderRadius: '0.125rem',
-        },
-      };
+          base: {
+            color: '#1e293b',
+            background: '#f1f5f9',
+            lineHeight: '1.5',
+            fontFamily:
+              '"Fira Code", "Fira Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace',
+            padding: '0.75rem 1rem',
+            borderRadius: '0.125rem',
+          },
+        };
 
     return (
       <ReactEmailCodeBlock


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves code block theme, language, and styles through compose → import in the editor, fixing the round-trip mismatch that shifted layouts. Addresses DEV-1251 and improves `all-elements` import accuracy.

- **Bug Fixes**
  - `@react-email/editor`: emit `data-language` and `data-theme` on `<pre>` and parse them on import to restore attrs.
  - Parse `<pre>` content directly to recover code, remove the trailing blank line, and decode encoded spaces.
  - Apply the node’s resolved inline styles on render and round-trip them via a `style` attr.
  - Added tests for language/theme/code recovery and style stability; updated snapshot and changeset.

<sup>Written for commit 566ca8e7a720c7f94b84172221ff60fd71b187c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

