### PR TITLE
fix(editor): keep full-width buttons inside their container in published emails

### DIFF
--- a/.changeset/full-width-button-border-box.md
+++ b/.changeset/full-width-button-border-box.md
@@ -2,4 +2,4 @@
 '@react-email/editor': patch
 ---
 
-Buttons now render with `box-sizing: border-box` on the canvas and in the published email, so a full-width button with horizontal padding no longer overflows its container in delivered emails. A button with an explicit width or height plus padding now renders slightly smaller, matching what the canvas shows.
+Buttons now render with `box-sizing: border-box`, so a full-width padded button no longer overflows its container in delivered emails. Buttons with an explicit size plus padding render slightly smaller, matching the canvas.

--- a/.changeset/full-width-button-border-box.md
+++ b/.changeset/full-width-button-border-box.md
@@ -1,0 +1,5 @@
+---
+'@react-email/editor': patch
+---
+
+Buttons now render with `box-sizing: border-box` on the canvas and in the published email, so a full-width button with horizontal padding no longer overflows its container in delivered emails.

--- a/.changeset/full-width-button-border-box.md
+++ b/.changeset/full-width-button-border-box.md
@@ -2,4 +2,4 @@
 '@react-email/editor': patch
 ---
 
-Buttons now render with `box-sizing: border-box` on the canvas and in the published email, so a full-width button with horizontal padding no longer overflows its container in delivered emails.
+Buttons now render with `box-sizing: border-box` on the canvas and in the published email, so a full-width button with horizontal padding no longer overflows its container in delivered emails. A button with an explicit width or height plus padding now renders slightly smaller, matching what the canvas shows.

--- a/packages/editor/src/core/serializer/compose-react-email.spec.tsx
+++ b/packages/editor/src/core/serializer/compose-react-email.spec.tsx
@@ -433,6 +433,50 @@ describe('Button and image reset styles', () => {
     expect(result.html).toContain('Click me');
   });
 
+  it('includes box-sizing:border-box on a full-width padded button with the basic theme', async () => {
+    const content = docWithGlobalContent(
+      [
+        {
+          type: 'button',
+          attrs: {
+            href: 'https://example.com',
+            class: 'button',
+            style:
+              'width:100%;padding-top:12px;padding-right:20px;padding-bottom:12px;padding-left:20px',
+          },
+          content: [{ type: 'text', text: 'Click me' }],
+        },
+      ],
+      basicTheme,
+      'basic',
+    );
+
+    const ed = createEditorWithContent(content, [EmailTheming]);
+    const result = await composeReactEmail({ editor: ed, preview: '' });
+
+    expect(result.html).toMatch(/box-sizing:\s*border-box/);
+    expect(result.html).toMatch(/width:\s*100%/);
+  });
+
+  it('includes box-sizing:border-box on buttons with the minimal theme', async () => {
+    const content = docWithGlobalContent(
+      [
+        {
+          type: 'button',
+          attrs: { href: 'https://example.com', class: 'button' },
+          content: [{ type: 'text', text: 'Click me' }],
+        },
+      ],
+      basicTheme,
+      'minimal',
+    );
+
+    const ed = createEditorWithContent(content, [EmailTheming]);
+    const result = await composeReactEmail({ editor: ed, preview: '' });
+
+    expect(result.html).toMatch(/box-sizing:\s*border-box/);
+  });
+
   it('includes line-height:100% on buttons with the minimal theme', async () => {
     const content = docWithGlobalContent(
       [

--- a/packages/editor/src/core/serializer/compose-react-email.spec.tsx
+++ b/packages/editor/src/core/serializer/compose-react-email.spec.tsx
@@ -454,8 +454,9 @@ describe('Button and image reset styles', () => {
     const ed = createEditorWithContent(content, [EmailTheming]);
     const result = await composeReactEmail({ editor: ed, preview: '' });
 
-    expect(result.html).toMatch(/box-sizing:\s*border-box/);
-    expect(result.html).toMatch(/width:\s*100%/);
+    const anchor = result.html.match(/<a[^>]*class="button"[^>]*>/)?.[0] ?? '';
+    expect(anchor).toMatch(/box-sizing:\s*border-box/);
+    expect(anchor).toMatch(/[;"]width:\s*100%/);
   });
 
   it('includes box-sizing:border-box on buttons with the minimal theme', async () => {
@@ -474,7 +475,8 @@ describe('Button and image reset styles', () => {
     const ed = createEditorWithContent(content, [EmailTheming]);
     const result = await composeReactEmail({ editor: ed, preview: '' });
 
-    expect(result.html).toMatch(/box-sizing:\s*border-box/);
+    const anchor = result.html.match(/<a[^>]*class="button"[^>]*>/)?.[0] ?? '';
+    expect(anchor).toMatch(/box-sizing:\s*border-box/);
   });
 
   it('includes line-height:100% on buttons with the minimal theme', async () => {

--- a/packages/editor/src/extensions/__snapshots__/button.spec.tsx.snap
+++ b/packages/editor/src/extensions/__snapshots__/button.spec.tsx.snap
@@ -16,7 +16,7 @@ exports[`EditorButton Node > renders React Email properly 1`] = `
         <a
           class="button"
           href="https://example.com"
-          style="line-height:100%;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px;margin:0;padding:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"
+          style="line-height:100%;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px;margin:0;padding:0;box-sizing:border-box;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"
           target="_blank"
           ><span
             ><!--[if mso]><i style="mso-font-width:0%;mso-text-raise:0px" hidden></i><![endif]--></span

--- a/packages/editor/src/plugins/email-theming/extension.spec.ts
+++ b/packages/editor/src/plugins/email-theming/extension.spec.ts
@@ -194,6 +194,11 @@ describe('EmailTheming', () => {
     expect(themeStyleTag?.textContent).toContain('.node-button');
     expect(themeStyleTag?.textContent).toContain('background-color:#000000;');
     expect(themeStyleTag?.textContent).toContain('padding-top:7px;');
+
+    const buttonRule = themeStyleTag?.textContent?.match(
+      /\.node-button\{[^}]*\}/,
+    )?.[0];
+    expect(buttonRule).toContain('box-sizing:border-box;');
   });
 
   it('injects list styles against the rendered list node classes', () => {

--- a/packages/editor/src/plugins/email-theming/themes.ts
+++ b/packages/editor/src/plugins/email-theming/themes.ts
@@ -752,6 +752,7 @@ const RESET_BASIC: ResetTheme = {
   button: {
     lineHeight: '100%',
     display: 'inline-block',
+    boxSizing: 'border-box' as const,
     paddingTop: '0.625em',
     paddingRight: '1.25em',
     paddingBottom: '0.625em',
@@ -805,6 +806,7 @@ const RESET_MINIMAL: ResetTheme = {
   button: {
     lineHeight: RESET_BASIC.button.lineHeight,
     display: RESET_BASIC.button.display,
+    boxSizing: RESET_BASIC.button.boxSizing,
   },
   image: RESET_BASIC.image,
   list: RESET_BASIC.list,

--- a/packages/editor/src/utils/default-styles.ts
+++ b/packages/editor/src/utils/default-styles.ts
@@ -79,6 +79,7 @@ export const DEFAULT_STYLES: CssJs = {
   button: {
     lineHeight: '100%',
     display: 'inline-block',
+    boxSizing: 'border-box' as const,
   },
   inlineCode: {
     paddingTop: '0.25em',


### PR DESCRIPTION
A full-width button looks right on the editor canvas but overflows its container in the sent email. 

The published markup never declares `box-sizing`, so email clients apply the `content-box` default and add the button's padding outside its width. With 20px side padding the button overflows by 40px. **The canvas only looked correct because the host page had a border-box reset.**

The fix adds `boxSizing: 'border-box'` to the button reset in both themes, next to the same declaration on `section`. The theming plugin injects it into the canvas CSS and the serializer emits it on the published anchor, so the two agree without host CSS. Stored templates get the fix on their next publish, because resets come from code, not from stored theme data.

**Behavior note.** A button with an explicit width or height plus padding renders smaller after upgrading. Only designs tuned against delivered emails change; the canvas always showed the border-box size.
