### PR TITLE
fix(editor): load prism languages through static import specifiers

### DIFF
--- a/.changeset/loud-bananas-shout.md
+++ b/.changeset/loud-bananas-shout.md
@@ -1,0 +1,5 @@
+---
+'@react-email/editor': patch
+---
+
+Load Prism language components for code blocks through static import specifiers so bundlers can resolve them without workarounds.

--- a/packages/editor/src/extensions/prism-plugin.spec.ts
+++ b/packages/editor/src/extensions/prism-plugin.spec.ts
@@ -20,7 +20,7 @@ describe('languageLoaders', () => {
 
   it('registers the grammar it loads for each language', async () => {
     for (const [language, load] of Object.entries(languageLoaders)) {
-      await load();
+      await load?.();
       expect(typeof Prism.languages[language]).toBe('object');
     }
   });

--- a/packages/editor/src/extensions/prism-plugin.spec.ts
+++ b/packages/editor/src/extensions/prism-plugin.spec.ts
@@ -1,0 +1,27 @@
+import Prism from 'prismjs';
+import { LOCAL_PROPS_SCHEMA } from '../ui/inspector/config/attribute-schema';
+import { languageLoaders } from './prism-plugin';
+
+describe('languageLoaders', () => {
+  it('covers every language the inspector offers that Prism core does not ship', () => {
+    const pickerLanguages = Object.keys(
+      LOCAL_PROPS_SCHEMA.language.options ?? {},
+    );
+    expect(pickerLanguages.length).toBeGreaterThan(0);
+
+    const uncovered = pickerLanguages.filter(
+      (language) =>
+        typeof Prism.languages[language] !== 'object' &&
+        !(language in languageLoaders),
+    );
+
+    expect(uncovered).toEqual([]);
+  });
+
+  it('registers the grammar it loads for each language', async () => {
+    for (const [language, load] of Object.entries(languageLoaders)) {
+      await load();
+      expect(typeof Prism.languages[language]).toBe('object');
+    }
+  });
+});

--- a/packages/editor/src/extensions/prism-plugin.ts
+++ b/packages/editor/src/extensions/prism-plugin.ts
@@ -52,23 +52,22 @@ function registeredLang(aliasOrLanguage: string) {
 }
 
 // Literal import specifiers so bundlers can statically resolve the chunks.
-export const languageLoaders: Partial<
-  Record<string, () => Promise<unknown>>
-> = {
-  go: () => import('prismjs/components/prism-go'),
-  jsx: () => import('prismjs/components/prism-jsx'),
-  json: () => import('prismjs/components/prism-json'),
-  markdown: () => import('prismjs/components/prism-markdown'),
-  php: () =>
-    import('prismjs/components/prism-markup-templating').then(
-      () => import('prismjs/components/prism-php'),
-    ),
-  python: () => import('prismjs/components/prism-python'),
-  ruby: () => import('prismjs/components/prism-ruby'),
-  shell: () => import('prismjs/components/prism-bash'),
-  sql: () => import('prismjs/components/prism-sql'),
-  typescript: () => import('prismjs/components/prism-typescript'),
-};
+export const languageLoaders: Partial<Record<string, () => Promise<unknown>>> =
+  {
+    go: () => import('prismjs/components/prism-go'),
+    jsx: () => import('prismjs/components/prism-jsx'),
+    json: () => import('prismjs/components/prism-json'),
+    markdown: () => import('prismjs/components/prism-markdown'),
+    php: () =>
+      import('prismjs/components/prism-markup-templating').then(
+        () => import('prismjs/components/prism-php'),
+      ),
+    python: () => import('prismjs/components/prism-python'),
+    ruby: () => import('prismjs/components/prism-ruby'),
+    shell: () => import('prismjs/components/prism-bash'),
+    sql: () => import('prismjs/components/prism-sql'),
+    typescript: () => import('prismjs/components/prism-typescript'),
+  };
 
 function getDecorations({
   doc,

--- a/packages/editor/src/extensions/prism-plugin.ts
+++ b/packages/editor/src/extensions/prism-plugin.ts
@@ -51,6 +51,24 @@ function registeredLang(aliasOrLanguage: string) {
   return Boolean(allSupportLang.find((x) => x === aliasOrLanguage));
 }
 
+// Literal import specifiers so bundlers can statically resolve the chunks;
+// languages not bundled into Prism core, matching the code block's language attribute options.
+const languageLoaders: Record<string, () => Promise<unknown>> = {
+  go: () => import('prismjs/components/prism-go'),
+  jsx: () => import('prismjs/components/prism-jsx'),
+  json: () => import('prismjs/components/prism-json'),
+  markdown: () => import('prismjs/components/prism-markdown'),
+  php: () =>
+    import('prismjs/components/prism-markup-templating').then(
+      () => import('prismjs/components/prism-php'),
+    ),
+  python: () => import('prismjs/components/prism-python'),
+  ruby: () => import('prismjs/components/prism-ruby'),
+  shell: () => import('prismjs/components/prism-bash'),
+  sql: () => import('prismjs/components/prism-sql'),
+  typescript: () => import('prismjs/components/prism-typescript'),
+};
+
 function getDecorations({
   doc,
   name,
@@ -75,9 +93,14 @@ function getDecorations({
     let html = '';
 
     try {
-      if (!registeredLang(language) && !loadingLanguages.has(language)) {
+      const loadLanguage = languageLoaders[language];
+      if (
+        loadLanguage &&
+        !registeredLang(language) &&
+        !loadingLanguages.has(language)
+      ) {
         loadingLanguages.add(language);
-        import(/* @vite-ignore */ `prismjs/components/prism-${language}`)
+        loadLanguage()
           .then(() => {
             loadingLanguages.delete(language);
             onLanguageLoaded(language);

--- a/packages/editor/src/extensions/prism-plugin.ts
+++ b/packages/editor/src/extensions/prism-plugin.ts
@@ -53,7 +53,7 @@ function registeredLang(aliasOrLanguage: string) {
 
 // Literal import specifiers so bundlers can statically resolve the chunks;
 // languages not bundled into Prism core, matching the code block's language attribute options.
-const languageLoaders: Record<string, () => Promise<unknown>> = {
+export const languageLoaders: Record<string, () => Promise<unknown>> = {
   go: () => import('prismjs/components/prism-go'),
   jsx: () => import('prismjs/components/prism-jsx'),
   json: () => import('prismjs/components/prism-json'),

--- a/packages/editor/src/extensions/prism-plugin.ts
+++ b/packages/editor/src/extensions/prism-plugin.ts
@@ -51,9 +51,10 @@ function registeredLang(aliasOrLanguage: string) {
   return Boolean(allSupportLang.find((x) => x === aliasOrLanguage));
 }
 
-// Literal import specifiers so bundlers can statically resolve the chunks;
-// languages not bundled into Prism core, matching the code block's language attribute options.
-export const languageLoaders: Record<string, () => Promise<unknown>> = {
+// Literal import specifiers so bundlers can statically resolve the chunks.
+export const languageLoaders: Partial<
+  Record<string, () => Promise<unknown>>
+> = {
   go: () => import('prismjs/components/prism-go'),
   jsx: () => import('prismjs/components/prism-jsx'),
   json: () => import('prismjs/components/prism-json'),

--- a/packages/editor/src/prismjs-components.d.ts
+++ b/packages/editor/src/prismjs-components.d.ts
@@ -1,0 +1,1 @@
+declare module 'prismjs/components/*';


### PR DESCRIPTION
## Summary

The code block extension loads Prism language components with a dynamic template-literal import:

```ts
import(/* @vite-ignore */ `prismjs/components/prism-${language}`)
```

Bundlers can't statically resolve a computed specifier inside a published dist bundle, so consuming apps end up patching the shipped dist files to rewrite it into explicit imports — and those patches break on every release because they target content-hashed chunk filenames.

The language set is closed and defined by this package itself (the code block's `language` attribute options), so the dynamic import buys no flexibility. This PR replaces it with a loader map of literal import specifiers covering the languages not bundled into Prism core (core already registers `css`, `html`, `javascript`, and `svg`; `plaintext` needs nothing). `php` loads `markup-templating` first, matching Prism's own dependency order, and `shell` maps to `prism-bash`.

Behavior is unchanged: languages still load lazily on first use and re-highlight via the existing `onLanguageLoaded` path, and unknown or already-registered languages are skipped. The built output now contains only literal `prismjs/components/prism-*` specifiers, verified in both the `.mjs` and `.cjs` dist files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces dynamic Prism language imports in `@react-email/editor` with a static loader map using literal `prismjs/components/*` specifiers. Bundlers can now resolve chunks without patches, with lazy loading preserved.

- **Bug Fixes**
  - Static loader map for non-core languages: go, jsx, json, markdown, php (via `markup-templating`), python, ruby, shell→bash, sql, typescript; dist uses literal `prismjs/components/prism-*` and includes a `prismjs/components/*` TS module declaration.
  - Same behavior: loads on first use, re-highlights, skips unknown or already-registered languages.
  - Added tests to prevent loader-map drift and verify grammars register (including shell→bash alias and php dependency order); `languageLoaders` is exported only for the spec and not part of the public API.

- **Refactors**
  - Typed `languageLoaders` as `Partial<Record<string, () => Promise<unknown>>>` so absent languages resolve to `undefined` and the guard is enforced at compile time. No runtime changes.

<sup>Written for commit e5df95c98881c0fa4a67189bdd4592a8e6d87501. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

