### PR TITLE
feat(editor): make the container center aligned on the basic theme

### DIFF
--- a/.changeset/swift-rocks-tease.md
+++ b/.changeset/swift-rocks-tease.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": minor
+---
+
+make the container center aligned on the basic theme

--- a/packages/editor/src/extensions/container.spec.tsx
+++ b/packages/editor/src/extensions/container.spec.tsx
@@ -292,13 +292,13 @@ describe('Container Node', () => {
                   lang="en"
                   style="font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:1em;min-height:100%;line-height:155%;background-color:#ffffff">
                   <table
-                    align="left"
+                    align="center"
                     width="100%"
                     border="0"
                     cellpadding="0"
                     cellspacing="0"
                     role="presentation"
-                    style="max-width:600px;align:left;width:100%;color:#000000;background-color:#ffffff;border-radius:0px;border-color:#000000;line-height:155%">
+                    style="max-width:600px;align:center;width:100%;color:#000000;background-color:#ffffff;border-radius:0px;border-color:#000000;line-height:155%">
                     <tbody>
                       <tr style="width:100%">
                         <td
@@ -1609,13 +1609,13 @@ describe('Container Node', () => {
                   lang="en"
                   style="font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;font-size:1em;min-height:100%;line-height:155%;background-color:#ffffff">
                   <table
-                    align="left"
+                    align="center"
                     width="100%"
                     border="0"
                     cellpadding="0"
                     cellspacing="0"
                     role="presentation"
-                    style="max-width:600px;align:left;width:100%;color:#000000;background-color:#ffffff;border-radius:0px;border-color:#000000;line-height:155%">
+                    style="max-width:600px;align:center;width:100%;color:#000000;background-color:#ffffff;border-radius:0px;border-color:#000000;line-height:155%">
                     <tbody>
                       <tr style="width:100%">
                         <td

--- a/packages/editor/src/plugins/email-theming/themes.ts
+++ b/packages/editor/src/plugins/email-theming/themes.ts
@@ -96,7 +96,7 @@ const THEME_BASIC: PanelGroup[] = [
       {
         label: 'Align',
         type: 'select',
-        value: 'left',
+        value: 'center',
         options: {
           left: 'Left',
           center: 'Center',


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>(<scope>): <Message>`

Examples:
- New feature: `feat(button): Add new thing`
- Fix: `fix(react-email): Dev command
- Misc/Chore: `chore(root): Update `readme.md`
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Center-aligns the container by default in the Basic theme in `@react-email/editor`. The “Align” control now defaults to “center” (was “left”), and tests were updated to reflect the new default.

<sup>Written for commit cc722a7bb8e4614ec91ae9641b3ccf61119f384b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

