### PR TITLE
feat(examples): add Mailchimp Transactional example

### DIFF
--- a/examples/mailchimp-transactional/package.json
+++ b/examples/mailchimp-transactional/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "react-email-with-mailchimp-transactional",
+  "license": "MIT",
+  "private": true,
+  "sideEffects": false,
+  "type": "module",
+  "main": "./dist/index.js",
+  "files": [
+    "dist/**"
+  ],
+  "scripts": {
+    "build": "tsdown src/index.tsx --format esm --target node20",
+    "dev": "tsdown src/index.tsx --format esm --target node20 --watch",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@mailchimp/mailchimp_transactional": "1.4.1",
+    "react-email": "6.0.3",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
+  },
+  "devDependencies": {
+    "@types/mailchimp__mailchimp_transactional": "1.0.12",
+    "tsdown": "0.21.9",
+    "typescript": "5.9.3"
+  }
+}

--- a/examples/mailchimp-transactional/src/email.tsx
+++ b/examples/mailchimp-transactional/src/email.tsx
@@ -1,0 +1,13 @@
+import { Button, Html } from 'react-email';
+
+interface EmailProps {
+  url: string;
+}
+
+export const Email: React.FC<Readonly<EmailProps>> = ({ url }) => {
+  return (
+    <Html lang="en">
+      <Button href={url}>Click me</Button>
+    </Html>
+  );
+};

--- a/examples/mailchimp-transactional/src/index.tsx
+++ b/examples/mailchimp-transactional/src/index.tsx
@@ -1,0 +1,16 @@
+import mailchimpTransactional from '@mailchimp/mailchimp_transactional';
+import { render } from 'react-email';
+import { Email } from './email';
+
+const mailchimp = mailchimpTransactional(process.env.MAILCHIMP_API_KEY || '');
+
+const emailHtml = await render(<Email url="https://example.com" />);
+
+await mailchimp.messages.send({
+  message: {
+    subject: 'Hello world',
+    from_email: 'hello@example.com',
+    to: [{ email: 'hello@example.com', type: 'to' }],
+    html: emailHtml,
+  },
+});

--- a/examples/mailchimp-transactional/tsconfig.json
+++ b/examples/mailchimp-transactional/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": false,
+    "isolatedModules": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "jsx": "react-jsx",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "target": "ESNext",
+    "types": ["vitest/globals"]
+  },
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"]
+}


### PR DESCRIPTION
Adds an example showing how to send a react-email template through Mailchimp's Transactional API (Mandrill), using the official `@mailchimp/mailchimp_transactional` SDK.

Follows the structure of the existing brevo and mailtrap examples: render the template, pass the HTML to `messages.send`. The SDK is a generated client and ships no bundled types, so I pinned the DefinitelyTyped `@types/mailchimp__mailchimp_transactional` and verified the call shape against those types.

Happy to add other providers if useful.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an example for sending a `react-email` template via Mailchimp Transactional (Mandrill) using the official `@mailchimp/mailchimp_transactional` SDK. This extends provider coverage and mirrors existing Brevo/Mailtrap examples.

- Renders `Email` with `react-email` and passes the HTML to `messages.send`.
- Uses `@mailchimp/mailchimp_transactional@1.4.1` with pinned `@types/mailchimp__mailchimp_transactional` due to missing bundled types.
- Built with ESM via `tsdown` targeting Node 20; example requires `MAILCHIMP_API_KEY` to run.

<sup>Written for commit 50adcd2545d1da9655e48ea6ceaf31d0d5a3f51e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

