### PR TITLE
fix(create-email): validate npm registry response and exit on invalid version

### DIFF
--- a/packages/create-email/src/index.js
+++ b/packages/create-email/src/index.js
@@ -19,6 +19,14 @@ const getLatestVersionOfTag = async (packageName, tag) => {
   const response = await fetch(
     `https://registry.npmjs.org/${packageName}/${tag}`,
   );
+
+  if (!response.ok) {
+    console.error(
+      `Failed to fetch tag ${tag} for ${packageName}: HTTP ${response.status}`,
+    );
+    process.exit(1);
+  }
+
   const data = await response.json();
 
   if (typeof data === 'string' && data.startsWith('version not found')) {
@@ -28,8 +36,9 @@ const getLatestVersionOfTag = async (packageName, tag) => {
 
   const { version } = data;
 
-  if (!/^\d+\.\d+\.\d+.*$/.test(version)) {
+  if (!version || !/^\d+\.\d+\.\d+.*$/.test(version)) {
     console.error('Invalid version received, something has gone very wrong.');
+    process.exit(1);
   }
 
   return version;


### PR DESCRIPTION
Check response.ok when querying npm registry in getLatestVersionOfTag inside create-email. Immediately exit with error status if the npm HTTP request fails, tag is not found, or the version format is invalid/empty, preventing create-email from silently writing undefined versions into starter package.json.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `create-email` to validate the npm registry response and exit with an error when the request fails or the version is empty/invalid, instead of silently writing `undefined` into the starter `package.json`.

<sup>Written for commit b334d414ed3c2b2968f29a6045e4dd47b67bfeab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

