### PR TITLE
fix(section): put padding media classes on td with base padding

### DIFF
--- a/packages/react-email/src/components/container/container.spec.tsx
+++ b/packages/react-email/src/components/container/container.spec.tsx
@@ -30,4 +30,19 @@ describe('<Container> component', () => {
       `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation" style="max-width:300px"><tbody><tr style="width:100%"><td><button type="button">Hi</button></td></tr></tbody></table><!--/$-->"`,
     );
   });
+
+  it('puts padding class variants on the td with base padding (#3693)', async () => {
+    const html = await render(
+      <Container
+        style={{ paddingLeft: '2.25rem', paddingRight: '2.25rem' }}
+        className="max-sm_px-5"
+      >
+        hi
+      </Container>,
+    );
+    expect(html).toMatch(/<td[^>]*class="max-sm_px-5"/);
+    expect(html).toMatch(/<td[^>]*style="[^"]*padding-left:2.25rem/);
+    // padding class should not only live on the outer table
+    expect(html).not.toMatch(/<table[^>]*class="max-sm_px-5"/);
+  });
 });

--- a/packages/react-email/src/components/container/container.tsx
+++ b/packages/react-email/src/components/container/container.tsx
@@ -1,37 +1,18 @@
 import * as React from 'react';
 import { markAsElement } from '../element-marker.js';
+import {
+  splitPaddingClassNames,
+  splitPaddingStyles,
+} from '../utils/split-padding-props.js';
 
 export type ContainerProps = Readonly<React.ComponentPropsWithoutRef<'table'>>;
 
 export const Container = React.forwardRef<HTMLTableElement, ContainerProps>(
-  ({ children, style = {}, ...props }, ref) => {
-    // Split padding styles to improve compatibility with Klaviyo and Outlook,
-    // while preserving user-provided style property order without allocating
-    // entry arrays on each render.
-    const tdStyle: React.CSSProperties = {};
-    const tableStyle: React.CSSProperties = {};
-
-    const styleRecord = style as Record<string, unknown>;
-
-    for (const key in styleRecord) {
-      if (!Object.hasOwn(styleRecord, key)) {
-        continue;
-      }
-
-      const value = styleRecord[key];
-
-      if (
-        key === 'padding' ||
-        key === 'paddingTop' ||
-        key === 'paddingRight' ||
-        key === 'paddingBottom' ||
-        key === 'paddingLeft'
-      ) {
-        (tdStyle as Record<string, unknown>)[key] = value;
-      } else {
-        (tableStyle as Record<string, unknown>)[key] = value;
-      }
-    }
+  ({ children, style = {}, className, ...props }, ref) => {
+    // Same padding split as Section — media-query padding classes must land on
+    // the <td> with base padding (https://github.com/resend/react-email/issues/3693).
+    const { tdStyle, tableStyle } = splitPaddingStyles(style);
+    const { tdClassName, tableClassName } = splitPaddingClassNames(className);
 
     return (
       <table
@@ -43,11 +24,14 @@ export const Container = React.forwardRef<HTMLTableElement, ContainerProps>(
         cellSpacing="0"
         ref={ref}
         role="presentation"
+        className={tableClassName}
         style={{ maxWidth: '37.5em', ...tableStyle }}
       >
         <tbody>
           <tr style={{ width: '100%' }}>
-            <td style={tdStyle}>{children}</td>
+            <td className={tdClassName} style={tdStyle}>
+              {children}
+            </td>
           </tr>
         </tbody>
       </table>

--- a/packages/react-email/src/components/section/section.spec.tsx
+++ b/packages/react-email/src/components/section/section.spec.tsx
@@ -55,4 +55,22 @@ describe('<Section> component', () => {
     const tdChildrenArr = actualOutput.match(/<td\s*.*?>.*?<\/td>/g);
     expect(tdChildrenArr).toHaveLength(1);
   });
+
+  it('puts padding styles on the td and non-padding styles on the table', async () => {
+    const html = await render(
+      <Section
+        style={{ padding: '16px', backgroundColor: 'red' }}
+        className="max-sm_px-5 bg-white"
+      >
+        hi
+      </Section>,
+    );
+    // Base padding on the cell (Outlook/Klaviyo)
+    expect(html).toMatch(/<td[^>]*style="[^"]*padding:16px/);
+    // Media-query padding class on the same cell so it can override base padding (#3693)
+    expect(html).toMatch(/<td[^>]*class="[^"]*max-sm_px-5/);
+    // Non-padding class stays on the table
+    expect(html).toMatch(/<table[^>]*class="[^"]*bg-white/);
+    expect(html).toMatch(/<table[^>]*style="[^"]*background-color:red/);
+  });
 });

--- a/packages/react-email/src/components/section/section.tsx
+++ b/packages/react-email/src/components/section/section.tsx
@@ -1,37 +1,19 @@
 import * as React from 'react';
 import { markAsElement } from '../element-marker.js';
+import {
+  splitPaddingClassNames,
+  splitPaddingStyles,
+} from '../utils/split-padding-props.js';
 
 export type SectionProps = Readonly<React.ComponentPropsWithoutRef<'table'>>;
 
 export const Section = React.forwardRef<HTMLTableElement, SectionProps>(
-  ({ children, style = {}, ...props }, ref) => {
-    // Split padding styles to improve compatibility with Klaviyo and Outlook,
-    // while preserving user-provided style property order without allocating
-    // entry arrays on each render.
-    const tdStyle: React.CSSProperties = {};
-    const tableStyle: React.CSSProperties = {};
-
-    const styleRecord = style as Record<string, unknown>;
-
-    for (const key in styleRecord) {
-      if (!Object.hasOwn(styleRecord, key)) {
-        continue;
-      }
-
-      const value = styleRecord[key];
-
-      if (
-        key === 'padding' ||
-        key === 'paddingTop' ||
-        key === 'paddingRight' ||
-        key === 'paddingBottom' ||
-        key === 'paddingLeft'
-      ) {
-        (tdStyle as Record<string, unknown>)[key] = value;
-      } else {
-        (tableStyle as Record<string, unknown>)[key] = value;
-      }
-    }
+  ({ children, style = {}, className, ...props }, ref) => {
+    // Split padding styles/classes onto the inner <td> for Outlook/Klaviyo, and so
+    // Tailwind media-query padding variants override base padding on the same
+    // element (https://github.com/resend/react-email/issues/3693).
+    const { tdStyle, tableStyle } = splitPaddingStyles(style);
+    const { tdClassName, tableClassName } = splitPaddingClassNames(className);
 
     return (
       <table
@@ -43,11 +25,14 @@ export const Section = React.forwardRef<HTMLTableElement, SectionProps>(
         role="presentation"
         {...props}
         ref={ref}
+        className={tableClassName}
         style={tableStyle}
       >
         <tbody>
           <tr>
-            <td style={tdStyle}>{children}</td>
+            <td className={tdClassName} style={tdStyle}>
+              {children}
+            </td>
           </tr>
         </tbody>
       </table>

--- a/packages/react-email/src/components/utils/split-padding-props.spec.ts
+++ b/packages/react-email/src/components/utils/split-padding-props.spec.ts
@@ -1,0 +1,76 @@
+import {
+  isPaddingClassName,
+  splitPaddingClassNames,
+  splitPaddingStyles,
+} from './split-padding-props.js';
+
+describe('isPaddingClassName', () => {
+  it.each([
+    'p-4',
+    'px-9',
+    'py-2',
+    'pt-1',
+    'pr-2',
+    'pb-3',
+    'pl-4',
+    'ps-2',
+    'pe-2',
+    'max-sm:px-5',
+    'sm:p-4',
+    'md:pt-[10px]',
+    // react-email Tailwind often rewrites ":" to "_"
+    'max-sm_px-5',
+    'sm_p-4',
+  ])('detects padding utility %s', (cls) => {
+    expect(isPaddingClassName(cls)).toBe(true);
+  });
+
+  it.each([
+    'bg-red-500',
+    'text-center',
+    'max-sm:bg-black',
+    'w-full',
+    'm-4',
+  ])('rejects non-padding utility %s', (cls) => {
+    expect(isPaddingClassName(cls)).toBe(false);
+  });
+});
+
+describe('splitPaddingStyles', () => {
+  it('moves padding keys to tdStyle and the rest to tableStyle', () => {
+    const { tdStyle, tableStyle } = splitPaddingStyles({
+      padding: 16,
+      paddingTop: 8,
+      backgroundColor: 'red',
+      maxWidth: '37.5em',
+    });
+    expect(tdStyle).toEqual({ padding: 16, paddingTop: 8 });
+    expect(tableStyle).toEqual({
+      backgroundColor: 'red',
+      maxWidth: '37.5em',
+    });
+  });
+});
+
+describe('splitPaddingClassNames', () => {
+  it('routes padding and media-query padding classes to the td', () => {
+    const { tdClassName, tableClassName } = splitPaddingClassNames(
+      'px-9 max-sm:px-5 bg-white max-sm_px-5',
+    );
+    expect(tdClassName?.split(/\s+/).sort()).toEqual(
+      ['max-sm:px-5', 'max-sm_px-5', 'px-9'].sort(),
+    );
+    expect(tableClassName).toBe('bg-white');
+  });
+
+  it('returns undefined parts when empty', () => {
+    expect(splitPaddingClassNames(undefined)).toEqual({
+      tdClassName: undefined,
+      tableClassName: undefined,
+    });
+    expect(splitPaddingClassNames('')).toEqual({
+      tdClassName: undefined,
+      tableClassName: undefined,
+    });
+  });
+});

--- a/packages/react-email/src/components/utils/split-padding-props.ts
+++ b/packages/react-email/src/components/utils/split-padding-props.ts
@@ -1,0 +1,84 @@
+import type * as React from 'react';
+
+const PADDING_STYLE_KEYS = new Set([
+  'padding',
+  'paddingTop',
+  'paddingRight',
+  'paddingBottom',
+  'paddingLeft',
+]);
+
+/**
+ * Tailwind padding utilities, including responsive/variant forms.
+ * Matches both author-facing classes (`max-sm:px-5`) and post-Tailwind
+ * rewritten forms used in email CSS (`max-sm_px-5`).
+ */
+const PADDING_CLASS_RE =
+  /(?:^|[_:])(p|px|py|pt|pr|pb|pl|ps|pe)(?:-|\[[^\]]+\])/;
+
+export function isPaddingStyleKey(key: string): boolean {
+  return PADDING_STYLE_KEYS.has(key);
+}
+
+export function isPaddingClassName(className: string): boolean {
+  return PADDING_CLASS_RE.test(className);
+}
+
+/**
+ * Split inline styles so padding lands on the inner `<td>` (Outlook/Klaviyo)
+ * and non-padding styles stay on the outer `<table>`.
+ */
+export function splitPaddingStyles(style: React.CSSProperties = {}): {
+  tdStyle: React.CSSProperties;
+  tableStyle: React.CSSProperties;
+} {
+  const tdStyle: React.CSSProperties = {};
+  const tableStyle: React.CSSProperties = {};
+  const styleRecord = style as Record<string, unknown>;
+
+  for (const key in styleRecord) {
+    if (!Object.hasOwn(styleRecord, key)) {
+      continue;
+    }
+
+    const value = styleRecord[key];
+    if (isPaddingStyleKey(key)) {
+      (tdStyle as Record<string, unknown>)[key] = value;
+    } else {
+      (tableStyle as Record<string, unknown>)[key] = value;
+    }
+  }
+
+  return { tdStyle, tableStyle };
+}
+
+/**
+ * Split `className` so padding utilities (including media-query variants)
+ * land on the same element as base padding (`<td>`), preventing stacked
+ * paddings when a media query targets the outer `<table>` (issue #3693).
+ */
+export function splitPaddingClassNames(className: string | undefined): {
+  tdClassName: string | undefined;
+  tableClassName: string | undefined;
+} {
+  if (!className) {
+    return { tdClassName: undefined, tableClassName: undefined };
+  }
+
+  const tokens = className.split(/\s+/).filter(Boolean);
+  const tdTokens: string[] = [];
+  const tableTokens: string[] = [];
+
+  for (const token of tokens) {
+    if (isPaddingClassName(token)) {
+      tdTokens.push(token);
+    } else {
+      tableTokens.push(token);
+    }
+  }
+
+  return {
+    tdClassName: tdTokens.length > 0 ? tdTokens.join(' ') : undefined,
+    tableClassName: tableTokens.length > 0 ? tableTokens.join(' ') : undefined,
+  };
+}


### PR DESCRIPTION
## Summary

Fixes media-query padding stacking on `<Section>` (and the same table/`td` shape on `<Container>`).

Base padding was applied on the inner `<td>` while Tailwind padding utilities (including rewritten forms like `max-sm_px-5`) landed on the outer `<table>`. In email CSS those paddings stack instead of the media query replacing the base padding.

This routes **padding styles** and **padding class utilities** (including `max-sm:px-*` / `max-sm_px-*`) onto the same `<td>` as base padding, and keeps non-padding styles/classes on the outer `<table>`.

Fixes #3693

## Changes

- Add `splitPaddingStyles` / `splitPaddingClassNames` helpers under `packages/react-email/src/components/utils/`
- Use them in `Section` and `Container`
- Unit tests for the helpers + regression cases on Section/Container

## Test plan

- [x] `pnpm --filter @react-email/render build`
- [x] `cd packages/react-email && pnpm test` (321 passed)
- [x] `pnpm lint` at repo root (exit 0; one pre-existing `!important` warning in `apps/web`, unrelated)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes padding stacking in `<Section>` and `<Container>` by moving responsive Tailwind padding classes and inline padding styles onto the inner `<td>`. Media-query padding now correctly overrides base padding in email clients like Outlook and Klaviyo.

- **Bug Fixes**
  - Route padding styles and utilities (e.g., `px-*`, `max-sm:px-*`, `max-sm_px-*`) to the `<td>`; keep non-padding styles/classes on the outer `<table>`.
  - Add `splitPaddingStyles` and `splitPaddingClassNames` helpers and use them in `Section` and `Container`.
  - Add unit tests for the helpers and regression tests for both components.

<sup>Written for commit e6270f327043ffb74fdee633f281fd2b6bf82999. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

