### PR TITLE
feat(examples): add Brevo example

### DIFF
--- a/examples/brevo/package.json
+++ b/examples/brevo/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "react-email-with-brevo",
+  "license": "MIT",
+  "private": true,
+  "sideEffects": false,
+  "type": "module",
+  "main": "./dist/index.js",
+  "files": [
+    "dist/**"
+  ],
+  "scripts": {
+    "build": "tsdown src/index.tsx --format esm --target node20",
+    "dev": "tsdown src/index.tsx --format esm --target node20 --watch",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@getbrevo/brevo": "6.0.2",
+    "react-email": "6.0.3",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
+  },
+  "devDependencies": {
+    "tsdown": "0.21.9",
+    "typescript": "5.9.3"
+  }
+}

--- a/examples/brevo/src/email.tsx
+++ b/examples/brevo/src/email.tsx
@@ -1,0 +1,13 @@
+import { Button, Html } from 'react-email';
+
+interface EmailProps {
+  url: string;
+}
+
+export const Email: React.FC<Readonly<EmailProps>> = ({ url }) => {
+  return (
+    <Html lang="en">
+      <Button href={url}>Click me</Button>
+    </Html>
+  );
+};

--- a/examples/brevo/src/index.tsx
+++ b/examples/brevo/src/index.tsx
@@ -1,0 +1,14 @@
+import { BrevoClient } from '@getbrevo/brevo';
+import { render } from 'react-email';
+import { Email } from './email';
+
+const brevo = new BrevoClient({ apiKey: process.env.BREVO_API_KEY || '' });
+
+const emailHtml = await render(<Email url="https://example.com" />);
+
+await brevo.transactionalEmails.sendTransacEmail({
+  sender: { name: 'Acme', email: 'hello@example.com' },
+  to: [{ email: 'hello@example.com' }],
+  subject: 'Hello world',
+  htmlContent: emailHtml,
+});

--- a/examples/brevo/tsconfig.json
+++ b/examples/brevo/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": false,
+    "isolatedModules": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "jsx": "react-jsx",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "target": "ESNext",
+    "types": ["vitest/globals"]
+  },
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"]
+}


### PR DESCRIPTION
Adds an example showing how to send a react-email template through Brevo's transactional API, using the official `@getbrevo/brevo` SDK (v6, the new `BrevoClient` interface).

Follows the structure of the existing plunk example: render the template, pass the HTML to `sendTransacEmail`. Verified the call shape against the v6.0.2 types.

Happy to add other providers if useful.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a working Brevo example that renders a `react-email` template and sends it via Brevo’s transactional API using the v6 `BrevoClient` from `@getbrevo/brevo`. This gives users a minimal, copy-pastable setup to test sending HTML emails with Brevo.

- **New Features**
  - New example at `examples/brevo` with a simple `Email` component and `index.tsx` that calls `transactionalEmails.sendTransacEmail`.
  - Uses `BREVO_API_KEY` from env and ESM build via `tsdown` targeting Node 20.
  - Adds pinned deps: `@getbrevo/brevo@6.0.2`, `react-email@6.0.3`, `react`, `react-dom`.

<sup>Written for commit eada642f9a502eb51d87018a70dea2537cb10032. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

