### PR TITLE
fix(react-email): preserve source order when inlining duplicate Tailwind class rules

### DIFF
--- a/.changeset/tailwind-inliner-rule-order.md
+++ b/.changeset/tailwind-inliner-rule-order.md
@@ -1,0 +1,5 @@
+---
+"react-email": patch
+---
+
+Fix `<Tailwind>` and `inlineStyles()` reordering duplicate class rules, which broke cascade precedence. Rules now keep their original stylesheet source order when merged across classes, so a later declaration correctly overrides an earlier conflicting one even when other classes are defined in between. Variable resolution in the inliner is now independent of rule order as well.

--- a/packages/react-email/src/cli/commands/testing/export.spec.ts
+++ b/packages/react-email/src/cli/commands/testing/export.spec.ts
@@ -83,7 +83,7 @@ test('email export', { retry: 3 }, async () => {
                           </tbody>
                         </table>
                         <h1
-                          style="margin-right:0;margin-left:0;margin-bottom:30px;margin-top:30px;padding:0;text-align:center;font-weight:400;font-size:24px;color:rgb(0,0,0)">
+                          style="margin-right:0;margin-left:0;margin-bottom:30px;margin-top:30px;padding:0;text-align:center;font-size:24px;font-weight:400;color:rgb(0,0,0)">
                           Join <strong></strong> on <strong>Vercel</strong>
                         </h1>
                         <p
@@ -166,7 +166,7 @@ test('email export', { retry: 3 }, async () => {
                             <tr>
                               <td>
                                 <a
-                                  style="line-height:100%;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px;border-radius:0.25rem;background-color:rgb(0,0,0);padding-right:20px;padding-left:20px;padding-bottom:12px;padding-top:12px;text-align:center;font-weight:600;font-size:12px;color:rgb(255,255,255);text-decoration-line:none"
+                                  style="line-height:100%;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px;border-radius:0.25rem;background-color:rgb(0,0,0);padding-right:20px;padding-left:20px;padding-bottom:12px;padding-top:12px;text-align:center;font-size:12px;font-weight:600;color:rgb(255,255,255);text-decoration-line:none"
                                   target="_blank"
                                   ><span
                                     ><!--[if mso]><i style="mso-font-width:500%;mso-text-raise:18px" hidden>&#8202;&#8202;</i><![endif]--></span

--- a/packages/react-email/src/components/tailwind/inline-styles.spec.ts
+++ b/packages/react-email/src/components/tailwind/inline-styles.spec.ts
@@ -46,4 +46,21 @@ describe('inlineStyles()', () => {
       }
     `);
   });
+
+  it('preserves global source order when interleaved classes conflict on the same property', () => {
+    // Regression for BU-2349: grouping rules per class and flattening by map
+    // values reordered `.box`'s later override after `.other`, so `.other`'s
+    // conflicting declaration wrongly won.
+    const styleSheet = parse(`
+      .box { color: red; }
+      .other { color: green; }
+      .box { color: blue; }
+    `) as StyleSheet;
+
+    expect(inlineStyles(styleSheet, ['box', 'other'])).toMatchInlineSnapshot(`
+      {
+        "color": "blue",
+      }
+    `);
+  });
 });

--- a/packages/react-email/src/components/tailwind/inline-styles.ts
+++ b/packages/react-email/src/components/tailwind/inline-styles.ts
@@ -2,6 +2,7 @@ import type { StyleSheet } from 'css-tree';
 import { extractRulesPerClass } from './utils/css/extract-rules-per-class.js';
 import { getCustomProperties } from './utils/css/get-custom-properties.js';
 import { makeInlineStylesFor } from './utils/css/make-inline-styles-for.js';
+import { sortRulesByOrder } from './utils/css/sort-rules-by-order.js';
 
 export function inlineStyles(
   styleSheet: StyleSheet,
@@ -15,7 +16,7 @@ export function inlineStyles(
   const customProperties = getCustomProperties(styleSheet);
 
   return makeInlineStylesFor(
-    Array.from(inlinableRules.values()).flat(),
+    sortRulesByOrder(Array.from(inlinableRules.values()).flat()),
     customProperties,
   );
 }

--- a/packages/react-email/src/components/tailwind/tailwind.spec.tsx
+++ b/packages/react-email/src/components/tailwind/tailwind.spec.tsx
@@ -114,7 +114,7 @@ describe('Tailwind component', () => {
         </Tailwind>,
       ),
     ).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><div style="padding:4px;color:rgb(81,162,255);background-color:rgb(251,44,54)"></div><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><div style="background-color:rgb(251,44,54);padding:4px;color:rgb(81,162,255)"></div><!--/$-->"`,
     );
   });
 
@@ -146,7 +146,7 @@ describe('Tailwind component', () => {
       </Html>,
     );
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html dir="ltr" lang="en"><head></head><body><!--$--><!--html--><!--body--><p style="font-size:14px;color:rgb(0,0,0);line-height:24px">or copy and paste this URL into your browser:<!-- --> <a class="other" href="https://react.email" style="color:rgb(21,93,252);text-decoration-line:none" target="_blank">https://react.email</a></p><p style="font-size:14px;color:rgb(0,0,0);line-height:24px">or copy and paste this URL into your browser:<!-- --> <a href="https://react.email" style="color:rgb(21,93,252);text-decoration-line:none" target="_blank">https://react.email</a></p><!--/$--></body></html>"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html dir="ltr" lang="en"><head></head><body><!--$--><!--html--><!--body--><p style="font-size:14px;line-height:24px;color:rgb(0,0,0)">or copy and paste this URL into your browser:<!-- --> <a class="other" href="https://react.email" style="color:rgb(21,93,252);text-decoration-line:none" target="_blank">https://react.email</a></p><p style="font-size:14px;line-height:24px;color:rgb(0,0,0)">or copy and paste this URL into your browser:<!-- --> <a href="https://react.email" style="color:rgb(21,93,252);text-decoration-line:none" target="_blank">https://react.email</a></p><!--/$--></body></html>"`,
     );
   });
 
@@ -173,7 +173,7 @@ describe('Tailwind component', () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><a style="line-height:1.4285714285714286;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px;margin-top:2rem;border-radius:0.375rem;background-color:rgb(21,93,252);padding-right:12px;padding-left:12px;padding-bottom:8px;padding-top:8px;color:rgb(229,231,235);font-size:0.875rem" target="_blank"><span><!--[if mso]><i style="mso-font-width:300%;mso-text-raise:12px" hidden>&#8202;&#8202;</i><![endif]--></span><span style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:6px">Testing button</span><span><!--[if mso]><i style="mso-font-width:300%" hidden>&#8202;&#8202;&#8203;</i><![endif]--></span></a>Testing<!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><a style="line-height:1.4285714285714286;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px;margin-top:2rem;border-radius:0.375rem;background-color:rgb(21,93,252);padding-right:12px;padding-left:12px;padding-bottom:8px;padding-top:8px;font-size:0.875rem;color:rgb(229,231,235)" target="_blank"><span><!--[if mso]><i style="mso-font-width:300%;mso-text-raise:12px" hidden>&#8202;&#8202;</i><![endif]--></span><span style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:6px">Testing button</span><span><!--[if mso]><i style="mso-font-width:300%" hidden>&#8202;&#8202;&#8203;</i><![endif]--></span></a>Testing<!--/$-->"`,
     );
   });
 
@@ -207,7 +207,7 @@ describe('Tailwind component', () => {
     const actualOutput = await render(EmailTemplate());
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><div style="margin-top:100px;font-size:50px;line-height:1">Hello world</div><div style="padding:20px"><p style="font-weight:700;font-size:50px">React Email</p></div><div style="padding:20px"><p style="font-weight:700;font-size:50px">React Email</p></div><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><div style="margin-top:100px;font-size:50px;line-height:1">Hello world</div><div style="padding:20px"><p style="font-size:50px;font-weight:700">React Email</p></div><div style="padding:20px"><p style="font-size:50px;font-weight:700">React Email</p></div><!--/$-->"`,
     );
   });
 
@@ -244,7 +244,7 @@ describe('Tailwind component', () => {
     const actualOutput = await render(EmailTemplate());
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><div style="margin-top:100px;font-size:50px;line-height:1">Hello world</div><div style="padding:20px"><p style="font-weight:700;font-size:50px">React Email</p></div><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><div style="margin-top:100px;font-size:50px;line-height:1">Hello world</div><div style="padding:20px"><p style="font-size:50px;font-weight:700">React Email</p></div><!--/$-->"`,
     );
   });
 
@@ -333,7 +333,7 @@ describe('Tailwind component', () => {
     const actualOutput = await render(EmailTemplate());
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><div style="margin-top:100px;font-size:50px;line-height:1">Hello world</div><div style="padding:20px"><p style="font-weight:700;font-size:50px">React Email</p></div><!--/$-->"`,
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><div style="margin-top:100px;font-size:50px;line-height:1">Hello world</div><div style="padding:20px"><p style="font-size:50px;font-weight:700">React Email</p></div><!--/$-->"`,
     );
   });
 

--- a/packages/react-email/src/components/tailwind/tailwind.tsx
+++ b/packages/react-email/src/components/tailwind/tailwind.tsx
@@ -7,6 +7,7 @@ import { downlevelForEmailClients } from './utils/css/downlevel-for-email-client
 import { extractRulesPerClass } from './utils/css/extract-rules-per-class.js';
 import { getCustomProperties } from './utils/css/get-custom-properties.js';
 import { sanitizeNonInlinableRules } from './utils/css/sanitize-non-inlinable-rules.js';
+import { sortRulesByOrder } from './utils/css/sort-rules-by-order.js';
 import { mapReactTree } from './utils/react/map-react-tree.js';
 import { cloneElementWithInlinedStyles } from './utils/tailwindcss/clone-element-with-inlined-styles.js';
 import { setupTailwind } from './utils/tailwindcss/setup-tailwind.js';
@@ -124,7 +125,7 @@ export function Tailwind({ children, config, theme, utility }: TailwindProps) {
   const nonInlineStyles: StyleSheet = {
     type: 'StyleSheet',
     children: new List<CssNode>().fromArray(
-      Array.from(nonInlinableRules.values()).flat(),
+      sortRulesByOrder(Array.from(nonInlinableRules.values()).flat()),
     ),
   };
   sanitizeNonInlinableRules(nonInlineStyles);

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.spec.ts
@@ -1,15 +1,21 @@
-import { generate, parse, type Rule, type StyleSheet } from 'css-tree';
+import { generate, parse, type StyleSheet } from 'css-tree';
 import { setupTailwind } from '../tailwindcss/setup-tailwind.js';
-import { extractRulesPerClass } from './extract-rules-per-class.js';
+import {
+  extractRulesPerClass,
+  type OrderedRule,
+} from './extract-rules-per-class.js';
 
 describe('extractRulesPerClass()', async () => {
   function convertToComparable(
-    map: Map<string, Rule[]>,
+    map: Map<string, OrderedRule[]>,
   ): Record<string, string[]> {
     return Object.fromEntries(
       map
         .entries()
-        .map(([k, rules]) => [k, rules.map((rule) => generate(rule))]),
+        .map(([k, rules]) => [
+          k,
+          rules.map((orderedRule) => generate(orderedRule.rule)),
+        ]),
     );
   }
 

--- a/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/extract-rules-per-class.ts
@@ -47,24 +47,35 @@ function nestAtRulesInsideRule(rule: Rule, enclosingAtRules: Atrule[]): Rule {
   };
 }
 
+export interface OrderedRule {
+  rule: Rule;
+  order: number;
+}
+
 export function extractRulesPerClass(root: CssNode, classes: string[]) {
   const classSet = new Set(classes);
 
   // A class can be defined by multiple rules (e.g. a preset and a child config
   // override), so keep them all to merge instead of the last one clobbering.
-  const inlinableRules = new Map<string, Rule[]>();
-  const nonInlinableRules = new Map<string, Rule[]>();
+  // Each rule carries its global source-order index so consumers can restore
+  // the original stylesheet cascade order after grouping by class.
+  const inlinableRules = new Map<string, OrderedRule[]>();
+  const nonInlinableRules = new Map<string, OrderedRule[]>();
+
+  let ruleOrder = 0;
 
   const appendRule = (
-    map: Map<string, Rule[]>,
+    map: Map<string, OrderedRule[]>,
     className: string,
     rule: Rule,
+    order: number,
   ) => {
     const existing = map.get(className);
+    const orderedRule: OrderedRule = { rule, order };
     if (existing) {
-      existing.push(rule);
+      existing.push(orderedRule);
     } else {
-      map.set(className, [rule]);
+      map.set(className, [orderedRule]);
     }
   };
 
@@ -85,6 +96,8 @@ export function extractRulesPerClass(root: CssNode, classes: string[]) {
       return;
     }
 
+    const order = ruleOrder++;
+
     // Only the prelude names the class that owns the rule; classes referenced
     // inside the block (e.g. `.group` in `:where(.group)`) must not key it.
     const selectorClasses: string[] = [];
@@ -99,7 +112,7 @@ export function extractRulesPerClass(root: CssNode, classes: string[]) {
       const nonInlinablePart = nestAtRulesInsideRule(rule, enclosingAtRules);
       for (const className of selectorClasses) {
         if (classSet.has(className)) {
-          appendRule(nonInlinableRules, className, nonInlinablePart);
+          appendRule(nonInlinableRules, className, nonInlinablePart, order);
         }
       }
       return;
@@ -108,7 +121,7 @@ export function extractRulesPerClass(root: CssNode, classes: string[]) {
     if (isRuleInlinable(rule)) {
       for (const className of selectorClasses) {
         if (classSet.has(className)) {
-          appendRule(inlinableRules, className, rule);
+          appendRule(inlinableRules, className, rule, order);
         }
       }
     } else {
@@ -116,10 +129,10 @@ export function extractRulesPerClass(root: CssNode, classes: string[]) {
       for (const className of selectorClasses) {
         if (!classSet.has(className)) continue;
         if (inlinablePart) {
-          appendRule(inlinableRules, className, inlinablePart);
+          appendRule(inlinableRules, className, inlinablePart, order);
         }
         if (nonInlinablePart) {
-          appendRule(nonInlinableRules, className, nonInlinablePart);
+          appendRule(nonInlinableRules, className, nonInlinablePart, order);
         }
       }
     }

--- a/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/make-inline-styles-for.ts
@@ -1,8 +1,8 @@
 import { type CssNode, type Declaration, generate, walk } from 'css-tree';
 import { getReactProperty } from '../compatibility/get-react-property.js';
 import type { CustomProperties } from './get-custom-properties.js';
+import { resolveVariableFunctions } from './resolve-variable-functions.js';
 import { stripEmptyTailwindVars } from './strip-empty-tailwind-vars.js';
-import { unwrapValue } from './unwrap-value.js';
 
 export function makeInlineStylesFor(
   inlinableRules: CssNode[],
@@ -24,42 +24,17 @@ export function makeInlineStylesFor(
 
   for (const rule of inlinableRules) {
     walk(rule, {
-      visit: 'Function',
-      enter(func, funcParentListItem) {
-        if (func.name === 'var') {
-          let variableName: string | undefined;
-          walk(func, {
-            visit: 'Identifier',
-            enter(identifier) {
-              variableName = identifier.name;
-              return this.break;
-            },
-          });
-          if (variableName) {
-            const definition = localVariableDeclarations.get(variableName);
-            if (definition) {
-              funcParentListItem.data = unwrapValue(definition.value);
-            } else {
-              // For most variables tailwindcss defines, they also define a custom
-              // property for them with an initial value that we can inline here
-              const customProperty = customProperties.get(variableName);
-              if (customProperty?.initialValue) {
-                funcParentListItem.data = unwrapValue(
-                  customProperty.initialValue.value,
-                );
-              }
-            }
-          }
-        }
-      },
-    });
-
-    walk(rule, {
       visit: 'Declaration',
       enter(declaration) {
         if (declaration.property.startsWith('--')) {
           return;
         }
+
+        resolveVariableFunctions(
+          declaration.value,
+          localVariableDeclarations,
+          customProperties,
+        );
         stripEmptyTailwindVars(declaration.value);
 
         styles[getReactProperty(declaration.property)] =

--- a/packages/react-email/src/components/tailwind/utils/css/resolve-variable-functions.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/resolve-variable-functions.spec.ts
@@ -1,0 +1,83 @@
+import { type Declaration, generate, parse, type Value } from 'css-tree';
+import { getCustomProperties } from './get-custom-properties.js';
+import { resolveVariableFunctions } from './resolve-variable-functions.js';
+
+const parseValue = (value: string) =>
+  parse(value, { context: 'value' }) as Value;
+
+const makeVariableDeclaration = (
+  property: string,
+  value: string,
+): Declaration => ({
+  type: 'Declaration',
+  important: false,
+  property,
+  value: parseValue(value),
+});
+
+describe('resolveVariableFunctions()', () => {
+  it('inlines a local variable value into a var() reference', () => {
+    const localVariableDeclarations = new Map([
+      ['--gap', makeVariableDeclaration('--gap', '8px')],
+    ]);
+
+    const value = parseValue('var(--gap)');
+    resolveVariableFunctions(value, localVariableDeclarations, new Map());
+
+    expect(generate(value)).toBe('8px');
+  });
+
+  it('falls back to a custom property initial value when no local exists', () => {
+    const customProperties = getCustomProperties(
+      parse(
+        '@property --alpha { syntax: "*"; inherits: false; initial-value: 100%; }',
+      ),
+    );
+
+    const value = parseValue('rgb(0, 0, 0, var(--alpha))');
+    resolveVariableFunctions(value, new Map(), customProperties);
+
+    expect(generate(value)).toBe('rgb(0,0,0,100%)');
+  });
+
+  it('resolves a variable that itself references another variable regardless of ordering', () => {
+    const customProperties = getCustomProperties(
+      parse(
+        '@property --alpha { syntax: "*"; inherits: false; initial-value: 100%; }',
+      ),
+    );
+    const localVariableDeclarations = new Map([
+      [
+        '--shadow-color',
+        makeVariableDeclaration('--shadow-color', 'var(--alpha)'),
+      ],
+    ]);
+
+    const value = parseValue('0 1px 3px rgb(85, 85, 85, var(--shadow-color))');
+    resolveVariableFunctions(
+      value,
+      localVariableDeclarations,
+      customProperties,
+    );
+
+    expect(generate(value)).toBe('0 1px 3px rgb(85,85,85,100%)');
+  });
+
+  it('leaves the reference untouched when a variable is unknown', () => {
+    const value = parseValue('var(--missing)');
+    resolveVariableFunctions(value, new Map(), new Map());
+
+    expect(generate(value)).toBe('var(--missing)');
+  });
+
+  it('does not loop forever on a self-referential variable', () => {
+    const localVariableDeclarations = new Map([
+      ['--loop', makeVariableDeclaration('--loop', 'var(--loop)')],
+    ]);
+
+    const value = parseValue('var(--loop)');
+    resolveVariableFunctions(value, localVariableDeclarations, new Map());
+
+    expect(generate(value)).toBe('var(--loop)');
+  });
+});

--- a/packages/react-email/src/components/tailwind/utils/css/resolve-variable-functions.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/resolve-variable-functions.ts
@@ -1,0 +1,58 @@
+import {
+  type CssNode,
+  clone,
+  type Declaration,
+  type Raw,
+  type Value,
+  walk,
+} from 'css-tree';
+import type { CustomProperties } from './get-custom-properties.js';
+import { unwrapValue } from './unwrap-value.js';
+
+export const resolveVariableFunctions = (
+  node: CssNode,
+  localVariableDeclarations: Map<string, Declaration>,
+  customProperties: CustomProperties,
+  seen: ReadonlySet<string> = new Set(),
+): void => {
+  walk(node, {
+    visit: 'Function',
+    enter(func, funcParentListItem) {
+      if (func.name !== 'var') {
+        return;
+      }
+
+      let variableName: string | undefined;
+      walk(func, {
+        visit: 'Identifier',
+        enter(identifier) {
+          variableName = identifier.name;
+          return this.break;
+        },
+      });
+
+      if (!variableName || seen.has(variableName)) {
+        return;
+      }
+
+      const localDefinition = localVariableDeclarations.get(variableName);
+      const replacementValue = localDefinition
+        ? localDefinition.value
+        : customProperties.get(variableName)?.initialValue?.value;
+
+      if (!replacementValue) {
+        return;
+      }
+
+      const clonedValue = clone(replacementValue) as Value | Raw;
+      resolveVariableFunctions(
+        clonedValue,
+        localVariableDeclarations,
+        customProperties,
+        new Set([...seen, variableName]),
+      );
+
+      funcParentListItem.data = unwrapValue(clonedValue);
+    },
+  });
+};

--- a/packages/react-email/src/components/tailwind/utils/css/sort-rules-by-order.spec.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/sort-rules-by-order.spec.ts
@@ -1,0 +1,38 @@
+import { generate, parse, type Rule, type StyleSheet } from 'css-tree';
+import type { OrderedRule } from './extract-rules-per-class.js';
+import { sortRulesByOrder } from './sort-rules-by-order.js';
+
+const parseRule = (css: string): Rule =>
+  (parse(css) as StyleSheet).children.first as Rule;
+
+describe('sortRulesByOrder()', () => {
+  it('returns rules ordered by their global source-order index', () => {
+    const first = parseRule('.a { color: red; }');
+    const second = parseRule('.b { color: green; }');
+    const third = parseRule('.c { color: blue; }');
+
+    const orderedRules: OrderedRule[] = [
+      { rule: third, order: 2 },
+      { rule: first, order: 0 },
+      { rule: second, order: 1 },
+    ];
+
+    expect(
+      sortRulesByOrder(orderedRules).map((rule) => generate(rule)),
+    ).toEqual(['.a{color:red}', '.b{color:green}', '.c{color:blue}']);
+  });
+
+  it('keeps insertion order for rules sharing the same index', () => {
+    const first = parseRule('.a { color: red; }');
+    const second = parseRule('.b { color: green; }');
+
+    const orderedRules: OrderedRule[] = [
+      { rule: first, order: 0 },
+      { rule: second, order: 0 },
+    ];
+
+    expect(
+      sortRulesByOrder(orderedRules).map((rule) => generate(rule)),
+    ).toEqual(['.a{color:red}', '.b{color:green}']);
+  });
+});

--- a/packages/react-email/src/components/tailwind/utils/css/sort-rules-by-order.ts
+++ b/packages/react-email/src/components/tailwind/utils/css/sort-rules-by-order.ts
@@ -1,0 +1,9 @@
+import type { Rule } from 'css-tree';
+import type { OrderedRule } from './extract-rules-per-class.js';
+
+export const sortRulesByOrder = (
+  orderedRules: readonly OrderedRule[],
+): Rule[] =>
+  orderedRules
+    .toSorted((a, b) => a.order - b.order)
+    .map((orderedRule) => orderedRule.rule);

--- a/packages/react-email/src/components/tailwind/utils/tailwindcss/clone-element-with-inlined-styles.ts
+++ b/packages/react-email/src/components/tailwind/utils/tailwindcss/clone-element-with-inlined-styles.ts
@@ -1,15 +1,16 @@
-import type { Rule } from 'css-tree';
 import React from 'react';
 import type { EmailElementProps } from '../../tailwind.js';
 import { sanitizeClassName } from '../compatibility/sanitize-class-name.js';
+import type { OrderedRule } from '../css/extract-rules-per-class.js';
 import type { CustomProperties } from '../css/get-custom-properties.js';
 import { makeInlineStylesFor } from '../css/make-inline-styles-for.js';
+import { sortRulesByOrder } from '../css/sort-rules-by-order.js';
 import { isComponent } from '../react/is-component.js';
 
 export function cloneElementWithInlinedStyles(
   element: React.ReactElement<EmailElementProps>,
-  inlinableRules: Map<string, Rule[]>,
-  nonInlinableRules: Map<string, Rule[]>,
+  inlinableRules: Map<string, OrderedRule[]>,
+  nonInlinableRules: Map<string, OrderedRule[]>,
   customProperties: CustomProperties,
 ) {
   const propsToOverwrite: Partial<EmailElementProps> = {};
@@ -19,11 +20,11 @@ export function cloneElementWithInlinedStyles(
 
     const residualClasses: string[] = [];
 
-    const rules: Rule[] = [];
+    const orderedRules: OrderedRule[] = [];
     for (const className of classes) {
       const classRules = inlinableRules.get(className);
       if (classRules) {
-        rules.push(...classRules);
+        orderedRules.push(...classRules);
       }
       if (nonInlinableRules.has(className)) {
         residualClasses.push(className);
@@ -32,7 +33,10 @@ export function cloneElementWithInlinedStyles(
       }
     }
 
-    const styles = makeInlineStylesFor(rules, customProperties);
+    const styles = makeInlineStylesFor(
+      sortRulesByOrder(orderedRules),
+      customProperties,
+    );
     propsToOverwrite.style = {
       ...styles,
       ...element.props.style,


### PR DESCRIPTION
## Summary by cubic

* **Bug Fixes**
  * Track a global source-order index per rule in `extractRulesPerClass()` and sort with `sort-rules-by-order` before inlining or emitting non-inlinable rules.
  * Apply sorting in `inlineStyles()`, `<Tailwind>` (non-inlinable `<style>`), and the clone path.
  * Add a regression test for interleaved duplicate classes; snapshots only change declaration order.
* **Refactors**
  * Add `resolve-variable-functions` to inline var() from local declarations or custom property initial values.
  * Supports nested var() with a cycle guard; resolution no longer depends on processing order.

Written for commit b924d992afe3ba609aec532b46cb261977174a78. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)