### PR TITLE
feat(examples): add ZeptoMail example

### DIFF
--- a/examples/zeptomail/package.json
+++ b/examples/zeptomail/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "react-email-with-zeptomail",
+  "license": "MIT",
+  "private": true,
+  "sideEffects": false,
+  "type": "module",
+  "main": "./dist/index.js",
+  "files": [
+    "dist/**"
+  ],
+  "scripts": {
+    "build": "tsdown src/index.tsx --format esm --target node20",
+    "dev": "tsdown src/index.tsx --format esm --target node20 --watch",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "zeptomail": "8.0.1",
+    "react-email": "6.0.3",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
+  },
+  "devDependencies": {
+    "tsdown": "0.21.9",
+    "typescript": "5.9.3"
+  }
+}

--- a/examples/zeptomail/src/email.tsx
+++ b/examples/zeptomail/src/email.tsx
@@ -1,0 +1,13 @@
+import { Button, Html } from 'react-email';
+
+interface EmailProps {
+  url: string;
+}
+
+export const Email: React.FC<Readonly<EmailProps>> = ({ url }) => {
+  return (
+    <Html lang="en">
+      <Button href={url}>Click me</Button>
+    </Html>
+  );
+};

--- a/examples/zeptomail/src/index.tsx
+++ b/examples/zeptomail/src/index.tsx
@@ -1,5 +1,5 @@
-import { SendMailClient } from 'zeptomail';
 import { render } from 'react-email';
+import { SendMailClient } from 'zeptomail';
 import { Email } from './email';
 
 const client = new SendMailClient({

--- a/examples/zeptomail/src/index.tsx
+++ b/examples/zeptomail/src/index.tsx
@@ -1,0 +1,17 @@
+import { SendMailClient } from 'zeptomail';
+import { render } from 'react-email';
+import { Email } from './email';
+
+const client = new SendMailClient({
+  url: 'api.zeptomail.com/',
+  token: process.env.ZEPTOMAIL_TOKEN || '',
+});
+
+const emailHtml = await render(<Email url="https://example.com" />);
+
+await client.sendMail({
+  from: { name: 'Acme', address: 'hello@example.com' },
+  to: [{ email_address: { name: 'Acme', address: 'hello@example.com' } }],
+  subject: 'Hello world',
+  htmlbody: emailHtml,
+});

--- a/examples/zeptomail/tsconfig.json
+++ b/examples/zeptomail/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": false,
+    "isolatedModules": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "jsx": "react-jsx",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "target": "ESNext",
+    "types": ["vitest/globals"]
+  },
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"]
+}


### PR DESCRIPTION
Adds a ZeptoMail example under `examples/zeptomail`, mirroring the existing provider examples (Brevo, Mailtrap, Mailchimp Transactional). Same shared `Email` template and `render` call as the others; `src/index.tsx` sends through ZeptoMail's `SendMailClient.sendMail` with `htmlbody`. Uses `zeptomail` 8.0.1. Builds with the same `tsdown` script as the sibling examples.