### PR TITLE
chore(docs): remove corepack from contributing guide

### DIFF
--- a/apps/docs/contributing/codebase-overview.mdx
+++ b/apps/docs/contributing/codebase-overview.mdx
@@ -65,11 +65,10 @@ After cloning the [React Email repository](https://github.com/resend/react-email
 The react-email repository is a [pnpm monorepo](https://pnpm.io/next/workspaces), which means it contains
 multiple packages.
 
-Because we use pnpm, you will need to use [pnpm](https://pnpm.io/) to install and run each package. If you do not have pnpm installed, we recommend you install it using [corepack](https://github.com/nodejs/corepack):
+Because we use pnpm, you will need to use [pnpm](https://pnpm.io/) to install and run each package. If you do not have pnpm installed, follow the [pnpm installation guide](https://pnpm.io/installation):
 
 ```bash
-corepack enable
-corepack prepare pnpm@latest --activate
+npm install -g pnpm
 ```
 
 Currently, we have the following packages:

--- a/apps/docs/contributing/development-workflow/1-setup.mdx
+++ b/apps/docs/contributing/development-workflow/1-setup.mdx
@@ -17,10 +17,9 @@ To contribute to the project, you must use **Node 18** or higher.
     git clone https://github.com/resend/react-email
     ```
   </Step>
-  <Step title={<>Enable <a href="https://pnpm.io/">pnpm</a> through <a href="https://github.com/nodejs/corepack">corepack</a></>}>
-    ```bash inside of react-email
-    corepack enable
-    corepack prepare pnpm@latest --activate
+  <Step title={<>Install <a href="https://pnpm.io/installation">pnpm</a></>}>
+    ```bash
+    npm install -g pnpm
     ```
   </Step>
   <Step title="Install all the dependencies">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Corepack has been deprecated, so the contributing docs should no longer recommend it for installing pnpm.

- `apps/docs/contributing/development-workflow/1-setup.mdx`: the "Enable pnpm through corepack" step now instructs installing pnpm directly (`npm install -g pnpm`), linking to the pnpm installation guide.
- `apps/docs/contributing/codebase-overview.mdx`: the corepack recommendation is replaced with a link to the pnpm installation guide and the same direct install command.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0AG3A0TP7W/p1786045189969419?thread_ts=1786045189.969419&cid=C0AG3A0TP7W)

<div><a href="https://cursor.com/agents/bc-c54c4399-e7d8-5d94-8305-9176ab7d376a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c54c4399-e7d8-5d94-8305-9176ab7d376a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed deprecated `corepack` setup from contributing docs and switched to direct `pnpm` install (`npm install -g pnpm`). This simplifies local setup and follows the official `pnpm` guide.

<sup>Written for commit 5ba398e48d40a828c9dd3bf2a36064ba5829fe5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

