### PR TITLE
feat(integrations): add Lettermint docs and example

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -120,7 +120,8 @@
               "integrations/azure-communication-email",
               "integrations/mailersend",
               "integrations/scaleway",
-              "integrations/plunk"
+              "integrations/plunk",
+              "integrations/lettermint"
             ]
           },
           {

--- a/apps/docs/integrations/lettermint.mdx
+++ b/apps/docs/integrations/lettermint.mdx
@@ -1,0 +1,81 @@
+---
+title: "Send email using Lettermint"
+sidebarTitle: "Lettermint"
+description: "Learn how to send an email using React Email and the Lettermint Node.js SDK."
+"og:image": "https://react.email/static/covers/react-email.png"
+---
+
+## 1. Install dependencies
+
+Get the [@react-email/components](https://www.npmjs.com/package/@react-email/components) package and the [Lettermint Node.js SDK](https://www.npmjs.com/package/lettermint).
+
+<CodeGroup>
+
+```sh npm
+npm install lettermint @react-email/components
+```
+
+```sh yarn
+yarn add lettermint @react-email/components
+```
+
+```sh pnpm
+pnpm add lettermint @react-email/components
+```
+
+```sh bun
+bun add lettermint @react-email/components
+```
+
+</CodeGroup>
+
+## 2. Create an email using React
+
+Start by building your email template in a `.jsx` or `.tsx` file.
+
+```tsx email.tsx
+import * as React from "react";
+import { Html, Button } from "@react-email/components";
+
+export function Email(props) {
+  const { url } = props;
+
+  return (
+    <Html lang="en">
+      <Button href={url}>Click me</Button>
+    </Html>
+  );
+}
+```
+
+## 3. Convert to HTML and send email
+
+Import the email template you just built, convert into an HTML string, and use the Lettermint SDK to send it.
+
+```tsx
+import { render } from "@react-email/components";
+import { Lettermint } from "lettermint";
+import { Email } from "./email";
+
+const lettermint = new Lettermint({ apiToken: process.env.LETTERMINT_API_TOKEN });
+
+const emailHtml = await render(<Email url="https://example.com" />);
+
+await lettermint.email
+  .from("you@example.com")
+  .to("user@gmail.com")
+  .subject("hello world")
+  .html(emailHtml)
+  .send();
+```
+
+## Try it yourself
+
+<Card
+  title="Lettermint example"
+  icon="arrow-up-right-from-square"
+  iconType="duotone"
+  href="https://github.com/resend/react-email/tree/main/examples/lettermint"
+>
+  See the full source code.
+</Card>

--- a/apps/docs/integrations/lettermint.mdx
+++ b/apps/docs/integrations/lettermint.mdx
@@ -7,24 +7,24 @@ description: "Learn how to send an email using React Email and the Lettermint No
 
 ## 1. Install dependencies
 
-Get the [@react-email/components](https://www.npmjs.com/package/@react-email/components) package and the [Lettermint Node.js SDK](https://www.npmjs.com/package/lettermint).
+Get the [react-email](https://www.npmjs.com/package/react-email) package and the [Lettermint Node.js SDK](https://www.npmjs.com/package/lettermint).
 
 <CodeGroup>
 
 ```sh npm
-npm install lettermint @react-email/components
+npm install lettermint react-email
 ```
 
 ```sh yarn
-yarn add lettermint @react-email/components
+yarn add lettermint react-email
 ```
 
 ```sh pnpm
-pnpm add lettermint @react-email/components
+pnpm add lettermint react-email
 ```
 
 ```sh bun
-bun add lettermint @react-email/components
+bun add lettermint react-email
 ```
 
 </CodeGroup>
@@ -34,12 +34,13 @@ bun add lettermint @react-email/components
 Start by building your email template in a `.jsx` or `.tsx` file.
 
 ```tsx email.tsx
-import * as React from "react";
-import { Html, Button } from "@react-email/components";
+import { Button, Html } from "react-email";
 
-export function Email(props) {
-  const { url } = props;
+interface EmailProps {
+  url: string;
+}
 
+export function Email({ url }: EmailProps) {
   return (
     <Html lang="en">
       <Button href={url}>Click me</Button>
@@ -53,15 +54,15 @@ export function Email(props) {
 Import the email template you just built, convert into an HTML string, and use the Lettermint SDK to send it.
 
 ```tsx
-import { render } from "@react-email/components";
 import { Lettermint } from "lettermint";
+import { render } from "react-email";
 import { Email } from "./email";
 
-const lettermint = new Lettermint({ apiToken: process.env.LETTERMINT_API_TOKEN });
+const email = Lettermint.email(process.env.LETTERMINT_SENDING_TOKEN);
 
 const emailHtml = await render(<Email url="https://example.com" />);
 
-await lettermint.email
+await email
   .from("you@example.com")
   .to("user@gmail.com")
   .subject("hello world")

--- a/apps/docs/snippets/integrations.mdx
+++ b/apps/docs/snippets/integrations.mdx
@@ -32,4 +32,7 @@
   <Card title="Plunk" href="/integrations/plunk">
     Send email using Plunk
   </Card>
+  <Card title="Lettermint" href="/integrations/lettermint">
+    Send email using Lettermint
+  </Card>
 </CardGroup>

--- a/examples/lettermint/package.json
+++ b/examples/lettermint/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "react-email-with-lettermint",
+  "license": "MIT",
+  "private": true,
+  "sideEffects": false,
+  "type": "module",
+  "main": "./dist/index.js",
+  "files": [
+    "dist/**"
+  ],
+  "scripts": {
+    "build": "tsdown src/index.tsx --format esm --target node20",
+    "dev": "tsdown src/index.tsx --format esm --target node20 --watch",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "lettermint": "^1",
+    "@react-email/components": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/examples/lettermint/package.json
+++ b/examples/lettermint/package.json
@@ -14,13 +14,13 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "lettermint": "^1",
-    "@react-email/components": "catalog:",
-    "react": "catalog:",
-    "react-dom": "catalog:"
+    "lettermint": "2.6.0",
+    "react-email": "6.0.3",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
   },
   "devDependencies": {
-    "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "tsdown": "0.21.9",
+    "typescript": "5.9.3"
   }
 }

--- a/examples/lettermint/src/email.tsx
+++ b/examples/lettermint/src/email.tsx
@@ -1,0 +1,13 @@
+import { Button, Html } from '@react-email/components';
+
+interface EmailProps {
+  url: string;
+}
+
+export const Email: React.FC<Readonly<EmailProps>> = ({ url }) => {
+  return (
+    <Html lang="en">
+      <Button href={url}>Click me</Button>
+    </Html>
+  );
+};

--- a/examples/lettermint/src/email.tsx
+++ b/examples/lettermint/src/email.tsx
@@ -1,4 +1,4 @@
-import { Button, Html } from '@react-email/components';
+import { Button, Html } from 'react-email';
 
 interface EmailProps {
   url: string;

--- a/examples/lettermint/src/index.tsx
+++ b/examples/lettermint/src/index.tsx
@@ -1,0 +1,14 @@
+import { render } from '@react-email/components';
+import { Lettermint } from 'lettermint';
+import { Email } from './email';
+
+const lettermint = new Lettermint({ apiToken: process.env.LETTERMINT_API_TOKEN || '' });
+
+const emailHtml = await render(<Email url="https://example.com" />);
+
+await lettermint.email
+  .from('you@example.com')
+  .to('user@gmail.com')
+  .subject('hello world')
+  .html(emailHtml)
+  .send();

--- a/examples/lettermint/src/index.tsx
+++ b/examples/lettermint/src/index.tsx
@@ -2,7 +2,9 @@ import { render } from '@react-email/components';
 import { Lettermint } from 'lettermint';
 import { Email } from './email';
 
-const lettermint = new Lettermint({ apiToken: process.env.LETTERMINT_API_TOKEN || '' });
+const lettermint = new Lettermint({
+  apiToken: process.env.LETTERMINT_API_TOKEN || '',
+});
 
 const emailHtml = await render(<Email url="https://example.com" />);
 

--- a/examples/lettermint/src/index.tsx
+++ b/examples/lettermint/src/index.tsx
@@ -1,14 +1,12 @@
-import { render } from '@react-email/components';
 import { Lettermint } from 'lettermint';
+import { render } from 'react-email';
 import { Email } from './email';
 
-const lettermint = new Lettermint({
-  apiToken: process.env.LETTERMINT_API_TOKEN || '',
-});
+const email = Lettermint.email(process.env.LETTERMINT_SENDING_TOKEN || '');
 
 const emailHtml = await render(<Email url="https://example.com" />);
 
-await lettermint.email
+await email
   .from('you@example.com')
   .to('user@gmail.com')
   .subject('hello world')

--- a/examples/lettermint/tsconfig.json
+++ b/examples/lettermint/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": false,
+    "isolatedModules": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "jsx": "react-jsx",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "target": "ESNext",
+    "types": ["vitest/globals"]
+  },
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"]
+}


### PR DESCRIPTION
Add docs and a runnable example for sending emails with the [Lettermint](https://lettermint.co) Node.js SDK.

This is a resubmission of #3033, which was closed in March because Lettermint was considered too small at the time. As noted in https://github.com/resend/react-email/pull/3033#issuecomment-5413427641, that has changed since:

- Lettermint now sends ~200,000 emails per day, up from 50,000 per month nine months earlier ([KumoMTA case study](https://kumomta.com/customers/lettermint-builds-sovereign-european-email-infrastructure-on-kumomta-and-scales-100x)).
- They are ISO 27001 certified ([trust center](https://trust.lettermint.co/)).
- As a European provider with its own network and IP ranges, it is a relevant option for React Email users who need EU data residency.

## Changes

- `apps/docs/integrations/lettermint.mdx`: new integration page, registered in `docs.json` under Integrations.
- `examples/lettermint`: runnable example that renders a template and sends it. Set `LETTERMINT_SENDING_TOKEN` to run.

Compared to #3033, the branch is rebased on current `canary` and updated to match the conventions that changed since then:

- Uses the `react-email` package instead of `@react-email/components`, like the other integration pages and examples.
- Updated to Lettermint SDK v2 (`Lettermint.email(token)`), which is now the documented way to send.
- Dependencies pinned to exact versions, matching the other examples.

The example builds with `tsdown` and passes `biome check`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Lettermint integration docs and a runnable example, replacing the previously closed PR now that Lettermint's scale and EU data-residency make it a relevant option.

- Adds a Lettermint page to the docs and registers it in the integrations navigation and overview.
- Adds a runnable example in `examples/lettermint` using the `react-email` package and Lettermint SDK v2, with dependencies pinned to exact versions.

<sup>Written for commit b816cd0adeb1c6591f59824ada11958ea10215f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

