### PR TITLE
fix(editor): render table header cells to send HTML

### DIFF
--- a/.changeset/table-header-render.md
+++ b/.changeset/table-header-render.md
@@ -1,0 +1,5 @@
+---
+'@react-email/editor': patch
+---
+
+fix table header cells being dropped when rendering to send HTML

--- a/packages/editor/src/extensions/__snapshots__/table.spec.tsx.snap
+++ b/packages/editor/src/extensions/__snapshots__/table.spec.tsx.snap
@@ -29,6 +29,14 @@ exports[`Table Nodes > renders TableCell React Email properly 1`] = `
 "
 `;
 
+exports[`Table Nodes > renders TableHeader React Email properly as a real th, not a dropped node 1`] = `
+"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--$-->
+<th align="left" style="margin:0;padding:0">Header content</th>
+<!--/$-->
+"
+`;
+
 exports[`Table Nodes > renders TableRow React Email properly 1`] = `
 "<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!--$-->

--- a/packages/editor/src/extensions/table.spec.tsx
+++ b/packages/editor/src/extensions/table.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from 'react-email';
 import { DEFAULT_STYLES } from '../utils/default-styles';
-import { Table, TableCell, TableRow } from './table';
+import { Table, TableCell, TableHeader, TableRow } from './table';
 
 const tableStyle = { ...DEFAULT_STYLES.reset };
 const tableRowStyle = { ...DEFAULT_STYLES.reset };
@@ -70,6 +70,30 @@ describe('Table Nodes', () => {
         { pretty: true },
       ),
     ).toMatchSnapshot();
+  });
+
+  it('renders TableHeader React Email properly as a real th, not a dropped node', async () => {
+    const Component = TableHeader.config.renderToReactEmail;
+    expect(Component).toBeDefined();
+    const html = await render(
+      <Component
+        node={{
+          type: 'tableHeader',
+          attrs: {
+            alignment: 'left',
+          },
+        }}
+        style={tableCellStyle}
+        extension={TableHeader}
+      >
+        Header content
+      </Component>,
+      { pretty: true },
+    );
+
+    expect(html).toContain('<th');
+    expect(html).toContain('Header content');
+    expect(html).toMatchSnapshot();
   });
 
   it('renders nested table structure without invalid tr-inside-td nesting', async () => {

--- a/packages/editor/src/extensions/table.tsx
+++ b/packages/editor/src/extensions/table.tsx
@@ -1,5 +1,5 @@
 import type { ParentConfig } from '@tiptap/core';
-import { mergeAttributes, Node } from '@tiptap/core';
+import { mergeAttributes } from '@tiptap/core';
 import { Column } from 'react-email';
 import { EmailNode } from '../core/serializer/email-node';
 import {
@@ -237,7 +237,11 @@ export const TableCell = EmailNode.create<TableCellOptions>({
   },
 });
 
-export const TableHeader = Node.create({
+export interface TableHeaderOptions extends Record<string, unknown> {
+  HTMLAttributes?: Record<string, unknown>;
+}
+
+export const TableHeader = EmailNode.create<TableHeaderOptions>({
   name: 'tableHeader',
 
   group: 'tableCell',
@@ -280,5 +284,21 @@ export const TableHeader = Node.create({
 
   renderHTML({ HTMLAttributes }) {
     return ['th', HTMLAttributes, 0];
+  },
+
+  renderToReactEmail({ children, node, style }) {
+    const inlineStyles = inlineCssToJs(node.attrs?.style);
+    return (
+      <Column
+        className={node.attrs?.class || undefined}
+        align={node.attrs?.align || node.attrs?.alignment}
+        style={{
+          ...style,
+          ...inlineStyles,
+        }}
+      >
+        {children}
+      </Column>
+    );
   },
 });

--- a/packages/editor/src/extensions/table.tsx
+++ b/packages/editor/src/extensions/table.tsx
@@ -289,7 +289,7 @@ export const TableHeader = EmailNode.create<TableHeaderOptions>({
   renderToReactEmail({ children, node, style }) {
     const inlineStyles = inlineCssToJs(node.attrs?.style);
     return (
-      <Column
+      <th
         className={node.attrs?.class || undefined}
         align={node.attrs?.align || node.attrs?.alignment}
         style={{
@@ -298,7 +298,7 @@ export const TableHeader = EmailNode.create<TableHeaderOptions>({
         }}
       >
         {children}
-      </Column>
+      </th>
     );
   },
 });


### PR DESCRIPTION
## Summary
- `TableHeader` (`<th>`) was built with plain TipTap `Node.create` and had no `renderToReactEmail`, so `composeReactEmail` dropped every `<th>` cell (and its children) when serializing pasted tables to send HTML.
- Build it with `EmailNode.create` and add `renderToReactEmail`, mirroring `TableCell`'s `Column` render.

## Test plan
- [ ] Paste a table with a `<th>` header row (e.g. from Google Sheets/Excel) into the editor and confirm the header cells appear in the sent HTML output, not just the live preview.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes table header cells being dropped when rendering pasted tables to send HTML. `TableHeader` now renders as a real `<th>` element, so header cells and their children appear in the sent HTML instead of only the live preview.

<sup>Written for commit d4de160376108fec7140a97f3b23f6a58efc5129. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

