### PR TITLE
chore(docs): document prism.js dev-time compilation as a known editor limitation

### DIFF
--- a/apps/docs/editor/overview.mdx
+++ b/apps/docs/editor/overview.mdx
@@ -77,3 +77,37 @@ Runnable examples are available at [react.email/editor/examples](https://react.e
     Browse the complete set of interactive examples.
   </Card>
 </CardGroup>
+
+## Known limitations
+
+<AccordionGroup>
+  <Accordion title="Slow dev-time compilation on Next.js because of Prism.js">
+    The editor's code block extension is built on top of react-email's
+    [`CodeBlock`](/components/code-block) component, which ships every Prism.js
+    language grammar in a single module. Bundlers that do not tree shake during
+    development, like Next.js, compile all of those grammars whenever the editor
+    is in the module graph, which significantly slows down dev-time compilation.
+
+    The current escape hatch is to patch your installed copy of `react-email`,
+    with [`pnpm patch`](https://pnpm.io/cli/patch) or
+    [`patch-package`](https://www.npmjs.com/package/patch-package), stripping the
+    grammars you don't use out of `dist/components/code-block/prism.mjs` (and
+    `prism.cjs` if you consume the CJS build) while keeping the top of the file
+    that imports and re-exports Prism itself:
+
+    ```js
+    import * as PrismImport from "prismjs";
+    const Prism = PrismImport.default ?? PrismImport;
+    export { Prism };
+    ```
+
+    Prism.js still registers `markup`, `css`, `clike` and `javascript` by
+    default, and the editor lazily loads any other grammar it needs while
+    editing, so the editing experience is unaffected. Keep the grammars for
+    every language you render into emails though, since `CodeBlock` throws when
+    it is given a language that is not registered.
+
+    Fully removing this weight requires a breaking change to how code blocks
+    are highlighted, which we are exploring.
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Known limitations** section to the editor docs overview, mirroring the one on the [Tailwind component docs](https://react.email/docs/components/tailwind#known-limitations).

It documents that the editor's code block extension pulls in react-email's `CodeBlock`, which ships every Prism.js language grammar in a single ~640KB module, making Next.js dev-time compilation significantly slower since dev builds don't tree shake.

It also documents the current escape hatch: patching the installed `react-email` package (`pnpm patch` / `patch-package`) to strip unused grammars out of `dist/components/code-block/prism.mjs` while keeping the Prism import/re-export. Prism.js core still registers `markup`, `css`, `clike`, and `javascript`, and the editor's `PrismPlugin` lazily loads other grammars from `prismjs/components/prism-<language>` at runtime, so editing keeps working; the caveat that `CodeBlock` throws for unregistered languages at export/render time is called out.

Context: [Slack thread](https://resend.slack.com/) discussion about the dashboard monkey-patching the package for this reason, tracked in [DEV-894](https://linear.app/resend/issue/DEV-894/explore-ways-to-avoid-having-to-patch-our-editor-in-the-dashboard).

## Checks

- `mintlify broken-links` passes with no broken links.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C058BM22A13/p1785189591982699?thread_ts=1785189591.982699&cid=C058BM22A13)

<div><a href="https://cursor.com/agents/bc-afc18744-7ab0-5924-9edd-e63e8de57464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afc18744-7ab0-5924-9edd-e63e8de57464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Known limitations section to the editor docs that explains slow dev-time builds in `Next.js` caused by `react-email`’s `CodeBlock` bundling all `prismjs` grammars, aligned with DEV-894. Documents a temporary workaround: patch `react-email` to remove unused grammars while keeping the Prism re-export (editing still works via lazy loading; export fails for unregistered languages).

<sup>Written for commit f25f126fdb16f5559678a272dde42347686ca430. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

