### PR TITLE
fix(react-email): responsive padding not applying to inner td for Container and Section

### DIFF
--- a/.changeset/tailwind-section-responsive-padding.md
+++ b/.changeset/tailwind-section-responsive-padding.md
@@ -2,4 +2,4 @@
 'react-email': patch
 ---
 
-Responsive padding classes like `max-sm:px-5` on `<Section>` and `<Container>` now land on the inner `<td>` that carries the base padding, so they override it instead of stacking. Components marked with `markAsElement` can pass a `resolveTailwind` option to decide how Tailwind's resolved styles and classes map onto their props.
+Responsive padding classes on `<Section>` and `<Container>` now override the base padding instead of stacking

--- a/.changeset/tailwind-section-responsive-padding.md
+++ b/.changeset/tailwind-section-responsive-padding.md
@@ -1,0 +1,5 @@
+---
+'react-email': patch
+---
+
+Responsive padding classes like `max-sm:px-5` on `<Section>` and `<Container>` now land on the inner `<td>` that carries the base padding, so they override it instead of stacking. Components marked with `markAsElement` can pass a `resolveTailwind` option to decide how Tailwind's resolved styles and classes map onto their props.

--- a/.changeset/tailwind-section-responsive-padding.md
+++ b/.changeset/tailwind-section-responsive-padding.md
@@ -2,4 +2,4 @@
 'react-email': patch
 ---
 
-Responsive padding classes on `<Section>` and `<Container>` now override the base padding instead of stacking
+fix responsive padding not applying to inner td for Container and Section

--- a/packages/react-email/src/components/container/container.tsx
+++ b/packages/react-email/src/components/container/container.tsx
@@ -3,57 +3,83 @@ import { markAsElement } from '../element-marker.js';
 
 export type ContainerProps = Readonly<React.ComponentPropsWithoutRef<'table'>>;
 
-export const Container = React.forwardRef<HTMLTableElement, ContainerProps>(
-  ({ children, style = {}, ...props }, ref) => {
-    // Split padding styles to improve compatibility with Klaviyo and Outlook,
-    // while preserving user-provided style property order without allocating
-    // entry arrays on each render.
-    const tdStyle: React.CSSProperties = {};
-    const tableStyle: React.CSSProperties = {};
+export const Container = React.forwardRef<
+  HTMLTableElement,
+  ContainerProps & { tdClassName?: string }
+>(({ children, style = {}, tdClassName, ...props }, ref) => {
+  // Split padding styles to improve compatibility with Klaviyo and Outlook,
+  // while preserving user-provided style property order without allocating
+  // entry arrays on each render.
+  const tdStyle: React.CSSProperties = {};
+  const tableStyle: React.CSSProperties = {};
 
-    const styleRecord = style as Record<string, unknown>;
+  const styleRecord = style as Record<string, unknown>;
 
-    for (const key in styleRecord) {
-      if (!Object.hasOwn(styleRecord, key)) {
-        continue;
-      }
-
-      const value = styleRecord[key];
-
-      if (
-        key === 'padding' ||
-        key === 'paddingTop' ||
-        key === 'paddingRight' ||
-        key === 'paddingBottom' ||
-        key === 'paddingLeft'
-      ) {
-        (tdStyle as Record<string, unknown>)[key] = value;
-      } else {
-        (tableStyle as Record<string, unknown>)[key] = value;
-      }
+  for (const key in styleRecord) {
+    if (!Object.hasOwn(styleRecord, key)) {
+      continue;
     }
 
-    return (
-      <table
-        align="center"
-        width="100%"
-        {...props}
-        border={0}
-        cellPadding="0"
-        cellSpacing="0"
-        ref={ref}
-        role="presentation"
-        style={{ maxWidth: '37.5em', ...tableStyle }}
-      >
-        <tbody>
-          <tr style={{ width: '100%' }}>
-            <td style={tdStyle}>{children}</td>
-          </tr>
-        </tbody>
-      </table>
-    );
-  },
-);
+    const value = styleRecord[key];
+
+    if (
+      key === 'padding' ||
+      key === 'paddingTop' ||
+      key === 'paddingRight' ||
+      key === 'paddingBottom' ||
+      key === 'paddingLeft'
+    ) {
+      (tdStyle as Record<string, unknown>)[key] = value;
+    } else {
+      (tableStyle as Record<string, unknown>)[key] = value;
+    }
+  }
+
+  return (
+    <table
+      align="center"
+      width="100%"
+      {...props}
+      border={0}
+      cellPadding="0"
+      cellSpacing="0"
+      ref={ref}
+      role="presentation"
+      style={{ maxWidth: '37.5em', ...tableStyle }}
+    >
+      <tbody>
+        <tr style={{ width: '100%' }}>
+          <td className={tdClassName} style={tdStyle}>
+            {children}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  );
+});
 
 Container.displayName = 'Container';
-markAsElement(Container);
+markAsElement<ContainerProps & { tdClassName?: string }>(Container, {
+  resolveTailwind(props, { style, className, classProperties }) {
+    const tableClasses: string[] = [];
+    const tdClasses: string[] = [];
+    for (const name of className?.split(' ') ?? []) {
+      const properties = classProperties[name];
+      if (
+        properties &&
+        properties.length > 0 &&
+        properties.every((property) => property.startsWith('padding'))
+      ) {
+        tdClasses.push(name);
+      } else {
+        tableClasses.push(name);
+      }
+    }
+    return {
+      ...props,
+      style,
+      className: tableClasses.length > 0 ? tableClasses.join(' ') : undefined,
+      tdClassName: tdClasses.length > 0 ? tdClasses.join(' ') : undefined,
+    };
+  },
+});

--- a/packages/react-email/src/components/container/container.tsx
+++ b/packages/react-email/src/components/container/container.tsx
@@ -22,13 +22,7 @@ export const Container = React.forwardRef<
 
     const value = styleRecord[key];
 
-    if (
-      key === 'padding' ||
-      key === 'paddingTop' ||
-      key === 'paddingRight' ||
-      key === 'paddingBottom' ||
-      key === 'paddingLeft'
-    ) {
+    if (key.startsWith('padding')) {
       (tdStyle as Record<string, unknown>)[key] = value;
     } else {
       (tableStyle as Record<string, unknown>)[key] = value;
@@ -62,7 +56,7 @@ Container.displayName = 'Container';
 markAsElement<ContainerProps & { tdClassName?: string }>(Container, {
   resolveTailwind(props, { style, className, classProperties }) {
     const tableClasses: string[] = [];
-    const tdClasses: string[] = [];
+    const tdClasses = props.tdClassName ? [props.tdClassName] : [];
     for (const name of className?.split(' ') ?? []) {
       const properties = classProperties[name];
       if (

--- a/packages/react-email/src/components/element-marker.ts
+++ b/packages/react-email/src/components/element-marker.ts
@@ -1,5 +1,28 @@
+import type * as React from 'react';
+
 export const elementMarker = Symbol.for('react-email.element');
 
-export const markAsElement = (component: unknown) => {
-  (component as Record<symbol, boolean>)[elementMarker] = true;
+export interface ResolvedTailwind {
+  style: React.CSSProperties;
+  className: string | undefined;
+  classProperties: Record<string, string[]>;
+}
+
+export interface ElementOptions<Props = object> {
+  resolveTailwind?: (props: Props, resolved: ResolvedTailwind) => Props;
+}
+
+export const markAsElement = <Props>(
+  component: unknown,
+  options: ElementOptions<Props> = {},
+) => {
+  (component as Record<symbol, ElementOptions<Props>>)[elementMarker] = options;
+};
+
+export const getElementOptions = (
+  type: unknown,
+): ElementOptions | undefined => {
+  if (typeof type !== 'function' && typeof type !== 'object') return undefined;
+  if (type === null) return undefined;
+  return (type as Record<symbol, ElementOptions | undefined>)[elementMarker];
 };

--- a/packages/react-email/src/components/index.ts
+++ b/packages/react-email/src/components/index.ts
@@ -4,6 +4,11 @@ export * from './code-block/index.js';
 export * from './code-inline/index.js';
 export * from './column/index.js';
 export * from './container/index.js';
+export {
+  type ElementOptions,
+  markAsElement,
+  type ResolvedTailwind,
+} from './element-marker.js';
 export * from './font/index.js';
 export * from './head/index.js';
 export * from './heading/index.js';

--- a/packages/react-email/src/components/section/section.tsx
+++ b/packages/react-email/src/components/section/section.tsx
@@ -3,57 +3,83 @@ import { markAsElement } from '../element-marker.js';
 
 export type SectionProps = Readonly<React.ComponentPropsWithoutRef<'table'>>;
 
-export const Section = React.forwardRef<HTMLTableElement, SectionProps>(
-  ({ children, style = {}, ...props }, ref) => {
-    // Split padding styles to improve compatibility with Klaviyo and Outlook,
-    // while preserving user-provided style property order without allocating
-    // entry arrays on each render.
-    const tdStyle: React.CSSProperties = {};
-    const tableStyle: React.CSSProperties = {};
+export const Section = React.forwardRef<
+  HTMLTableElement,
+  SectionProps & { tdClassName?: string }
+>(({ children, style = {}, tdClassName, ...props }, ref) => {
+  // Split padding styles to improve compatibility with Klaviyo and Outlook,
+  // while preserving user-provided style property order without allocating
+  // entry arrays on each render.
+  const tdStyle: React.CSSProperties = {};
+  const tableStyle: React.CSSProperties = {};
 
-    const styleRecord = style as Record<string, unknown>;
+  const styleRecord = style as Record<string, unknown>;
 
-    for (const key in styleRecord) {
-      if (!Object.hasOwn(styleRecord, key)) {
-        continue;
-      }
-
-      const value = styleRecord[key];
-
-      if (
-        key === 'padding' ||
-        key === 'paddingTop' ||
-        key === 'paddingRight' ||
-        key === 'paddingBottom' ||
-        key === 'paddingLeft'
-      ) {
-        (tdStyle as Record<string, unknown>)[key] = value;
-      } else {
-        (tableStyle as Record<string, unknown>)[key] = value;
-      }
+  for (const key in styleRecord) {
+    if (!Object.hasOwn(styleRecord, key)) {
+      continue;
     }
 
-    return (
-      <table
-        align="center"
-        width="100%"
-        border={0}
-        cellPadding="0"
-        cellSpacing="0"
-        role="presentation"
-        {...props}
-        ref={ref}
-        style={tableStyle}
-      >
-        <tbody>
-          <tr>
-            <td style={tdStyle}>{children}</td>
-          </tr>
-        </tbody>
-      </table>
-    );
-  },
-);
+    const value = styleRecord[key];
+
+    if (
+      key === 'padding' ||
+      key === 'paddingTop' ||
+      key === 'paddingRight' ||
+      key === 'paddingBottom' ||
+      key === 'paddingLeft'
+    ) {
+      (tdStyle as Record<string, unknown>)[key] = value;
+    } else {
+      (tableStyle as Record<string, unknown>)[key] = value;
+    }
+  }
+
+  return (
+    <table
+      align="center"
+      width="100%"
+      border={0}
+      cellPadding="0"
+      cellSpacing="0"
+      role="presentation"
+      {...props}
+      ref={ref}
+      style={tableStyle}
+    >
+      <tbody>
+        <tr>
+          <td className={tdClassName} style={tdStyle}>
+            {children}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  );
+});
 
 Section.displayName = 'Section';
-markAsElement(Section);
+markAsElement<SectionProps & { tdClassName?: string }>(Section, {
+  resolveTailwind(props, { style, className, classProperties }) {
+    const tableClasses: string[] = [];
+    const tdClasses: string[] = [];
+    for (const name of className?.split(' ') ?? []) {
+      const properties = classProperties[name];
+      if (
+        properties &&
+        properties.length > 0 &&
+        properties.every((property) => property.startsWith('padding'))
+      ) {
+        tdClasses.push(name);
+      } else {
+        tableClasses.push(name);
+      }
+    }
+    return {
+      ...props,
+      style,
+      className: tableClasses.length > 0 ? tableClasses.join(' ') : undefined,
+      tdClassName: tdClasses.length > 0 ? tdClasses.join(' ') : undefined,
+    };
+  },
+});

--- a/packages/react-email/src/components/section/section.tsx
+++ b/packages/react-email/src/components/section/section.tsx
@@ -22,13 +22,7 @@ export const Section = React.forwardRef<
 
     const value = styleRecord[key];
 
-    if (
-      key === 'padding' ||
-      key === 'paddingTop' ||
-      key === 'paddingRight' ||
-      key === 'paddingBottom' ||
-      key === 'paddingLeft'
-    ) {
+    if (key.startsWith('padding')) {
       (tdStyle as Record<string, unknown>)[key] = value;
     } else {
       (tableStyle as Record<string, unknown>)[key] = value;
@@ -62,7 +56,7 @@ Section.displayName = 'Section';
 markAsElement<SectionProps & { tdClassName?: string }>(Section, {
   resolveTailwind(props, { style, className, classProperties }) {
     const tableClasses: string[] = [];
-    const tdClasses: string[] = [];
+    const tdClasses = props.tdClassName ? [props.tdClassName] : [];
     for (const name of className?.split(' ') ?? []) {
       const properties = classProperties[name];
       if (

--- a/packages/react-email/src/components/tailwind/tailwind.spec.tsx
+++ b/packages/react-email/src/components/tailwind/tailwind.spec.tsx
@@ -275,6 +275,19 @@ describe('Tailwind component', () => {
     expect(html).not.toMatch(/<table[^>]*style="[^"]*padding:1rem/);
   });
 
+  it('routes responsive padding classes on <Section> to the inner <td>', async () => {
+    const html = await render(
+      <Tailwind>
+        <Head />
+        <Section className="max-sm:px-5 max-sm:bg-red-500 px-9">x</Section>
+      </Tailwind>,
+    );
+
+    expect(html).toMatchInlineSnapshot(
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><head><meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/><meta name="x-apple-disable-message-reformatting"/><style>@media (max-width:40rem){.max-sm_bg-red-500{background-color:rgb(251,44,54)!important}}@media (max-width:40rem){.max-sm_px-5{padding-right:1.25rem!important;padding-left:1.25rem!important}}</style></head><!--$--><!--head--><table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation" class="max-sm_bg-red-500"><tbody><tr><td class="max-sm_px-5" style="padding-right:2.25rem;padding-left:2.25rem">x</td></tr></tbody></table><!--/$-->"`,
+    );
+  });
+
   it('inlines Tailwind classes on <Column> onto its <td>', async () => {
     const html = await render(
       <Tailwind>

--- a/packages/react-email/src/components/tailwind/utils/tailwindcss/clone-element-with-inlined-styles.ts
+++ b/packages/react-email/src/components/tailwind/utils/tailwindcss/clone-element-with-inlined-styles.ts
@@ -1,5 +1,6 @@
-import type { Rule } from 'css-tree';
+import { type Rule, walk } from 'css-tree';
 import React from 'react';
+import { getElementOptions } from '../../../element-marker.js';
 import type { EmailElementProps } from '../../tailwind.js';
 import { sanitizeClassName } from '../compatibility/sanitize-class-name.js';
 import type { CustomProperties } from '../css/get-custom-properties.js';
@@ -12,50 +13,58 @@ export function cloneElementWithInlinedStyles(
   nonInlinableRules: Map<string, Rule[]>,
   customProperties: CustomProperties,
 ) {
-  const propsToOverwrite: Partial<EmailElementProps> = {};
+  if (!element.props.className || isComponent(element)) {
+    return React.cloneElement(element, element.props, element.props.children);
+  }
 
-  if (element.props.className && !isComponent(element)) {
-    const classes = element.props.className.trim().split(/\s+/);
+  const classes = element.props.className.trim().split(/\s+/);
 
-    const residualClasses: string[] = [];
+  const residualClasses: string[] = [];
+  const classProperties: Record<string, string[]> = {};
 
-    const rules: Rule[] = [];
-    for (const className of classes) {
-      const classRules = inlinableRules.get(className);
-      if (classRules) {
-        rules.push(...classRules);
-      }
-      if (nonInlinableRules.has(className)) {
-        residualClasses.push(className);
-      } else if (!classRules) {
-        residualClasses.push(className);
-      }
+  const rules: Rule[] = [];
+  for (const className of classes) {
+    const classRules = inlinableRules.get(className);
+    if (classRules) {
+      rules.push(...classRules);
     }
-
-    const styles = makeInlineStylesFor(rules, customProperties);
-    propsToOverwrite.style = {
-      ...styles,
-      ...element.props.style,
-    };
-
-    if (residualClasses.length > 0) {
-      propsToOverwrite.className = residualClasses
-        .map((className) => {
-          if (nonInlinableRules.has(className)) {
-            return sanitizeClassName(className);
-          }
-          return className;
-        })
-        .join(' ');
-    } else {
-      propsToOverwrite.className = undefined;
+    const nonInlinable = nonInlinableRules.get(className);
+    if (nonInlinable) {
+      const sanitized = sanitizeClassName(className);
+      residualClasses.push(sanitized);
+      const properties: string[] = [];
+      for (const rule of nonInlinable) {
+        walk(rule, {
+          visit: 'Declaration',
+          enter(declaration) {
+            properties.push(declaration.property);
+          },
+        });
+      }
+      classProperties[sanitized] = properties;
+    } else if (!classRules) {
+      residualClasses.push(className);
     }
   }
 
-  const newProps = {
-    ...element.props,
-    ...propsToOverwrite,
+  const resolved = {
+    style: {
+      ...makeInlineStylesFor(rules, customProperties),
+      ...element.props.style,
+    },
+    className:
+      residualClasses.length > 0 ? residualClasses.join(' ') : undefined,
+    classProperties,
   };
+
+  const resolveTailwind = getElementOptions(element.type)?.resolveTailwind;
+  const newProps = resolveTailwind
+    ? (resolveTailwind(element.props, resolved) as EmailElementProps)
+    : {
+        ...element.props,
+        style: resolved.style,
+        className: resolved.className,
+      };
 
   return React.cloneElement(element, newProps, newProps.children);
 }

--- a/packages/react-email/src/components/tailwind/utils/tailwindcss/clone-element-with-inlined-styles.ts
+++ b/packages/react-email/src/components/tailwind/utils/tailwindcss/clone-element-with-inlined-styles.ts
@@ -20,7 +20,7 @@ export function cloneElementWithInlinedStyles(
   const classes = element.props.className.trim().split(/\s+/);
 
   const residualClasses: string[] = [];
-  const classProperties: Record<string, string[]> = {};
+  const classProperties: Record<string, string[]> = Object.create(null);
 
   const rules: Rule[] = [];
   for (const className of classes) {


### PR DESCRIPTION
Fixes #3693. Section and Container put padding on the inner td, but Tailwind left every non-inlinable class on the table, so a `max-sm:px-5` media rule stacked on top of the `px-9` base padding instead of overriding it. Instead of teaching Tailwind about Section, `markAsElement` now accepts a `resolveTailwind` option: Tailwind hands the marked component its inlined style, the residual classes, and the CSS properties each class sets, and the component decides which props they become. Section and Container use it to move padding-only classes onto the td, and the option is exported so user components can do the same. Components that don't pass it keep the previous behavior.

Claude ran the repro from the issue against the branch. Relevant tags from the output:

```html
<style>@media (max-width:40rem){.max-sm_hidden{display:none!important}}@media (max-width:40rem){.max-sm_p-2{padding:0.5rem!important}}@media (max-width:40rem){.max-sm_px-5{padding-right:1.25rem!important;padding-left:1.25rem!important}}</style>
<td class="max-sm_px-5" style="padding-right:2.25rem;padding-left:2.25rem">
<table align="center" width="100%" class="max-sm_hidden" border="0" cellPadding="0" cellSpacing="0" role="presentation" style="max-width:37.5em">
<td class="max-sm_p-2" style="padding:1rem">
```

The second pair is `<Container className="max-sm:p-2 p-4 max-sm:hidden">`, showing a non-padding class staying on the table.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes responsive padding classes like `max-sm:px-5` on `<Section>` and `<Container>` so they override the base padding instead of stacking on top of it.

**Migration**

- `markAsElement` now accepts an optional `resolveTailwind` option; components that don't pass it keep the previous behavior.
- The option and its types (`ElementOptions`, `ResolvedTailwind`) are exported from the package entry point.

<sup>Written for commit fc387e45ee931abea4f1bd53b20f01d80fd2450b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

