### PR TITLE
fix(editor): stop containerEnforcer racing collaborative initial sync

### DIFF
--- a/.changeset/container-enforcer-collab-race.md
+++ b/.changeset/container-enforcer-collab-race.md
@@ -2,4 +2,4 @@
 '@react-email/editor': patch
 ---
 
-Fix the container enforcer racing against collaborative (Yjs/Liveblocks) initial sync, which permanently added a spurious empty container to the shared doc on editor open. In collaborative mode the enforcer no longer wraps synchronously from `appendTransaction`; it wraps only after the document settles containerless following a real doc change, never wraps the bare empty placeholder doc, ignores no-op sync transactions, and defers while IME composition is active. An empty collaborative doc is wrapped after the first real edit. Paragraphs auto-inserted by the TrailingNode extension now carry an `autoTrailingNode` transaction meta so integrations can recognize machine-generated transactions.
+Fix duplicated containers when the enforcer races collaborative sync

--- a/.changeset/container-enforcer-collab-race.md
+++ b/.changeset/container-enforcer-collab-race.md
@@ -1,0 +1,5 @@
+---
+'@react-email/editor': patch
+---
+
+Fix the container enforcer racing against collaborative (Yjs/Liveblocks) initial sync, which permanently added a spurious empty container to the shared doc on editor open. In collaborative mode the enforcer no longer wraps synchronously from `appendTransaction`; it wraps only after the document settles containerless following a real doc change, never wraps the bare empty placeholder doc, ignores no-op sync transactions, and defers while IME composition is active. An empty collaborative doc is wrapped after the first real edit. Paragraphs auto-inserted by the TrailingNode extension now carry an `autoTrailingNode` transaction meta so integrations can recognize machine-generated transactions.

--- a/packages/editor/src/extensions/container.spec.tsx
+++ b/packages/editor/src/extensions/container.spec.tsx
@@ -323,6 +323,14 @@ describe('Container Node', () => {
   });
 
   describe('collaboration mode (simulated liveblocks)', () => {
+    // Replays the real Liveblocks transaction pattern observed in production:
+    //
+    //  1. One y-sync$ replacing doc with a bare empty paragraph
+    //     (TipTap normalises null → '' → schema `block+` gives one <p>)
+    //  2. ~18 rapid-fire y-sync$ "stabilisation" transactions that each
+    //     replace the doc with its current content
+    //  3. One final y-sync$ delivering the real document content
+    //  4. Two generic no-op transactions (Liveblocks cleanup)
     const STABILIZATION_ROUNDS = 18;
 
     beforeEach(() => {

--- a/packages/editor/src/extensions/container.spec.tsx
+++ b/packages/editor/src/extensions/container.spec.tsx
@@ -1,11 +1,11 @@
 import type { JSONContent } from '@tiptap/core';
 import { Editor, Extension } from '@tiptap/core';
 import { Container as ReactEmailContainer, render } from 'react-email';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { composeReactEmail } from '../core/serializer/compose-react-email';
 import { EmailTheming } from '../plugins';
 import { DEFAULT_STYLES } from '../utils/default-styles';
-import { Container } from './container';
+import { COLLABORATIVE_WRAP_DEBOUNCE_MS, Container } from './container';
 import { StarterKit } from './index';
 
 vi.mock('@/actions/ai', () => ({
@@ -323,16 +323,25 @@ describe('Container Node', () => {
   });
 
   describe('collaboration mode (simulated liveblocks)', () => {
-    // Replays the real Liveblocks transaction pattern observed in production:
-    //
-    //  1. One y-sync$ replacing doc with a bare empty paragraph
-    //     (TipTap normalises null → '' → schema `block+` gives one <p>)
-    //  2. ~18 rapid-fire y-sync$ "stabilisation" transactions that each
-    //     replace the doc with container+paragraph (the Yjs doc mirrors
-    //     back the container that appendTransaction created after step 1)
-    //  3. One final y-sync$ delivering the real document content
-    //  4. Two generic no-op transactions (Liveblocks cleanup)
     const STABILIZATION_ROUNDS = 18;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    async function settle() {
+      await vi.advanceTimersByTimeAsync(COLLABORATIVE_WRAP_DEBOUNCE_MS + 10);
+    }
+
+    function countTopLevelContainers(editorInstance: Editor) {
+      return editorInstance
+        .getJSON()
+        .content!.filter((n) => n.type === 'container').length;
+    }
 
     function createFakeLiveblocksExtension(getContent: (schema: any) => any) {
       let resolve: () => void;
@@ -398,6 +407,7 @@ describe('Container Node', () => {
         extensions: [StarterKit, fakeLiveblocks],
       });
 
+      await settle();
       await contentResolved;
 
       const json = editor!.getJSON();
@@ -444,6 +454,7 @@ describe('Container Node', () => {
         extensions: [StarterKit, fakeLiveblocks],
       });
 
+      await settle();
       await contentResolved;
 
       const json = editor!.getJSON();
@@ -475,8 +486,7 @@ describe('Container Node', () => {
       `);
     });
 
-    // We skip this because it fails and there's no good solution for this that fits in all situations.
-    it.skip('wraps the schema-default empty paragraph when collaboration starts with no content', async () => {
+    it('wraps a doc that syncs with no content only after the first real edit', async () => {
       const [fakeLiveblocks, contentResolved] = createFakeLiveblocksExtension(
         (schema) => schema.nodes.paragraph.create(),
       );
@@ -485,29 +495,15 @@ describe('Container Node', () => {
         extensions: [StarterKit, fakeLiveblocks],
       });
 
+      await settle();
       await contentResolved;
 
-      const json = editor!.getJSON();
-      expect(json).toMatchInlineSnapshot(`
-        {
-          "content": [
-            {
-              "content": [
-                {
-                  "attrs": {
-                    "alignment": null,
-                    "class": "",
-                    "style": "",
-                  },
-                  "type": "paragraph",
-                },
-              ],
-              "type": "container",
-            },
-          ],
-          "type": "doc",
-        }
-      `);
+      expect(countTopLevelContainers(editor!)).toBe(0);
+
+      editor!.commands.insertContent('Hello');
+      await settle();
+
+      expect(countTopLevelContainers(editor!)).toBe(1);
     });
 
     it('preserves globalContent outside the container when synced via collaboration', async () => {
@@ -528,6 +524,7 @@ describe('Container Node', () => {
         extensions: [StarterKit, fakeLiveblocks],
       });
 
+      await settle();
       await contentResolved;
 
       const json = editor!.getJSON();
@@ -590,6 +587,7 @@ describe('Container Node', () => {
         extensions: [StarterKit, fakeLiveblocks],
       });
 
+      await settle();
       await contentResolved;
 
       const json = editor!.getJSON();
@@ -724,6 +722,7 @@ describe('Container Node', () => {
         extensions: [StarterKit, fakeLiveblocks],
       });
 
+      await vi.advanceTimersByTimeAsync(1);
       await initDone;
       let json = editor.getJSON();
       expect(json).toMatchInlineSnapshot(`
@@ -753,6 +752,7 @@ describe('Container Node', () => {
         }
       `);
 
+      await settle();
       await updateDone;
       json = editor.getJSON();
       expect(json).toMatchInlineSnapshot(`
@@ -783,7 +783,7 @@ describe('Container Node', () => {
       `);
     });
 
-    it('does not eagerly wrap before the first y-sync$ content arrives', () => {
+    it('does not eagerly wrap before the first y-sync$ content arrives', async () => {
       const fakeLiveblocks = Extension.create({
         name: 'liveblocksExtension',
       });
@@ -794,6 +794,126 @@ describe('Container Node', () => {
 
       const json = editor!.getJSON();
       expect(json.content!.some((n) => n.type === 'container')).toBe(false);
+
+      await settle();
+      expect(countTopLevelContainers(editor!)).toBe(0);
+    });
+
+    it('does not wrap the transient containerless docs produced while sync is still streaming', async () => {
+      const fakeLiveblocks = Extension.create({
+        name: 'liveblocksExtension',
+      });
+
+      editor = new Editor({
+        extensions: [StarterKit, fakeLiveblocks],
+      });
+
+      const { view } = editor;
+      const { schema } = view.state;
+      const dispatchSync = (content: any) => {
+        const tr = view.state.tr.replaceWith(
+          0,
+          view.state.doc.content.size,
+          content,
+        );
+        tr.setMeta('y-sync$', true);
+        view.dispatch(tr);
+      };
+
+      const chunk1 = schema.nodes.paragraph.create(
+        null,
+        schema.text('First chunk'),
+      );
+      const chunk2 = schema.nodes.paragraph.create(
+        null,
+        schema.text('Second chunk'),
+      );
+
+      dispatchSync(chunk1);
+      await vi.advanceTimersByTimeAsync(COLLABORATIVE_WRAP_DEBOUNCE_MS - 100);
+      expect(countTopLevelContainers(editor!)).toBe(0);
+
+      dispatchSync([chunk1, chunk2]);
+      await vi.advanceTimersByTimeAsync(COLLABORATIVE_WRAP_DEBOUNCE_MS - 100);
+      expect(countTopLevelContainers(editor!)).toBe(0);
+
+      dispatchSync(schema.nodes.container.create(null, [chunk1, chunk2]));
+      await settle();
+      expect(countTopLevelContainers(editor!)).toBe(1);
+    });
+
+    it('does not arm the wrap from sync transactions that do not change the doc', async () => {
+      const fakeLiveblocks = Extension.create({
+        name: 'liveblocksExtension',
+      });
+
+      editor = new Editor({
+        extensions: [StarterKit, fakeLiveblocks],
+      });
+
+      const { view } = editor;
+      const noop = view.state.tr.replaceWith(
+        0,
+        view.state.doc.content.size,
+        view.state.doc,
+      );
+      noop.setMeta('y-sync$', true);
+      view.dispatch(noop);
+
+      await settle();
+      expect(countTopLevelContainers(editor!)).toBe(0);
+
+      const { schema } = view.state;
+      const late = view.state.tr.replaceWith(
+        0,
+        view.state.doc.content.size,
+        schema.nodes.container.create(
+          null,
+          schema.nodes.paragraph.create(null, schema.text('Late content')),
+        ),
+      );
+      late.setMeta('y-sync$', true);
+      view.dispatch(late);
+
+      await settle();
+      expect(countTopLevelContainers(editor!)).toBe(1);
+    });
+
+    it('does not wrap a doc reduced to a bare empty paragraph until the next real edit', async () => {
+      const fakeLiveblocks = Extension.create({
+        name: 'liveblocksExtension',
+      });
+
+      editor = new Editor({
+        extensions: [StarterKit, fakeLiveblocks],
+      });
+
+      const { view } = editor;
+      const { schema } = view.state;
+      const seed = view.state.tr.replaceWith(
+        0,
+        view.state.doc.content.size,
+        schema.nodes.container.create(
+          null,
+          schema.nodes.paragraph.create(null, schema.text('Hi')),
+        ),
+      );
+      seed.setMeta('y-sync$', true);
+      view.dispatch(seed);
+
+      const wipe = view.state.tr.replaceWith(
+        0,
+        view.state.doc.content.size,
+        schema.nodes.paragraph.create(),
+      );
+      view.dispatch(wipe);
+
+      await settle();
+      expect(countTopLevelContainers(editor!)).toBe(0);
+
+      editor!.commands.insertContent('Hello');
+      await settle();
+      expect(countTopLevelContainers(editor!)).toBe(1);
     });
 
     it('preserves multiple containers when the synced document has them', async () => {
@@ -821,6 +941,7 @@ describe('Container Node', () => {
         extensions: [StarterKit, fakeLiveblocks],
       });
 
+      await settle();
       await contentResolved;
 
       const json = editor!.getJSON();

--- a/packages/editor/src/extensions/container.tsx
+++ b/packages/editor/src/extensions/container.tsx
@@ -7,13 +7,12 @@ import { hasCollaborationExtension } from '../utils/is-collaboration';
 import { inlineCssToJs } from '../utils/styles';
 
 function hasContainerNode(doc: PmNode): boolean {
-  let found = false;
-  doc.forEach((node) => {
-    if (node.type.name === 'container') {
-      found = true;
+  for (let i = 0; i < doc.childCount; i++) {
+    if (doc.child(i).type.name === 'container') {
+      return true;
     }
-  });
-  return found;
+  }
+  return false;
 }
 
 function wrapInContainer(state: EditorState) {
@@ -49,6 +48,17 @@ function wrapInContainer(state: EditorState) {
 
 export interface ContainerOptions {
   HTMLAttributes: Record<string, unknown>;
+}
+
+export const COLLABORATIVE_WRAP_DEBOUNCE_MS = 500;
+
+function isBareEmptyDoc(doc: PmNode): boolean {
+  return (
+    doc.childCount === 1 &&
+    doc.firstChild !== null &&
+    doc.firstChild.type.name === 'paragraph' &&
+    doc.firstChild.childCount === 0
+  );
 }
 
 export const Container = EmailNode.create<ContainerOptions>({
@@ -113,47 +123,82 @@ export const Container = EmailNode.create<ContainerOptions>({
     const isCollaborative = hasCollaborationExtension(
       this.editor.extensionManager.extensions,
     );
+
+    if (!isCollaborative) {
+      return [
+        new Plugin({
+          key: new PluginKey('containerEnforcer'),
+          view: (editorView) => {
+            if (!hasContainerNode(editorView.state.doc)) {
+              editorView.dispatch(wrapInContainer(editorView.state));
+            }
+            return {};
+          },
+          appendTransaction(_transactions, oldState, newState) {
+            if (hasContainerNode(newState.doc)) {
+              return null;
+            }
+            if (newState.doc.eq(oldState.doc)) {
+              return null;
+            }
+            return wrapInContainer(newState);
+          },
+        }),
+      ];
+    }
+
+    let wrapTimer: ReturnType<typeof setTimeout> | null = null;
     return [
       new Plugin({
         key: new PluginKey('containerEnforcer'),
-        view: isCollaborative
-          ? undefined
-          : (editorView) => {
-              if (!hasContainerNode(editorView.state.doc)) {
-                const tr = wrapInContainer(editorView.state);
-                editorView.dispatch(tr);
+        view: (editorView) => {
+          const cancelPendingWrap = () => {
+            if (wrapTimer !== null) {
+              clearTimeout(wrapTimer);
+              wrapTimer = null;
+            }
+          };
+          const scheduleWrap = () => {
+            cancelPendingWrap();
+            wrapTimer = setTimeout(() => {
+              wrapTimer = null;
+              if (editorView.isDestroyed) {
+                return;
               }
-              return {};
+              if (editorView.composing) {
+                scheduleWrap();
+                return;
+              }
+              const state = editorView.state;
+              if (hasContainerNode(state.doc)) {
+                return;
+              }
+              if (isBareEmptyDoc(state.doc)) {
+                return;
+              }
+              editorView.dispatch(wrapInContainer(state));
+            }, COLLABORATIVE_WRAP_DEBOUNCE_MS);
+          };
+
+          if (
+            !hasContainerNode(editorView.state.doc) &&
+            !isBareEmptyDoc(editorView.state.doc)
+          ) {
+            scheduleWrap();
+          }
+
+          return {
+            update: (view, prevState) => {
+              if (view.state.doc.eq(prevState.doc)) {
+                return;
+              }
+              if (hasContainerNode(view.state.doc)) {
+                cancelPendingWrap();
+                return;
+              }
+              scheduleWrap();
             },
-        appendTransaction(_transactions, oldState, newState) {
-          if (hasContainerNode(newState.doc)) {
-            return null;
-          }
-
-          // This is meant to deal with the weird behavior from Liveblocks's
-          // extension. It repeatedly creates transactions that do basically no
-          // changes before the actual content of the room arrives. And, if we
-          // don't do this, this plugin wraps the initial document from TipTap
-          // (an empty paragraph) with a container, and this is then kept in
-          // the TipTap, effectively duplicating containers every time someone
-          // opens the editor.
-          //
-          // This check is, at the end of the day, a heuristic and therefore it
-          // might fail. It's just not the best solution, the best solution
-          // would be for us to either not receive any content update until the
-          // contents are actually being set, or to be able to distinguish
-          // between "fake" transactions and "real" transactions in the
-          // Liveblocks extension. But, for now, this is what we have.
-          //
-          // One such case where this fails is if the email's contents are
-          // literally the default contents from TipTap, meaning an empty
-          // paragraph, it won't wrap, and we have a test for this that's being
-          // skipped in container.spec.tsx
-          if (newState.doc.eq(oldState.doc)) {
-            return null;
-          }
-
-          return wrapInContainer(newState);
+          };
         },
       }),
     ];

--- a/packages/editor/src/extensions/container.tsx
+++ b/packages/editor/src/extensions/container.tsx
@@ -147,6 +147,25 @@ export const Container = EmailNode.create<ContainerOptions>({
       ];
     }
 
+    // In collaborative mode the initial document streams in through several
+    // Yjs/Liveblocks sync transactions, so the doc can be transiently
+    // containerless mid-sync. Wrapping that transient synchronously (what
+    // appendTransaction used to do here) merges a spurious container into
+    // the shared Yjs doc permanently, duplicating containers on every
+    // editor open. Instead, wrapping is debounced and armed only by a real
+    // document change: no-op sync transactions neither arm nor delay it,
+    // and the bare empty placeholder doc (the shape mid-sync transients
+    // have) is never wrapped — an empty doc is wrapped after the first
+    // real edit instead.
+    //
+    // This is still a heuristic and can fail: a stall longer than the
+    // debounce around a containerless, content-bearing transient still
+    // wraps too early, and two clients can wrap a legitimately
+    // containerless doc at the same time (CRDT merge keeps both). The real
+    // fix needs the collaboration provider's sync status, which this
+    // package cannot see — consumers should gate editor mount on sync
+    // completion and seed rooms with a container so this plugin never has
+    // work to do.
     let wrapTimer: ReturnType<typeof setTimeout> | null = null;
     return [
       new Plugin({
@@ -179,13 +198,6 @@ export const Container = EmailNode.create<ContainerOptions>({
               editorView.dispatch(wrapInContainer(state));
             }, COLLABORATIVE_WRAP_DEBOUNCE_MS);
           };
-
-          if (
-            !hasContainerNode(editorView.state.doc) &&
-            !isBareEmptyDoc(editorView.state.doc)
-          ) {
-            scheduleWrap();
-          }
 
           return {
             update: (view, prevState) => {

--- a/packages/editor/src/extensions/trailing-node.tsx
+++ b/packages/editor/src/extensions/trailing-node.tsx
@@ -133,6 +133,10 @@ export const TrailingNode = Extension.create<TrailingNodeOptions>({
             tr.insert(pos, type.create());
           }
 
+          if (positions.length > 0) {
+            tr.setMeta('autoTrailingNode', true);
+          }
+
           return positions.length > 0 ? tr : undefined;
         },
         state: {


### PR DESCRIPTION
## Problem

Collaborative (Liveblocks/Yjs) email documents accumulate spurious top-level `container` nodes. Verified in production: a brand-new single-container template grew 1 → 2 → 3 top-level `(globalContent, container)` pairs across three consecutive fresh page loads with no user edits. Rendered emails show multiple `max-width` wrapper tables — empty shells at the top, and in one captured example real content split across two containers.

## Root cause

The `containerEnforcer` plugin's `appendTransaction` ran on **every** transaction, including those produced by the Yjs binding applying initial sync. Initial sync arrives as multiple discrete updates, so the doc is transiently containerless mid-stream. The enforcer wrapped that transient state, and since the wrap is a real, locally-originated transaction (no `y-sync$` meta), it merged into the shared Yjs doc via normal CRDT semantics and persisted — one more spurious container per affected open. The old `doc.eq` heuristic only suppressed no-op transactions, not doc-changing mid-stream transients. The corruption never self-heals: one landed container satisfies `hasContainerNode` forever.

## Fix

Non-collaborative mode is unchanged (synchronous wrap at mount + `appendTransaction` with the `doc.eq` guard).

In collaborative mode the enforcer no longer wraps from `appendTransaction`. Instead the plugin view debounces (500ms):

- Only a **real doc change** arms/resets the timer — no-op sync transactions neither arm nor delay it (the old guard's protection, preserved).
- The wrap fires only if the doc is still containerless after the debounce, and **never for the bare empty placeholder doc** (a single empty paragraph — the exact shape mid-sync transients have). An empty collaborative doc is wrapped after the first real edit instead.
- The pending wrap survives plugin reconfiguration (`registerPlugin`/`unregisterPlugin` recreates plugin views without calling `update()`), is skipped on destroyed views, and defers while IME composition is active.

This turns a deterministic every-load corruption into a rare race. It is intentionally not claimed to be airtight: without the collaboration provider's sync status (which this package cannot see), a >500ms gap of total silence mid-stream around a content-bearing transient can still misfire, and two clients can still wrap a legitimately containerless doc simultaneously. Consumers should additionally gate editor mount on sync completion and seed rooms with a valid container.

Also ports from the same field patch: `TrailingNode` auto-insert transactions now carry an `autoTrailingNode` meta so integrations can recognize machine-generated transactions.

## Tests

- Unskipped/replaced the previously-impossible empty-doc case (`it.skip` with "no good solution" comment) — now asserts wrap-after-first-edit.
- New regression tests: streaming containerless chunks with real sub-debounce gaps between them (exercises timer reset), no-op sync transactions never arming the wrap (fails if the `doc.eq` gate is removed — verified), and a doc wiped to a bare empty paragraph staying unwrapped until the next edit.
- 518/518 editor tests pass; the pre-fix implementation fails 7 of the collaboration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race during collaborative (Yjs/Liveblocks) initial sync that duplicated top‑level `container` nodes and produced extra wrapper tables in emails. In collaborative mode, wrapping is now debounced and scheduled only after a real doc change; never at view creation. Non‑collab behavior is unchanged.

- **Bug Fixes**
  - Replaced `appendTransaction` with a 500ms debounced plugin view in collab mode that arms only on real doc updates and wraps only if the doc remains containerless.
  - Ignores y-sync no-ops, skips the bare empty placeholder paragraph, defers during IME, never wraps before first sync, and cancels any pending wrap if a container appears. Added tests for streaming chunks, no-ops, empty-doc wrap-after-first-edit, and pre-sync cases.

- **New Features**
  - Paragraphs auto-inserted by `TrailingNode` now set an `autoTrailingNode` transaction meta for downstream detection.

<sup>Written for commit edf5b8ef103c0d4a60a6df3ed70d38bd6d2c35db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

