### PR TITLE
fix(editor): light Left alignment button for effective left alignment

### DIFF
--- a/.changeset/fix-editor-left-alignment-active.md
+++ b/.changeset/fix-editor-left-alignment-active.md
@@ -2,4 +2,4 @@
 "@react-email/editor": patch
 ---
 
-Fix the bubble menu's Left alignment button never reading as active for left-aligned (default) content, and persist an explicit left alignment to the HTML.
+Fix the bubble menu's Left alignment button never reading as active for left-aligned (default) content, persist an explicit left alignment to the HTML, and resolve inherited alignment from aligned ancestors (for example a paragraph inside a center-aligned table cell) so the button no longer reports `left` while the content is visually centered.

--- a/.changeset/fix-editor-left-alignment-active.md
+++ b/.changeset/fix-editor-left-alignment-active.md
@@ -1,0 +1,5 @@
+---
+"@react-email/editor": patch
+---
+
+Fix the bubble menu's Left alignment button never reading as active for left-aligned (default) content, and persist an explicit left alignment to the HTML.

--- a/packages/editor/src/extensions/alignment-attribute.spec.tsx
+++ b/packages/editor/src/extensions/alignment-attribute.spec.tsx
@@ -1,0 +1,40 @@
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { setTextAlignment } from '../utils/set-text-alignment';
+import { AlignmentAttribute } from './alignment-attribute';
+
+function createEditor(content?: string) {
+  return new Editor({
+    extensions: [
+      StarterKit,
+      AlignmentAttribute.configure({
+        types: ['heading', 'paragraph'],
+      }),
+    ],
+    content: content ?? '<p>hello world</p>',
+  });
+}
+
+describe('AlignmentAttribute', () => {
+  let editor: Editor;
+
+  afterEach(() => {
+    editor?.destroy();
+  });
+
+  it('persists an explicit left alignment to the HTML', () => {
+    editor = createEditor();
+    editor.commands.setTextSelection(3);
+    setTextAlignment(editor, 'left');
+
+    expect(editor.getHTML()).toContain('alignment="left"');
+  });
+
+  it('persists center alignment to the HTML', () => {
+    editor = createEditor();
+    editor.commands.setTextSelection(3);
+    setTextAlignment(editor, 'center');
+
+    expect(editor.getHTML()).toContain('alignment="center"');
+  });
+});

--- a/packages/editor/src/extensions/alignment-attribute.tsx
+++ b/packages/editor/src/extensions/alignment-attribute.tsx
@@ -47,13 +47,7 @@ export const AlignmentAttribute = Extension.create<AlignmentOptions>({
               // Return null to let natural inheritance work
               return null;
             },
-            renderHTML: (attributes) => {
-              if (attributes.alignment === 'left') {
-                return {};
-              }
-
-              return { alignment: attributes.alignment };
-            },
+            renderHTML: (attributes) => ({ alignment: attributes.alignment }),
           },
         },
       },

--- a/packages/editor/src/ui/bubble-menu/align-left.tsx
+++ b/packages/editor/src/ui/bubble-menu/align-left.tsx
@@ -1,5 +1,5 @@
 import { useEditorState } from '@tiptap/react';
-import { setTextAlignment } from '../../utils/set-text-alignment';
+import { getSelectionAlignment, setTextAlignment } from '../../utils';
 import { AlignLeftIcon } from '../icons';
 import { useBubbleMenuContext } from './context';
 import type { PreWiredItemProps } from './create-mark-bubble-item';
@@ -13,7 +13,8 @@ export function BubbleMenuAlignLeft({
 
   const isActive = useEditorState({
     editor,
-    selector: ({ editor }) => editor?.isActive({ alignment: 'left' }) ?? false,
+    selector: ({ editor }) =>
+      editor ? getSelectionAlignment(editor) === 'left' : false,
   });
 
   return (

--- a/packages/editor/src/utils/get-selection-alignment.spec.ts
+++ b/packages/editor/src/utils/get-selection-alignment.spec.ts
@@ -1,0 +1,71 @@
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { AlignmentAttribute } from '../extensions/alignment-attribute';
+import { getSelectionAlignment } from './get-selection-alignment';
+import { setTextAlignment } from './set-text-alignment';
+
+function createEditor(content?: Record<string, unknown> | string) {
+  return new Editor({
+    extensions: [
+      StarterKit,
+      AlignmentAttribute.configure({
+        types: ['heading', 'paragraph'],
+      }),
+    ],
+    content: content ?? undefined,
+  });
+}
+
+const PARAGRAPH_DOC = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'Hello world' }],
+    },
+  ],
+};
+
+const HEADING_DOC = {
+  type: 'doc',
+  content: [
+    {
+      type: 'heading',
+      attrs: { level: 1 },
+      content: [{ type: 'text', text: 'Title' }],
+    },
+  ],
+};
+
+describe('getSelectionAlignment', () => {
+  let editor: Editor;
+
+  afterEach(() => {
+    editor?.destroy();
+  });
+
+  it('resolves to left when no explicit alignment is set', () => {
+    editor = createEditor(PARAGRAPH_DOC);
+    editor.commands.setTextSelection(3);
+
+    expect(getSelectionAlignment(editor)).toBe('left');
+    // The raw attribute stays null so natural inheritance still works
+    expect(editor.getAttributes('paragraph').alignment).toBeNull();
+  });
+
+  it('resolves an explicit alignment', () => {
+    editor = createEditor(PARAGRAPH_DOC);
+    editor.commands.setTextSelection(3);
+    setTextAlignment(editor, 'center');
+
+    expect(getSelectionAlignment(editor)).toBe('center');
+  });
+
+  it('resolves alignment from the current heading textblock', () => {
+    editor = createEditor(HEADING_DOC);
+    editor.commands.setTextSelection(2);
+    setTextAlignment(editor, 'right');
+
+    expect(getSelectionAlignment(editor)).toBe('right');
+  });
+});

--- a/packages/editor/src/utils/get-selection-alignment.spec.ts
+++ b/packages/editor/src/utils/get-selection-alignment.spec.ts
@@ -1,8 +1,22 @@
-import { Editor } from '@tiptap/core';
+import { Editor, Node } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
 import { AlignmentAttribute } from '../extensions/alignment-attribute';
 import { getSelectionAlignment } from './get-selection-alignment';
 import { setTextAlignment } from './set-text-alignment';
+
+const AlignedContainer = Node.create({
+  name: 'alignedContainer',
+  group: 'block',
+  content: 'block+',
+  addAttributes() {
+    return {
+      alignment: { default: null },
+    };
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['div', HTMLAttributes, 0];
+  },
+});
 
 function createEditor(content?: Record<string, unknown> | string) {
   return new Editor({
@@ -11,6 +25,7 @@ function createEditor(content?: Record<string, unknown> | string) {
       AlignmentAttribute.configure({
         types: ['heading', 'paragraph'],
       }),
+      AlignedContainer,
     ],
     content: content ?? undefined,
   });
@@ -33,6 +48,22 @@ const HEADING_DOC = {
       type: 'heading',
       attrs: { level: 1 },
       content: [{ type: 'text', text: 'Title' }],
+    },
+  ],
+};
+
+const CENTERED_CELL_PARAGRAPH_DOC = {
+  type: 'doc',
+  content: [
+    {
+      type: 'alignedContainer',
+      attrs: { alignment: 'center' },
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Inside centered cell' }],
+        },
+      ],
     },
   ],
 };
@@ -67,5 +98,14 @@ describe('getSelectionAlignment', () => {
     setTextAlignment(editor, 'right');
 
     expect(getSelectionAlignment(editor)).toBe('right');
+  });
+
+  it('resolves inherited alignment from an aligned ancestor', () => {
+    editor = createEditor(CENTERED_CELL_PARAGRAPH_DOC);
+    editor.commands.setTextSelection(3);
+
+    expect(getSelectionAlignment(editor)).toBe('center');
+    // The paragraph itself keeps a null alignment; inheritance is preserved
+    expect(editor.getAttributes('paragraph').alignment).toBeNull();
   });
 });

--- a/packages/editor/src/utils/get-selection-alignment.ts
+++ b/packages/editor/src/utils/get-selection-alignment.ts
@@ -1,0 +1,19 @@
+import type { Editor } from '@tiptap/core';
+
+/**
+ * Resolves the effective text alignment for the current selection.
+ *
+ * The `alignment` attribute is left `null` when no explicit alignment is set so
+ * that natural (left) inheritance can work. This helper treats that `null` as
+ * `left` so callers can compare against the resolved value.
+ */
+export function getSelectionAlignment(editor: Editor): string {
+  const { $from } = editor.state.selection;
+  const parent = $from.parent;
+
+  if (!parent.isTextblock) {
+    return 'left';
+  }
+
+  return parent.attrs.alignment ?? 'left';
+}

--- a/packages/editor/src/utils/get-selection-alignment.ts
+++ b/packages/editor/src/utils/get-selection-alignment.ts
@@ -4,16 +4,22 @@ import type { Editor } from '@tiptap/core';
  * Resolves the effective text alignment for the current selection.
  *
  * The `alignment` attribute is left `null` when no explicit alignment is set so
- * that natural (left) inheritance can work. This helper treats that `null` as
- * `left` so callers can compare against the resolved value.
+ * that natural inheritance can work. This helper walks up the ancestor chain and
+ * returns the nearest explicit alignment (on the textblock itself or an aligned
+ * ancestor such as a table cell), falling back to `left` only when nothing sets
+ * one. Without this, a paragraph inside a center-aligned cell would report
+ * `left` while visually inheriting `center`.
  */
 export function getSelectionAlignment(editor: Editor): string {
   const { $from } = editor.state.selection;
-  const parent = $from.parent;
 
-  if (!parent.isTextblock) {
-    return 'left';
+  for (let depth = $from.depth; depth >= 0; depth -= 1) {
+    const node = $from.node(depth);
+    const alignment = node.attrs?.alignment ?? node.attrs?.align;
+    if (alignment) {
+      return alignment;
+    }
   }
 
-  return parent.attrs.alignment ?? 'left';
+  return 'left';
 }

--- a/packages/editor/src/utils/index.ts
+++ b/packages/editor/src/utils/index.ts
@@ -1,1 +1,2 @@
+export { getSelectionAlignment } from './get-selection-alignment';
 export { setTextAlignment } from './set-text-alignment';


### PR DESCRIPTION
## What

Fixes #3719 — the bubble menu's **Left** alignment button never read as active for left-aligned content (the default), while Center/Right/Justify worked correctly.

The extension had two conflicting behaviours that cancelled each other out:

1. `parseHTML` deliberately returns `null` when no explicit alignment is set (so natural left inheritance works), but `BubbleMenuAlignLeft` tested for an *explicit* `left` attribute via `editor.isActive({ alignment: 'left' })`. With the attribute `null`, the button could never light up.
2. `renderHTML` returned `{}` for an explicit `left`, so clicking Left set the attribute and lit the button, but nothing was written to the DOM — the state was lost on reload.

## Changes

- **`packages/editor/src/utils/get-selection-alignment.ts`** (new): resolves the *effective* alignment of the textblock at the current selection, treating a `null` attribute as `left` so natural inheritance still works.
- **`packages/editor/src/ui/bubble-menu/align-left.tsx`**: uses `getSelectionAlignment(editor) === 'left'` instead of the explicit-attribute `isActive` check.
- **`packages/editor/src/extensions/alignment-attribute.tsx`**: `renderHTML` now always emits `{ alignment: attributes.alignment }`, so an explicit left alignment is persisted (null attributes are still skipped by ProseMirror's HTML renderer, so inherited left blocks remain unchanged).
- **`packages/editor/src/utils/index.ts`**: exports the new helper.

## Tests

- `packages/editor/src/utils/get-selection-alignment.spec.ts`: asserts `null` resolves to `left`, explicit alignments resolve correctly, and the current heading textblock is used.
- `packages/editor/src/extensions/alignment-attribute.spec.tsx`: asserts clicking Left now persists `alignment="left"` in `getHTML()` (and center still persists).

All editor unit tests pass (`52` files, `507` tests), `tsc --noEmit` and `biome check` are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bubble menu's Left alignment button never showing as active for left-aligned content, and makes clicking Left persist to the HTML so the state survives reloads.

- Resolves effective alignment by treating a `null` alignment attribute as `left` and walking up the ancestor chain for inherited alignment (for example, a paragraph inside a center-aligned cell no longer reports `left`).
- Stops dropping an explicit `left` alignment from the rendered HTML.

<sup>Written for commit 3b03967511715f9d1260c1156b6361f3fb1daf0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

