### PR TITLE
fix(editor): drop body reset spacing

### DIFF
--- a/.changeset/minimal-theme-body-spacing.md
+++ b/.changeset/minimal-theme-body-spacing.md
@@ -2,4 +2,4 @@
 '@react-email/editor': patch
 ---
 
-Make body margin and padding theme-driven instead of hardcoded on the email `<Body>`. The `minimal` theme's body panel now includes a Margin input and defaults its padding inputs to `0`, so body spacing is visible and editable in the inspector and can be overridden per document. The hardcoded `margin: 0; padding: 0` reset was removed from the `basic` theme's body as well: exported HTML no longer zeroes body spacing there, leaving it to the email client unless the document or theme sets it.
+remove body from style reset

--- a/.changeset/minimal-theme-body-spacing.md
+++ b/.changeset/minimal-theme-body-spacing.md
@@ -1,0 +1,5 @@
+---
+'@react-email/editor': patch
+---
+
+Make body margin and padding theme-driven instead of hardcoded on the email `<Body>`. The `minimal` theme's body panel now includes a Margin input and defaults its padding inputs to `0`, so body spacing is visible and editable in the inspector and can be overridden per document. The hardcoded `margin: 0; padding: 0` reset was removed from the `basic` theme's body as well: exported HTML no longer zeroes body spacing there, leaving it to the email client unless the document or theme sets it.

--- a/.changeset/minimal-theme-body-spacing.md
+++ b/.changeset/minimal-theme-body-spacing.md
@@ -2,4 +2,4 @@
 '@react-email/editor': patch
 ---
 
-remove body from style reset
+remove padding and margin reset from body style reset

--- a/packages/editor/src/extensions/container.spec.tsx
+++ b/packages/editor/src/extensions/container.spec.tsx
@@ -276,7 +276,7 @@ describe('Container Node', () => {
             @media (prefers-color-scheme: dark){li::marker{color:#c4c4c4}}
           </style>
         </head>
-        <body dir="ltr" lang="en" style="background-color:#ffffff;margin:0;padding:0">
+        <body dir="ltr" lang="en" style="background-color:#ffffff">
           <!--$--><!--html--><!--head--><!--body-->
           <table
             border="0"
@@ -290,7 +290,7 @@ describe('Container Node', () => {
                 <td
                   dir="ltr"
                   lang="en"
-                  style="margin:0;padding:0;font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:1em;min-height:100%;line-height:155%;background-color:#ffffff">
+                  style="font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:1em;min-height:100%;line-height:155%;background-color:#ffffff">
                   <table
                     align="left"
                     width="100%"
@@ -1389,7 +1389,7 @@ describe('Container Node', () => {
             @media (prefers-color-scheme: dark){li::marker{color:#c4c4c4}}
           </style>
         </head>
-        <body dir="ltr" lang="en" style="margin:0;padding:0">
+        <body dir="ltr" lang="en">
           <!--$--><!--html--><!--head--><!--body-->
           <table
             border="0"
@@ -1403,7 +1403,7 @@ describe('Container Node', () => {
                 <td
                   dir="ltr"
                   lang="en"
-                  style="margin:0;padding:0;font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:14px;min-height:100%;line-height:155%">
+                  style="font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:14px;min-height:100%;line-height:155%">
                   <table
                     align="center"
                     width="100%"
@@ -1507,7 +1507,7 @@ describe('Container Node', () => {
             @media (prefers-color-scheme: dark){li::marker{color:#c4c4c4}}
           </style>
         </head>
-        <body dir="ltr" lang="en" style="margin:0;padding:0">
+        <body dir="ltr" lang="en">
           <!--$--><!--html--><!--head--><!--body-->
           <table
             border="0"
@@ -1521,7 +1521,7 @@ describe('Container Node', () => {
                 <td
                   dir="ltr"
                   lang="en"
-                  style="margin:0;padding:0;font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:14px;min-height:100%;line-height:155%">
+                  style="font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:14px;min-height:100%;line-height:155%">
                   <table
                     align="left"
                     width="100%"
@@ -1593,7 +1593,7 @@ describe('Container Node', () => {
             @media (prefers-color-scheme: dark){li::marker{color:#c4c4c4}}
           </style>
         </head>
-        <body dir="ltr" lang="en" style="background-color:#ffffff;margin:0;padding:0">
+        <body dir="ltr" lang="en" style="background-color:#ffffff">
           <!--$--><!--html--><!--head--><!--body-->
           <table
             border="0"
@@ -1607,7 +1607,7 @@ describe('Container Node', () => {
                 <td
                   dir="ltr"
                   lang="en"
-                  style="margin:0;padding:0;font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:1em;min-height:100%;line-height:155%;background-color:#ffffff">
+                  style="font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:1em;min-height:100%;line-height:155%;background-color:#ffffff">
                   <table
                     align="left"
                     width="100%"

--- a/packages/editor/src/plugins/email-theming/themes.ts
+++ b/packages/editor/src/plugins/email-theming/themes.ts
@@ -677,8 +677,6 @@ const RESET_BASIC: ResetTheme = {
     padding: '0',
   },
   body: {
-    margin: '0',
-    padding: '0',
     fontFamily:
       "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif",
     fontSize: '14px',


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make body spacing theme-driven in `@react-email/editor`. Remove the `body { margin: 0; padding: 0 }` reset; `minimal` exposes Body Margin and defaults Body Padding to `0`.

- **Migration**
  - If you relied on the `basic` reset to zero body spacing, set body margin/padding in your theme or document.
  - In `minimal`, use the Body panel to adjust Margin/Padding.

<sup>Written for commit 10ea180872774bd3dcf729788bb059fdc956bc15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

