### PR TITLE
feat(integrations): add Brevo docs

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -121,7 +121,8 @@
               "integrations/mailersend",
               "integrations/scaleway",
               "integrations/plunk",
-              "integrations/lettermint"
+              "integrations/lettermint",
+              "integrations/brevo"
             ]
           },
           {

--- a/apps/docs/integrations/brevo.mdx
+++ b/apps/docs/integrations/brevo.mdx
@@ -1,0 +1,82 @@
+---
+title: "Send email using Brevo"
+sidebarTitle: "Brevo"
+description: "Learn how to send an email using React Email and the Brevo Node.js SDK."
+"og:image": "https://react.email/static/covers/react-email.png"
+---
+
+## 1. Install dependencies
+
+Get the [react-email](https://www.npmjs.com/package/react-email) package and the [Brevo Node.js SDK](https://www.npmjs.com/package/@getbrevo/brevo).
+
+<CodeGroup>
+
+```sh npm
+npm install @getbrevo/brevo react-email
+```
+
+```sh yarn
+yarn add @getbrevo/brevo react-email
+```
+
+```sh pnpm
+pnpm add @getbrevo/brevo react-email
+```
+
+```sh bun
+bun add @getbrevo/brevo react-email
+```
+
+</CodeGroup>
+
+## 2. Create an email using React
+
+Start by building your email template in a `.jsx` or `.tsx` file.
+
+```tsx email.tsx
+import { Button, Html } from "react-email";
+
+interface EmailProps {
+  url: string;
+}
+
+export function Email({ url }: EmailProps) {
+  return (
+    <Html lang="en">
+      <Button href={url}>Click me</Button>
+    </Html>
+  );
+}
+```
+
+## 3. Convert to HTML and send email
+
+Import the email template you just built, convert into an HTML string, and use the Brevo SDK to send it.
+
+```tsx
+import { BrevoClient } from "@getbrevo/brevo";
+import { render } from "react-email";
+import { Email } from "./email";
+
+const brevo = new BrevoClient({ apiKey: process.env.BREVO_API_KEY || "" });
+
+const emailHtml = await render(<Email url="https://example.com" />);
+
+await brevo.transactionalEmails.sendTransacEmail({
+  sender: { name: "Acme", email: "you@example.com" },
+  to: [{ email: "user@gmail.com" }],
+  subject: "hello world",
+  htmlContent: emailHtml,
+});
+```
+
+## Try it yourself
+
+<Card
+  title="Brevo example"
+  icon="arrow-up-right-from-square"
+  iconType="duotone"
+  href="https://github.com/resend/react-email/tree/main/examples/brevo"
+>
+  See the full source code.
+</Card>

--- a/apps/docs/snippets/integrations.mdx
+++ b/apps/docs/snippets/integrations.mdx
@@ -35,4 +35,7 @@
   <Card title="Lettermint" href="/integrations/lettermint">
     Send email using Lettermint
   </Card>
+  <Card title="Brevo" href="/integrations/brevo">
+    Send email using Brevo
+  </Card>
 </CardGroup>


### PR DESCRIPTION
Adds the missing integration page for Brevo. `examples/brevo` was added in
#3704 but never got a docs page, so Brevo doesn't show up in the Integrations
nav or in the overview cards.

## Changes

- `apps/docs/integrations/brevo.mdx`: new integration page, registered in
  `docs.json` under Integrations.
- `apps/docs/snippets/integrations.mdx`: adds the Brevo card to the overview.

The page follows the same structure as `lettermint.mdx` and documents the exact
flow already in `examples/brevo` — `BrevoClient` and
`transactionalEmails.sendTransacEmail()` from `@getbrevo/brevo`.

Checked the page renders with `mintlify dev`; `pnpm lint` passes.

`examples/mailtrap`, `examples/zeptomail` and `examples/mailchimp-transactional`
are in the same situation. Happy to open separate PRs for those if useful.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing documentation page for the Brevo integration so Brevo now appears in the Integrations nav and overview cards instead of being missing from the docs despite the existing `examples/brevo`.

The new `apps/docs/integrations/brevo.mdx` follows the same structure as `lettermint.mdx` and documents the flow using `BrevoClient` and `transactionalEmails.sendTransacEmail()` from `@getbrevo/brevo`. It also registers the page in `apps/docs/docs.json` and adds a Brevo card to `apps/docs/snippets/integrations.mdx`.

<sup>Written for commit 179db70639b0fdc4adeb15eca11abf4ecfd455e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/react-email/pull/3742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

