### PR TITLE
fix: update check-spam inline snapshot for DCC_CHECK flag

### DIFF
--- a/apps/web/src/app/api/check-spam/check-spam.spec.tsx
+++ b/apps/web/src/app/api/check-spam/check-spam.spec.tsx
@@ -39,9 +39,14 @@ describe.skipIf(!host || !port)('checkSpam()', { timeout: 10_000 }, () => {
             "name": "DRUGS_ERECTILE",
             "points": 2.2,
           },
+          {
+            "description": "Detected as bulk mail by DCC (dcc-servers.net)",
+            "name": "DCC_CHECK",
+            "points": 1.1,
+          },
         ],
-        "isSpam": false,
-        "points": 3.9000000000000004,
+        "isSpam": true,
+        "points": 5,
       }
     `);
   });


### PR DESCRIPTION
## Summary
- SpamAssassin's live DCC (dcc-servers.net) reputation check now flags the `check-spam.spec.tsx` "most spammy email" fixture as bulk mail, adding `DCC_CHECK` (+1.1 pts) and pushing the total from 3.9 to 5.0 — flipping `isSpam` from `false` to `true`.
- This is failing canary's `Tests` job on unrelated merges (first seen after merging #3698, a `next` version bump with no path to spam-checking code). The same commit passed this test in the PR's own CI a few days earlier — DCC's classification of the fixture drifted between runs, it isn't a code regression.
- Updates the inline snapshot to match the current, real SpamAssassin/DCC response.

## Test plan
- [ ] CI `tests` job green on canary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `check-spam.spec.tsx` inline snapshot to reflect SpamAssassin/DCC now flagging the fixture with `DCC_CHECK` (+1.1), raising the score from 3.9 to 5.0 and flipping `isSpam` to true. This unblocks canary tests that failed due to external reputation drift; no app logic changed.

<sup>Written for commit 87cc8534a1515bdbe0d68b65d53297dd62f6b6a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

